### PR TITLE
Add data conversions for extra BrAPI data types

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrAPIService.java
@@ -71,7 +71,7 @@ public class BrAPIService {
 
         ApiClient apiClient = new ApiClient().setBasePath(brapiBaseURL);
 
-        // Make timeout longer. Set it to 120 seconds for now
+        // Make timeout longer. Set it to 60 seconds for now
         apiClient.setReadTimeout(60000);
 
         this.studiesApi = new StudiesApi(apiClient);

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrAPIService.java
@@ -71,7 +71,7 @@ public class BrAPIService {
 
         ApiClient apiClient = new ApiClient().setBasePath(brapiBaseURL);
 
-        // Make timeout longer. Set it to 60 seconds for now
+        // Make timeout longer. Set it to 120 seconds for now
         apiClient.setReadTimeout(60000);
 
         this.studiesApi = new StudiesApi(apiClient);
@@ -561,12 +561,17 @@ public class BrAPIService {
         //TODO: Check these out and make sure they match with fieldbook data types.
         switch (dataType){
             case "Code":
+                // Not the ideal solution for this conversion
+                return "text";
             case "Nominal":
                 return "categorical";
             case "Date":
                 return "date";
             case "Numerical":
+                return "numeric";
             case "Ordinal":
+                // All Field Book categories are ordered, so this works
+                return "categorical";
             case "Duration":
                 return "numeric";
             case "Text":


### PR DESCRIPTION
Added conversions for data types that were left out of the original conversion. Converted the data types to the closest matches in Fieldbook:

"Code" - This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For exemple a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. "75VD" means "75%" of the plant is Crop Ontology & Integrated Breeding Platform Curation Guidelines 5/6/2016 9 infected and the plant is very delayed.
"Date" - The date class is for events expressed in a time format, e.g. yyyymmddThh:mm:ssZ or dd/mm/yy
"Duration" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months
"Nominal" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories
"Numerical" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectar, branches
"Ordinal" - Ordinal scales are scales composed of ordered categories
"Text" - A free text is used to express the trait.

Conversions are: 

Code -> text
Ordinal -> categorical
Numerical -> numeric

