### PR TITLE
Fie 61 fie 62

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/DataHelper.java
@@ -827,7 +827,7 @@ public class DataHelper {
         data.setCategories("");
 
         Cursor cursor = db.query(TRAITS, new String[]{"trait", "format", "defaultValue", "minimum",
-                        "maximum", "details", "categories", "id"}, "trait like ? and isVisible like ?",
+                        "maximum", "details", "categories", "id", "external_db_id"}, "trait like ? and isVisible like ?",
                 new String[]{trait, "true"}, null, null, null
         );
 
@@ -840,6 +840,7 @@ public class DataHelper {
             data.setDetails(cursor.getString(5));
             data.setCategories(cursor.getString(6));
             data.setId(cursor.getString(7));
+            data.setExternalDbId(cursor.getString(8));
         }
 
         if (!cursor.isClosed()) {

--- a/app/src/main/java/com/fieldbook/tracker/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/DataHelper.java
@@ -693,7 +693,7 @@ public class DataHelper {
         ArrayList<FieldObject> list = new ArrayList<>();
 
         Cursor cursor = db.query(EXP_INDEX, new String[]{"exp_id", "exp_name", "unique_id", "primary_id",
-                        "secondary_id", "date_import", "date_edit", "date_export", "count"},
+                        "secondary_id", "date_import", "date_edit", "date_export", "count", "exp_source"},
                 null, null, null, null, "exp_id"
         );
 
@@ -709,6 +709,7 @@ public class DataHelper {
                 o.setDate_edit(cursor.getString(6));
                 o.setDate_export(cursor.getString(7));
                 o.setCount(cursor.getString(8));
+                o.setExp_source(cursor.getString(9));
                 list.add(o);
             } while (cursor.moveToNext());
         }

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiInfoDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiInfoDialog.java
@@ -1,0 +1,51 @@
+package com.fieldbook.tracker.brapi;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import com.fieldbook.tracker.R;
+
+public class BrapiInfoDialog extends Dialog implements android.view.View.OnClickListener {
+
+    private Context context;
+    private String bodyMessage;
+    private Button closeBtn;
+    private TextView bodyTextView;
+
+    public BrapiInfoDialog(@NonNull Context context, String bodyMessage) {
+
+        super(context);
+        this.context = context;
+        this.bodyMessage = bodyMessage;
+
+    }
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.dialog_info);
+        closeBtn = findViewById(R.id.closeBtn);
+        bodyTextView = findViewById(R.id.body_message);
+
+        // Set our body text
+        bodyTextView.setText(bodyMessage);
+
+        closeBtn.setOnClickListener(this);
+    }
+
+    @Override
+    public void onClick(View view) {
+
+        switch (view.getId()) {
+            case R.id.closeBtn:
+                dismiss();
+        }
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -45,6 +45,7 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        this.setCanceledOnTouchOutside(false);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         setContentView(R.layout.dialog_brapi_import);
 

--- a/app/src/main/java/com/fieldbook/tracker/fields/FieldAdapter.java
+++ b/app/src/main/java/com/fieldbook/tracker/fields/FieldAdapter.java
@@ -20,6 +20,9 @@ import android.widget.Toast;
 import com.fieldbook.tracker.ConfigActivity;
 import com.fieldbook.tracker.MainActivity;
 import com.fieldbook.tracker.R;
+import com.fieldbook.tracker.brapi.BrAPIService;
+import com.fieldbook.tracker.brapi.BrapiAuthDialog;
+import com.fieldbook.tracker.brapi.BrapiInfoDialog;
 
 import java.util.ArrayList;
 
@@ -91,22 +94,7 @@ class FieldAdapter extends BaseAdapter {
 
         convertView.setOnClickListener(new OnClickListener() {
             public void onClick(View v) {
-                SharedPreferences.Editor ed = ep.edit();
-                ed.putString("FieldFile", getItem(position).getExp_name());
-                ed.putString("ImportUniqueName", getItem(position).getUnique_id());
-                ed.putString("ImportFirstName", getItem(position).getPrimary_id());
-                ed.putString("ImportSecondName", getItem(position).getSecondary_id());
-                ed.putBoolean("ImportFieldFinished", true);
-                ed.putBoolean("FieldSelected",true);
-                ed.putString("lastplot", null);
-                ed.putString("DROP1", null);
-                ed.putString("DROP2", null);
-                ed.putString("DROP3", null);
-                ed.apply();
-
-                ConfigActivity.dt.switchField(getItem(position).getExp_id());
-                MainActivity.reloadData = true;
-                notifyDataSetChanged();
+                fieldClick(getItem(position));
             }
         });
 
@@ -135,23 +123,7 @@ class FieldAdapter extends BaseAdapter {
         holder.active.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                SharedPreferences.Editor ed = ep.edit();
-                ed.putString("FieldFile", getItem(position).getExp_name());
-                ed.putInt("ExpID", getItem(position).getExp_id());
-                ed.putString("ImportUniqueName", getItem(position).getUnique_id());
-                ed.putString("ImportFirstName", getItem(position).getPrimary_id());
-                ed.putString("ImportSecondName", getItem(position).getSecondary_id());
-                ed.putBoolean("ImportFieldFinished", true);
-                ed.putBoolean("FieldSelected",true);
-                ed.putString("lastplot", null);
-                ed.putString("DROP1", null);
-                ed.putString("DROP2", null);
-                ed.putString("DROP3", null);
-                ed.apply();
-
-                ConfigActivity.dt.switchField(getItem(position).getExp_id());
-                MainActivity.reloadData = true;
-                notifyDataSetChanged();
+                fieldClick(getItem(position));
             }
         });
 
@@ -230,5 +202,36 @@ class FieldAdapter extends BaseAdapter {
         });
 
         return convertView;
+    }
+
+    public void fieldClick(FieldObject selectedField) {
+
+        SharedPreferences.Editor ed = ep.edit();
+        ed.putString("FieldFile", selectedField.getExp_name());
+        ed.putInt("ExpID", selectedField.getExp_id());
+        ed.putString("ImportUniqueName", selectedField.getUnique_id());
+        ed.putString("ImportFirstName", selectedField.getPrimary_id());
+        ed.putString("ImportSecondName", selectedField.getSecondary_id());
+        ed.putBoolean("ImportFieldFinished", true);
+        ed.putBoolean("FieldSelected",true);
+        ed.putString("lastplot", null);
+        ed.putString("DROP1", null);
+        ed.putString("DROP2", null);
+        ed.putString("DROP3", null);
+        ed.apply();
+
+        ConfigActivity.dt.switchField(selectedField.getExp_id());
+        MainActivity.reloadData = true;
+        notifyDataSetChanged();
+
+        // Check if this is a BrAPI field and show BrAPI info dialog if so
+        if (selectedField.getExp_source() != null &&
+                selectedField.getExp_source() != "" &&
+                selectedField.getExp_source() != "local"){
+
+            BrapiInfoDialog brapiInfo = new BrapiInfoDialog(context,
+                    context.getResources().getString(R.string.brapi_info_message));
+            brapiInfo.show();
+        }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/fields/FieldAdapter.java
+++ b/app/src/main/java/com/fieldbook/tracker/fields/FieldAdapter.java
@@ -159,6 +159,7 @@ class FieldAdapter extends BaseAdapter {
                                     if (getItem(position).getExp_name().equals(ep.getString("FieldFile", ""))) {
                                         SharedPreferences.Editor ed = ep.edit();
                                         ed.putString("FieldFile", null);
+                                        ed.putString("ImportExpSource", null);
                                         ed.putBoolean("ImportFieldFinished", false);
                                         ed.putBoolean("FieldSelected",false);
                                         ed.putString("lastplot", null);
@@ -209,6 +210,7 @@ class FieldAdapter extends BaseAdapter {
         SharedPreferences.Editor ed = ep.edit();
         ed.putString("FieldFile", selectedField.getExp_name());
         ed.putInt("ExpID", selectedField.getExp_id());
+        ed.putString("ImportExpSource", selectedField.getExp_source());
         ed.putString("ImportUniqueName", selectedField.getUnique_id());
         ed.putString("ImportFirstName", selectedField.getPrimary_id());
         ed.putString("ImportSecondName", selectedField.getSecondary_id());

--- a/app/src/main/java/com/fieldbook/tracker/traits/TraitAdapter.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/TraitAdapter.java
@@ -3,6 +3,8 @@ package com.fieldbook.tracker.traits;
 import androidx.appcompat.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -18,8 +20,12 @@ import android.widget.PopupMenu;
 import android.widget.TextView;
 
 import com.fieldbook.tracker.ConfigActivity;
+import com.fieldbook.tracker.DataHelper;
 import com.fieldbook.tracker.MainActivity;
 import com.fieldbook.tracker.R;
+import com.fieldbook.tracker.brapi.BrAPIService;
+import com.fieldbook.tracker.brapi.BrapiAuthDialog;
+import com.fieldbook.tracker.brapi.BrapiInfoDialog;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,12 +40,15 @@ class TraitAdapter extends BaseAdapter {
     private Context context;
     private OnItemClickListener listener;
     private HashMap visibility;
+    public Boolean infoDialogShown = false;
 
-    TraitAdapter(Context context, int resource, ArrayList<TraitObject> list, OnItemClickListener listener, HashMap visibility) {
+    TraitAdapter(Context context, int resource, ArrayList<TraitObject> list, OnItemClickListener listener, HashMap visibility, Boolean dialogShown) {
         this.context = context;
         this.list = list;
         this.listener = listener;
         this.visibility = visibility;
+        // dialog shown indicates whether dialog has been shown on activity or not
+        this.infoDialogShown = dialogShown;
     }
 
     public int getCount() {
@@ -160,10 +169,37 @@ class TraitAdapter extends BaseAdapter {
             public void onCheckedChanged(CompoundButton arg0, boolean isChecked) {
                 if (holder.visible.isChecked()) {
                     ConfigActivity.dt.updateTraitVisibility(holder.name.getText().toString(), true);
-                    visibility.put(holder.name.getText().toString(),"true");
+                    visibility.put(holder.name.getText().toString(), "true");
+
+
                 } else {
                     ConfigActivity.dt.updateTraitVisibility(holder.name.getText().toString(), false);
-                    visibility.put(holder.name.getText().toString(),false);
+                    visibility.put(holder.name.getText().toString(), false);
+                }
+
+            }
+        });
+
+        holder.visible.setOnClickListener(new OnClickListener() {
+            // We make this separate form the on check changed listener so that we can
+            // separate the difference between user interaction and programmatic checking.
+
+            @Override
+            public void onClick(View v) {
+
+                // Only show dialog if it hasn't been show yet
+                if (!infoDialogShown) {
+
+                    // Check if the button is checked or not.
+                    CheckBox visibleCheckBox = (CheckBox) v;
+                    if (visibleCheckBox.isChecked()) {
+
+                        // Show our BrAPI info box if this is a non-BrAPI trait
+                        String traitName = holder.name.getText().toString();
+                        infoDialogShown = TraitEditorActivity.displayBrapiInfo(context, new DataHelper(context), traitName, false);
+
+                    }
+
                 }
             }
         });
@@ -253,4 +289,5 @@ class TraitAdapter extends BaseAdapter {
 
         return convertView;
     }
+
 }

--- a/app/src/main/java/com/fieldbook/tracker/traits/TraitEditorActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/TraitEditorActivity.java
@@ -812,7 +812,7 @@ public class TraitEditorActivity extends AppCompatActivity {
             if (!traitList.isShown())
                 traitList.setVisibility(ListView.VISIBLE);
 
-            // Determine if our BrAPI dialog was should with our current trait adapter
+            // Determine if our BrAPI dialog was shown with our current trait adapter
             Boolean showBrapiDialog;
             if (mAdapter != null ) {
                 // Check if current trait adapter has shown a dialog

--- a/app/src/main/java/com/fieldbook/tracker/traits/TraitEditorActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/TraitEditorActivity.java
@@ -1531,11 +1531,11 @@ public class TraitEditorActivity extends AppCompatActivity {
 
                     // Just returns an empty trait object in the case the trait isn't found
                     TraitObject trait = dt.getDetail(traitName);
-                    if (trait.getExternalDbId() == null) {
+                    if (trait.getTrait() == null) {
                         return false;
                     }
 
-                    if (trait.getExternalDbId().equals("local") || trait.getExternalDbId().equals("")) {
+                    if (trait.getExternalDbId() == null || trait.getExternalDbId().equals("local") || trait.getExternalDbId().equals("")) {
 
                         // Show info dialog if a BrAPI field is selected.
                         BrapiInfoDialog brapiInfo = new BrapiInfoDialog(context, context.getResources().getString(R.string.brapi_info_message));

--- a/app/src/main/res/layout/dialog_info.xml
+++ b/app/src/main/res/layout/dialog_info.xml
@@ -12,6 +12,17 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:id="@+id/body_title"
+        android:text="@string/brapi_info_title"
+        android:textColor="#000000"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="10dp"
+        android:textSize="@dimen/text_size_large"
+        android:textStyle="bold"
+        android:gravity="center"></TextView>
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
         android:id="@+id/body_message"
         android:text="Example"
         android:textColor="#000000"

--- a/app/src/main/res/layout/dialog_info.xml
+++ b/app/src/main/res/layout/dialog_info.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="#FFFFFF"
+    android:orientation="vertical"
+    android:paddingLeft="20dp"
+    android:paddingRight="20dp"
+    android:paddingTop="5dp"
+    android:paddingBottom="5dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/body_message"
+        android:text="Example"
+        android:textColor="#000000"
+        android:paddingHorizontal="20dp"
+        android:paddingVertical="10dp"
+        android:textSize="@dimen/text_size_medium"
+        android:gravity="center"></TextView>
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/closeBtn"
+        android:text="@string/dialog_ok"></Button>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -429,5 +429,9 @@
 
     Would you like to authenticate now?
     </string>
+    <string name="brapi_info_message">
+        Traits and fields imported via BrAPI will be able to export their observations via the BrAPI export.
+        Traits and fields created manually or imported via CSV, will need to be exported via CSV format.
+    </string>
     <string name="brapi_auth_btn">Log In to Site</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -431,7 +431,7 @@
     </string>
     <string name="brapi_info_message">
         Traits and fields imported via BrAPI will be able to export their observations via the BrAPI export.
-        Traits and fields created manually or imported via CSV, will need to be exported via CSV format.
+        Traits and fields created manually or imported via CSV will need to be exported via CSV format.
     </string>
     <string name="brapi_info_title">BrAPI Syncing Info</string>
     <string name="brapi_auth_btn">Log In to Site</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -433,5 +433,6 @@
         Traits and fields imported via BrAPI will be able to export their observations via the BrAPI export.
         Traits and fields created manually or imported via CSV, will need to be exported via CSV format.
     </string>
+    <string name="brapi_info_title">BrAPI Syncing Info</string>
     <string name="brapi_auth_btn">Log In to Site</string>
 </resources>


### PR DESCRIPTION
Displays a dialog when a BrAPI field is selected as the active field. 

Displays a dialog when a non-BrAPI traits is selected or imported when a BrAPI field is the selected field. The dialog will display:

- Once per navigation to the Trait Editor page. After initial showing of dialog, it is not shown again until the user navigates away from the page, and then back to the page. 

The occasions when the dialog is shown for the first time are: 
- Dialog will display when a non-BrAPI trait is made active (visible in field book lingo)
- Dialog will display when CSV of traits is imported
- Dialog will display when trait is manually added. 

The dialog informs the user that fields and traits imported from BrAPI can be exported via BrAPI, but fields and traits imported from csv or created manually will need to be exported via CSV. 