### PR TITLE
BrAPI trait duplicate errors more specific. Added info messages to st…

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiTraitActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiTraitActivity.java
@@ -258,7 +258,7 @@ public class BrapiTraitActivity extends AppCompatActivity {
 
             // Check if the trait already exists
             if (ConfigActivity.dt.hasTrait(trait.getTrait())) {
-                secondaryMessage = "Trait already exists: " + trait.getTrait();
+                secondaryMessage = getResources().getString(R.string.brapi_trait_already_exists, trait.getTrait());
                 // Skip this one, continue on.
                 continue;
             }
@@ -280,14 +280,14 @@ public class BrapiTraitActivity extends AppCompatActivity {
 
         // Check how successful we were at saving our traits.
         if (successfulSaves == 0) {
-            return "Error saving traits. No traits were saved";
+            return secondaryMessage != "" ? secondaryMessage : getResources().getString(R.string.brapi_error_saving_all_traits);
         }
         else if (successfulSaves < totalTraits) {
-            return "Error saving some traits. Some traits were not saved";
+            return secondaryMessage != "" ? secondaryMessage : getResources().getString(R.string.brapi_error_saving_some_traits);
         }
 
         // Check if we had a secondary message to show
-        return secondaryMessage != "" ? secondaryMessage : "Selected traits saved successfully.";
+        return secondaryMessage != "" ? secondaryMessage : getResources().getString(R.string.brapi_traits_saved_success);
 
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiTraitActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiTraitActivity.java
@@ -286,7 +286,10 @@ public class BrapiTraitActivity extends AppCompatActivity {
             return secondaryMessage != "" ? secondaryMessage : getResources().getString(R.string.brapi_error_saving_some_traits);
         }
 
-        // Check if we had a secondary message to show
+        // Check if we had a secondary message to show.
+        // Current this secondaryMessage will always be empty for the success message.
+        // Putting selection for secondaryMessage in here now for potential future use with
+        // more detailed success and failure messages. 
         return secondaryMessage != "" ? secondaryMessage : getResources().getString(R.string.brapi_traits_saved_success);
 
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -414,6 +414,10 @@
     <string name="brapi_export_successful">BrAPI Export Successful</string>
     <string name="brapi_saving_indicator">Saving Observations...</string>
     <string name="brapi_field_non_matching_sources">Unable to sync data. Field data originates from, %1$s, BrAPI url currently set to %2$s. Sources must match.</string>
+    <string name="brapi_trait_already_exists">Trait already exists: %1$s. Not saving.</string>
+    <string name="brapi_error_saving_all_traits">Error saving traits. No traits were saved.</string>
+    <string name="brapi_error_saving_some_traits">Error saving some traits. Some traits were not saved</string>
+    <string name="brapi_traits_saved_success">Selected traits saved successfully.</string>
     <string name="device_offline_warning">Device Offline: Please connect to a network and try again</string>
     <string name="next">Next</string>
     <string name="prev">Prev</string>


### PR DESCRIPTION
Displays a message when a duplicate trait is attempted to be imported through BrAPI. If there is more than one duplicate trait, the last trait that is a duplicate will be displayed in the message. 

Additional info: If many traits are selected, traits that are not duplicated will be inserted, but traits that are duplicates will be skipped. 