### PR TITLE
Fie 60

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrAPIService.java
@@ -665,6 +665,10 @@ public class BrAPIService {
 
         if (data != null && data.isHierarchical()) {
 
+            // Clear our data from our deep link so the app doesn't think it is
+            // coming from a deep link if it is coming from deep link on pause and resume.
+            activity.getIntent().setData(null);
+
             Integer status = Integer.parseInt(data.getQueryParameter("status"));
 
             // Check that we actually have the data. If not return failure.

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiExportActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiExportActivity.java
@@ -1,6 +1,9 @@
 package com.fieldbook.tracker.brapi;
 
+import android.app.Activity;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
@@ -61,9 +64,6 @@ public class BrapiExportActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Check if our activity was started up with brapi auth deep link.
-        brapiControllerResponse = BrAPIService.checkBrapiAuth(this);
-
         if(Utils.isConnected(this)) {
             if (BrAPIService.hasValidBaseUrl(this)) {
 
@@ -108,13 +108,23 @@ public class BrapiExportActivity extends AppCompatActivity {
     public void onResume() {
         super.onResume();
 
-        // If our activity was resumed, we will want to see if it was resumed from a deep link.
-        if (brapiControllerResponse.status == null) {
-            brapiControllerResponse = BrAPIService.checkBrapiAuth(this);
-        }
+        // Check out brapi auth
+        brapiControllerResponse = BrAPIService.checkBrapiAuth(this);
 
-        // Check whether our brapi auth response was successful
+        // Check whether our brapi auth response was exists or was successful
         processBrapiControllerMessage(brapiControllerResponse);
+
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+
+        // We will arrive at this function after our deep link when starting the auth
+        // process from this page.
+
+        // Set our intent on resume so we get the deep link info.
+        setIntent(intent);
 
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/preferences/PreferencesActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/PreferencesActivity.java
@@ -85,9 +85,6 @@ public class PreferencesActivity extends AppCompatActivity {
             getSupportActionBar().setHomeButtonEnabled(true);
         }
 
-        // Check if our activity was started up with brapi auth deep link.
-        brapiControllerResponse = BrAPIService.checkBrapiAuth(this);
-
         // This is not related to the deep link, load normally.
         preferencesFragment = new PreferencesFragment();
         getFragmentManager().beginTransaction()
@@ -100,12 +97,13 @@ public class PreferencesActivity extends AppCompatActivity {
 
     public void processMessage(BrapiControllerResponse brapiControllerResponse) {
 
-        // If we fail or succeed, show our message
-        if (brapiControllerResponse.status) {
-            Toast.makeText(this, R.string.brapi_auth_success, Toast.LENGTH_LONG).show();
-        }
-        else {
-            Toast.makeText(this, R.string.brapi_auth_deny, Toast.LENGTH_LONG).show();
+        if (brapiControllerResponse.status != null) {
+            if (!brapiControllerResponse.status) {
+                Toast.makeText(this, R.string.brapi_auth_error_starting, Toast.LENGTH_LONG).show();
+            }
+            else {
+                Toast.makeText(this, R.string.brapi_auth_success, Toast.LENGTH_LONG).show();
+            }
         }
 
     }
@@ -115,21 +113,13 @@ public class PreferencesActivity extends AppCompatActivity {
         super.onResume();
 
         // If our preference page was resumed, we will want to see if it was resumed from a deep link.
-        if (brapiControllerResponse.status == null) {
-            brapiControllerResponse = BrAPIService.checkBrapiAuth(this);
-        }
+        brapiControllerResponse = BrAPIService.checkBrapiAuth(this);
 
-        // Check whether our brapi auth response was successful
-        if (brapiControllerResponse.status != null) {
-            processMessage(brapiControllerResponse);
+        // Set our button visibility and text
+        preferencesFragment.setButtonView();
 
-            // Show our brapi preferences if they just came back from a brapi auth and it is not displayed already.
-            PreferenceScreen brapi_prefs = (PreferenceScreen) preferencesFragment.findPreference("brapi_preference_screen");
-            if (!preferencesFragment.getPreferenceScreen().equals(brapi_prefs)) {
-                preferencesFragment.setPreferenceScreen(brapi_prefs);
-            }
+        processMessage(brapiControllerResponse);
 
-        }
     }
 
     @Override

--- a/app/src/main/java/com/fieldbook/tracker/preferences/PreferencesFragment.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/PreferencesFragment.java
@@ -75,12 +75,14 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
 
             // Call our brapi authorize function
             if (brapiPrefCategory != null) {
-                brapiPrefCategory.addPreference(brapiAuthButton);
-                brapiPrefCategory.addPreference(brapiLogoutButton);
+                // Set our button visibility and text
+                setButtonView();
+
+                // Start our login process
                 BrapiControllerResponse brapiControllerResponse  = BrAPIService.authorizeBrAPI(prefMgr.getSharedPreferences(), context, null);
+
                 // Show our error message if it exists
                 processResponseMessage(brapiControllerResponse);
-                ((Activity)context).finish();
             }
         }
 
@@ -107,26 +109,18 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
                 public boolean onPreferenceClick(Preference preference) {
                     String brapiHost = prefMgr.getSharedPreferences().getString(BRAPI_BASE_URL, null);
                     if (brapiHost != null) {
-                        BrapiControllerResponse brapiControllerResponse = BrAPIService.authorizeBrAPI(prefMgr.getSharedPreferences(), PreferencesFragment.this.context, null);
+                        // Start our login process
+                        BrapiControllerResponse brapiControllerResponse = BrAPIService.authorizeBrAPI(prefMgr.getSharedPreferences(), context, null);
+
                         // Show our error message if it exists
                         processResponseMessage(brapiControllerResponse);
-                        ((Activity)context).finish();
                     }
                     return true;
                 }
             });
 
-            if(brapiHost != null && !brapiHost.equals(getString(R.string.brapi_base_url_default))) {
-                brapiAuthButton.setTitle(R.string.brapi_authorize);
-                brapiAuthButton.setSummary(null);
-                if (brapiToken != null) {
-                    brapiAuthButton.setTitle(R.string.brapi_reauthorize);
-                    brapiAuthButton.setSummary(getString(R.string.brapi_btn_auth_summary, brapiHost));
-                }
-            } else {
-                brapiPrefCategory.removePreference(brapiAuthButton);
-                brapiPrefCategory.removePreference(brapiLogoutButton);
-            }
+            // Set our button visibility and text
+            setButtonView();
         }
 
         if (brapiLogoutButton != null) {
@@ -135,18 +129,45 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
                 public boolean onPreferenceClick(Preference preference) {
                     SharedPreferences preferences = prefMgr.getSharedPreferences();
 
+                    // Clear our brapi token
                     SharedPreferences.Editor editor = preferences.edit();
                     editor.putString(PreferencesActivity.BRAPI_TOKEN, null);
                     editor.apply();
 
-                    brapiAuthButton.setTitle(R.string.brapi_authorize);
-                    brapiAuthButton.setSummary(null);
+                    // Set our button visibility and text
+                    setButtonView();
 
-
-                    brapiPrefCategory.removePreference(brapiLogoutButton);
                     return true;
                 }
             });
         }
+    }
+
+    public void setButtonView() {
+
+        String brapiToken = prefMgr.getSharedPreferences().getString(PreferencesActivity.BRAPI_TOKEN, null);
+        String brapiHost = prefMgr.getSharedPreferences().getString(BRAPI_BASE_URL, null);
+
+        if(brapiHost != null && !brapiHost.equals(getString(R.string.brapi_base_url_default))) {
+
+            if (brapiToken != null) {
+                // Show our reauthorize button and remove logout button
+                brapiAuthButton.setTitle(R.string.brapi_reauthorize);
+                brapiAuthButton.setSummary(getString(R.string.brapi_btn_auth_summary, brapiHost));
+                // Show if our logout button if it is not shown already
+                brapiPrefCategory.addPreference(brapiLogoutButton);
+            }
+            else {
+                // Show authorize button and remove our logout button
+                brapiAuthButton.setTitle(R.string.brapi_authorize);
+                brapiAuthButton.setSummary(null);
+                brapiPrefCategory.removePreference(brapiLogoutButton);
+            }
+
+        } else {
+            brapiPrefCategory.removePreference(brapiAuthButton);
+            brapiPrefCategory.removePreference(brapiLogoutButton);
+        }
+
     }
 }


### PR DESCRIPTION
This fixes an issue on the Brapi Export page. When the export button was clicked, and a 401 response was returned, the login process that began on the export page after that did not successfully get the deep link response. 

Another addition in the branch besides the auth loop fix was to reformat the brapi login code in the preferences menu. Reformatting consisted of using native android functions for the activity flow, instead of the hack arounds that were in place before. Also, a general cleaning up of button visibility and text code. 