### PR TITLE
Fix auth btn. Remove unused category from export page.

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/DataHelper.java
@@ -241,49 +241,6 @@ public class DataHelper {
         return observations;
     }
 
-    /**
-     * Get empty value observations
-     */
-    public List<Observation> getEmptyValueObservations() {
-        List<Observation> observations = new ArrayList<>();
-
-        String query = "SELECT " +
-                "user_traits.id, " +
-                "user_traits.userValue " +
-                "FROM " +
-                "user_traits " +
-                "JOIN " +
-                "traits ON user_traits.parent = traits.trait " +
-                "JOIN " +
-                "exp_id ON user_traits.exp_id = exp_id.exp_id " +
-                "WHERE " +
-                "exp_id.exp_source IS NOT NULL " +
-                "AND " +
-                "traits.trait_data_source <> 'local' " +
-                "AND " +
-                "user_traits.userValue = '' " +
-                "AND " +
-                "traits.trait_data_source IS NOT NULL;";
-
-        Cursor cursor = db.rawQuery(query,null);
-
-        if (cursor.moveToFirst()) {
-            do {
-                Observation o = new Observation();
-                o.setFieldbookDbId(cursor.getString(0));
-                o.setValue(cursor.getString(1));
-                observations.add(o);
-
-            } while (cursor.moveToNext());
-        }
-
-        if (!cursor.isClosed()) {
-            cursor.close();
-        }
-
-        return observations;
-    }
-
     public List<Observation> getWrongSourceObservations(String hostUrl) {
 
         List<Observation> observations = new ArrayList<>();

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiExportActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiExportActivity.java
@@ -36,7 +36,6 @@ public class BrapiExportActivity extends AppCompatActivity {
     private List<Observation> observations;
     private List<Observation> observationsNeedingSync;
     private List<Observation> userCreatedTraitObservations;
-    private List<Observation> emptyValueObservations;
     private List<Observation> wrongSourceObservations;
 
     private BrapiControllerResponse brapiControllerResponse;
@@ -342,7 +341,6 @@ public class BrapiExportActivity extends AppCompatActivity {
         observations = dataHelper.getObservations(hostURL);
         observationsNeedingSync.clear();
         userCreatedTraitObservations = dataHelper.getUserTraitObservations();
-        emptyValueObservations = dataHelper.getEmptyValueObservations();
         wrongSourceObservations = dataHelper.getWrongSourceObservations(hostURL);
 
         for (Observation observation : observations) {
@@ -369,7 +367,6 @@ public class BrapiExportActivity extends AppCompatActivity {
         ((TextView) findViewById(R.id.brapiNumSyncedValue)).setText(String.valueOf(numSyncedObservations));
         ((TextView) findViewById(R.id.brapiNumEditedValue)).setText(String.valueOf(numEditedObservations));
         ((TextView) findViewById(R.id.brapiUserCreatedValue)).setText(String.valueOf(userCreatedTraitObservations.size()));
-        ((TextView) findViewById(R.id.brapiEmptyValue)).setText(String.valueOf(emptyValueObservations.size()));
         ((TextView) findViewById(R.id.brapiWrongSource)).setText(String.valueOf(wrongSourceObservations.size()));
 
     }

--- a/app/src/main/java/com/fieldbook/tracker/preferences/PreferencesFragment.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/PreferencesFragment.java
@@ -75,14 +75,15 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
 
             // Call our brapi authorize function
             if (brapiPrefCategory != null) {
-                // Set our button visibility and text
-                setButtonView();
 
                 // Start our login process
                 BrapiControllerResponse brapiControllerResponse  = BrAPIService.authorizeBrAPI(prefMgr.getSharedPreferences(), context, null);
 
                 // Show our error message if it exists
                 processResponseMessage(brapiControllerResponse);
+
+                // Set our button visibility and text
+                setButtonView();
             }
         }
 
@@ -149,6 +150,8 @@ public class PreferencesFragment extends PreferenceFragment implements Preferenc
         String brapiHost = prefMgr.getSharedPreferences().getString(BRAPI_BASE_URL, null);
 
         if(brapiHost != null && !brapiHost.equals(getString(R.string.brapi_base_url_default))) {
+
+            brapiPrefCategory.addPreference(brapiAuthButton);
 
             if (brapiToken != null) {
                 // Show our reauthorize button and remove logout button

--- a/app/src/main/res/layout/dialog_brapi_export.xml
+++ b/app/src/main/res/layout/dialog_brapi_export.xml
@@ -188,33 +188,6 @@
             android:orientation="horizontal">
 
             <TextView
-                android:id="@+id/brapiEmptyValue"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
-                android:paddingBottom="5dp"
-                android:textColor="#000000"
-                android:textSize="@dimen/text_size_medium"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/brapiEmptyLbl"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:paddingLeft="10dp"
-                android:paddingBottom="10dp"
-                android:text="@string/brapi_export_skipped_empty"
-                android:textColor="#000000"
-                android:textSize="@dimen/text_size_medium"
-                android:textStyle="bold" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
                 android:id="@+id/brapiWrongSource"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -340,7 +340,6 @@
     <string name="brapi_export_num_ed_obs"> Edited Observations</string>
     <string name="brapi_export_skipped_observations"> Skipped Observations</string>
     <string name="brapi_export_skipped_user_created"> User Created Trait Observations</string>
-    <string name="brapi_export_skipped_empty"> Empty Value Observations</string>
     <string name="brapi_export_skipped_wrong_source"> Different Data Source</string>
     <string name="brapi_na">NA</string>
     <string name="brapi_delete_message">Cannot delete synced BrAPI observation, using NA instead</string>


### PR DESCRIPTION
Made it so the auth button appears after the brapi url is changed. Before, the user had to exit and re-enter the settings menu for it to appear. 

Remove the 'Empty Observation Values' category and related code because it was unused. 