### PR TITLE
Check for duplicate ids when importing brapi fields

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -225,10 +225,14 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
     private void saveStudy() {
 
         BrapiControllerResponse brapiControllerResponse = brAPIService.saveStudyDetails(studyDetails);
+
         // Display our message.
         if (brapiControllerResponse.status == false) {
             if (brapiControllerResponse.message == BrAPIService.notUniqueFieldMessage) {
                 Toast.makeText(context, R.string.fields_study_exists_message, Toast.LENGTH_LONG).show();
+            }
+            else if (brapiControllerResponse.message == BrAPIService.notUniqueIdMessage) {
+                Toast.makeText(context, R.string.import_error_unique, Toast.LENGTH_LONG).show();
             }
             else {
                 Log.e("error", brapiControllerResponse.message);


### PR DESCRIPTION
Currently with csv imports, Field Book does not allow duplicate id's in the unique_id column in the plot table. This feature adds a check when importing a BrAPI field to make sure we are not importing duplicate unique plot ids. 