### PR TITLE
Send authorization token in GET requests.

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrAPIService.java
@@ -325,7 +325,7 @@ public class BrAPIService {
 
     }
 
-    public void getStudies(final Function<List<BrapiStudySummary>, Void> function, final Function<String, Void> failFunction) {
+    public void getStudies(final String brapiToken, final Function<List<BrapiStudySummary>, Void> function, final Function<String, Void> failFunction) {
         try {
 
             BrapiApiCallBack<StudiesResponse> callback = new BrapiApiCallBack<StudiesResponse>() {
@@ -354,7 +354,7 @@ public class BrAPIService {
                     null, null, null, null,
                     null, null, null, null, null,
                     null, null, null, null,
-                    0, 1000, null, callback);
+                    0, 1000, brapiToken, callback);
 
         } catch (ApiException e) {
             e.printStackTrace();
@@ -369,7 +369,7 @@ public class BrAPIService {
         return study;
     }
 
-    public void getStudyDetails(String studyDbId, final Function<BrapiStudyDetails, Void> function, final Function<ApiException, Void> failFunction) {
+    public void getStudyDetails(final String brapiToken, final String studyDbId, final Function<BrapiStudyDetails, Void> function, final Function<ApiException, Void> failFunction) {
         try {
 
             BrapiApiCallBack<StudyResponse> callback = new BrapiApiCallBack<StudyResponse>() {
@@ -390,7 +390,7 @@ public class BrAPIService {
             };
 
             studiesApi.studiesStudyDbIdGetAsync(
-                    studyDbId, null, callback);
+                    studyDbId, brapiToken, callback);
 
         } catch (ApiException e) {
             failFunction.apply(e);
@@ -408,7 +408,7 @@ public class BrAPIService {
         return studyDetails;
     }
 
-    public void getPlotDetails(final String studyDbId, final Function<BrapiStudyDetails, Void> function, final Function<ApiException, Void> failFunction) {
+    public void getPlotDetails(final String brapiToken, final String studyDbId, final Function<BrapiStudyDetails, Void> function, final Function<ApiException, Void> failFunction) {
         try {
 
             BrapiApiCallBack<ObservationUnitsResponse1> callback = new BrapiApiCallBack<ObservationUnitsResponse1>() {
@@ -434,7 +434,7 @@ public class BrAPIService {
 
             studiesApi.studiesStudyDbIdObservationunitsGetAsync(
                     studyDbId, "plot", 0, 1000,
-                    null, callback);
+                    brapiToken, callback);
 
         } catch (ApiException e) {
             failFunction.apply(e);
@@ -518,7 +518,7 @@ public class BrAPIService {
         return getPrioritizedValue(values) != null;
     }
 
-    public void getOntology(Integer page, Integer pageSize, final Function<BrapiListResponse<TraitObject>, Void> function, final Function<ApiException, Void> failFunction) {
+    public void getOntology(final String brapiToken, Integer page, Integer pageSize, final Function<BrapiListResponse<TraitObject>, Void> function, final Function<ApiException, Void> failFunction) {
         try {
 
             BrapiApiCallBack<ObservationVariablesResponse> callback = new BrapiApiCallBack<ObservationVariablesResponse>() {
@@ -559,7 +559,7 @@ public class BrAPIService {
                 pageSize = 50;
             }
 
-            traitsApi.variablesGetAsync(page, pageSize, null, null,
+            traitsApi.variablesGetAsync(page, pageSize, brapiToken, null,
                     null, callback);
 
         } catch (ApiException e) {
@@ -701,7 +701,7 @@ public class BrAPIService {
         return returnValue;
     }
 
-    public void getTraits(final String studyDbId, final Function<BrapiStudyDetails, Void> function, final Function<ApiException, Void> failFunction) {
+    public void getTraits(final String brapiToken, final String studyDbId, final Function<BrapiStudyDetails, Void> function, final Function<ApiException, Void> failFunction) {
         try {
 
             BrapiApiCallBack<StudyObservationVariablesResponse> callback = new BrapiApiCallBack<StudyObservationVariablesResponse>() {
@@ -723,7 +723,7 @@ public class BrAPIService {
             };
             studiesApi.studiesStudyDbIdObservationvariablesGetAsync(
                     studyDbId, 0, 200,
-                    null, callback);
+                    brapiToken, callback);
         } catch (ApiException e) {
             failFunction.apply(e);
             e.printStackTrace();

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiActivity.java
@@ -81,7 +81,7 @@ public class BrapiActivity extends AppCompatActivity {
         listStudies.setVisibility(View.GONE);
         findViewById(R.id.loadingPanel).setVisibility(View.VISIBLE);
 
-        brAPIService.getStudies(new Function<List<BrapiStudySummary>, Void>() {
+        brAPIService.getStudies(BrAPIService.getBrapiToken(this), new Function<List<BrapiStudySummary>, Void>() {
             @Override
             public Void apply(final List<BrapiStudySummary> studies) {
 

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -75,8 +75,10 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
 
     private void buildStudyDetails() {
 
+        final String brapiToken = BrAPIService.getBrapiToken(this.context);
+
         findViewById(R.id.loadingPanel).setVisibility(View.VISIBLE);
-        brAPIService.getStudyDetails(study.getStudyDbId(), new Function<BrapiStudyDetails, Void>() {
+        brAPIService.getStudyDetails(brapiToken, study.getStudyDbId(), new Function<BrapiStudyDetails, Void>() {
             @Override
             public Void apply(final BrapiStudyDetails study) {
 
@@ -112,7 +114,7 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
         });
 
 
-        brAPIService.getPlotDetails(study.getStudyDbId(), new Function<BrapiStudyDetails, Void>() {
+        brAPIService.getPlotDetails(brapiToken, study.getStudyDbId(), new Function<BrapiStudyDetails, Void>() {
             @Override
             public Void apply(final BrapiStudyDetails study) {
 
@@ -149,7 +151,7 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
         });
 
 
-        brAPIService.getTraits(study.getStudyDbId(), new Function<BrapiStudyDetails, Void>() {
+        brAPIService.getTraits(brapiToken, study.getStudyDbId(), new Function<BrapiStudyDetails, Void>() {
             @Override
             public Void apply(final BrapiStudyDetails study) {
 

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiTraitActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiTraitActivity.java
@@ -121,7 +121,7 @@ public class BrapiTraitActivity extends AppCompatActivity {
         determineBtnVisibility();
 
         // Call our API to get the data
-        brAPIService.getOntology(page, pageSize, new Function<BrapiListResponse<TraitObject>, Void>() {
+        brAPIService.getOntology(BrAPIService.getBrapiToken(this), page, pageSize, new Function<BrapiListResponse<TraitObject>, Void>() {
             @Override
             public Void apply(final BrapiListResponse<TraitObject> input) {
 

--- a/app/src/test/java/BrapiServiceTest.java
+++ b/app/src/test/java/BrapiServiceTest.java
@@ -57,12 +57,13 @@ public class BrapiServiceTest {
     @Test
     public void checkGetStudies() {
 
+        final String brapiToken = "Bearer YYYY";
 
         // Set up our signal to wait for the callback to be called.
         final CountDownLatch signal = new CountDownLatch(1);
 
         // Call our get studies endpoint with the same parsing that our classes use.
-        this.brAPIService.getStudies(new Function<List<BrapiStudySummary>, Void>() {
+        this.brAPIService.getStudies(brapiToken, new Function<List<BrapiStudySummary>, Void>() {
             @Override
             public Void apply(List<BrapiStudySummary> input) {
                 // Check that there is atleast one study returned.
@@ -99,9 +100,10 @@ public class BrapiServiceTest {
         // Set up our signal to wait for the callback to be called.
         final CountDownLatch signal = new CountDownLatch(1);
         final String studyDbId = "1001";
+        final String brapiToken = "Bearer YYYY";
 
         // Call our get study details endpoint with the same parsing that our classes use.
-        this.brAPIService.getStudyDetails(studyDbId, new Function<BrapiStudyDetails, Void>() {
+        this.brAPIService.getStudyDetails(brapiToken, studyDbId, new Function<BrapiStudyDetails, Void>() {
             @Override
             public Void apply(BrapiStudyDetails input) {
                 // Check that the study db id we passed is what we are getting back
@@ -139,9 +141,10 @@ public class BrapiServiceTest {
         // Set up our signal to wait for the callback to be called.
         final CountDownLatch signal = new CountDownLatch(1);
         final String studyDbId = "1001";
+        final String brapiToken = "Bearer YYYY";
 
         // Call our get study details endpoint with the same parsing that our classes use.
-        this.brAPIService.getPlotDetails(studyDbId, new Function<BrapiStudyDetails, Void>() {
+        this.brAPIService.getPlotDetails(brapiToken, studyDbId, new Function<BrapiStudyDetails, Void>() {
             @Override
             public Void apply(BrapiStudyDetails input) {
                 // Check that we are getting some results back
@@ -178,9 +181,10 @@ public class BrapiServiceTest {
         // Call our get plot details endpoint with the same parsing that our classes use.
         // Set up our signal to wait for the callback to be called.
         final CountDownLatch signal = new CountDownLatch(1);
+        final String brapiToken = "Bearer YYYY";
 
         // Call our get study details endpoint with the same parsing that our classes use.
-        this.brAPIService.getOntology(null, null, new Function<BrapiListResponse<TraitObject>, Void>() {
+        this.brAPIService.getOntology(brapiToken,null, null, new Function<BrapiListResponse<TraitObject>, Void>() {
             @Override
             public Void apply(BrapiListResponse<TraitObject> input) {
                 // Check that we are getting some results back
@@ -218,9 +222,10 @@ public class BrapiServiceTest {
         // Set up our signal to wait for the callback to be called.
         final CountDownLatch signal = new CountDownLatch(1);
         final String studyDbId = "1001";
+        final String brapiToken = "Bearer YYYY";
 
         // Call our get study details endpoint with the same parsing that our classes use.
-        this.brAPIService.getTraits(studyDbId, new Function<BrapiStudyDetails, Void>() {
+        this.brAPIService.getTraits(brapiToken, studyDbId, new Function<BrapiStudyDetails, Void>() {
             @Override
             public Void apply(BrapiStudyDetails input) {
                 // Check that we are getting some results back


### PR DESCRIPTION
# Description

Applied changes to send the authorization token to the following GET requests:

- GET /studies
- GET /studies/{studyDbId}
- GET /studies/{studyDbId}/observationunits
- GET /studies/{studyDbId}/observationvariables
- GET /variables


Fixes # https://github.com/PhenoApps/Field-Book/issues/96

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe any tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Verify the GET calls with authorization token are called successfully 

1. Set the BrAPI URL, save and authorize
2. In the Fields section, import from BrAPI
3. A list of fields (studies) should be displayed
4. Select a field then click Save Field
5. A dialog box will appear showing the Name, Description, Location, Number of Plots and Traits
6. Verify that the Traits associated with the selected field are showing correctly
7. In the Traits section, click on '...'
8. Select Import/Export > Import > BrAPI
9. A list of available traits from BrAPI should be displayed

- [x] Verify unit tests of the affected methods are passing


**Test Configuration**:
* Hardware: Android Emulator
* SDK: Pixel 2 API 29 Android 10

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings