### PR TITLE
BrAPI: filter fields (studies) by program and trial

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,6 +70,18 @@
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme" />
         <activity
+            android:name=".activities.BrapiProgramActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize|locale"
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait"
+            android:theme="@style/AppTheme" />
+        <activity
+            android:name=".activities.BrapiTrialActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize|locale"
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait"
+            android:theme="@style/AppTheme" />
+        <activity
             android:name=".activities.BrapiTraitActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|locale"
             android:launchMode="singleTop"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,7 @@
             android:configChanges="orientation|keyboardHidden|screenSize|locale"
             android:launchMode="singleTop"
             android:screenOrientation="portrait"
-            android:theme="@style/AppTheme" />
+            android:theme="@style/AppThemeAction" />
         <activity
             android:name=".activities.BrapiProgramActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|locale"

--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
@@ -13,7 +13,6 @@ import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import androidx.arch.core.util.Function;
 
 import com.fieldbook.tracker.R;
@@ -83,8 +82,6 @@ public class BrapiActivity extends AppCompatActivity {
     }
 
     private void loadToolbar() {
-        Toolbar toolbar = findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
         if (getSupportActionBar() != null) {
             getSupportActionBar().setTitle(null);
             getSupportActionBar().getThemedContext();

--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiProgramActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiProgramActivity.java
@@ -1,0 +1,140 @@
+package com.fieldbook.tracker.activities;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.arch.core.util.Function;
+
+import com.fieldbook.tracker.R;
+import com.fieldbook.tracker.brapi.BrAPIService;
+import com.fieldbook.tracker.brapi.BrapiProgram;
+import com.fieldbook.tracker.database.DataHelper;
+import com.fieldbook.tracker.utilities.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BrapiProgramActivity extends AppCompatActivity {
+    private BrAPIService brAPIService;
+    private BrapiProgram brapiProgram;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (Utils.isConnected(this)) {
+            if (BrAPIService.hasValidBaseUrl(this)) {
+                setContentView(R.layout.activity_brapi_programs);
+                String brapiBaseURL = BrAPIService.getBrapiUrl(this);
+                brAPIService = new BrAPIService(brapiBaseURL, new DataHelper(BrapiProgramActivity.this));
+
+                TextView baseURLText = findViewById(R.id.brapiBaseURL);
+                baseURLText.setText(brapiBaseURL);
+
+                loadToolbar();
+                loadPrograms();
+            } else {
+                Toast.makeText(getApplicationContext(), R.string.brapi_must_configure_url, Toast.LENGTH_SHORT).show();
+                finish();
+            }
+        } else {
+            Toast.makeText(getApplicationContext(), R.string.device_offline_warning, Toast.LENGTH_SHORT).show();
+            finish();
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void loadToolbar() {
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setTitle(null);
+            getSupportActionBar().getThemedContext();
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setHomeButtonEnabled(true);
+        }
+    }
+
+    private void loadPrograms() {
+        ListView programsView = findViewById(R.id.brapiPrograms);
+        programsView.setVisibility(View.GONE);
+        findViewById(R.id.loadingPanel).setVisibility(View.VISIBLE);
+
+        brAPIService.getPrograms(BrAPIService.getBrapiToken(this), new Function<List<BrapiProgram>, Void>() {
+            @Override
+            public Void apply(List<BrapiProgram> programs) {
+                (BrapiProgramActivity.this).runOnUiThread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        programsView.setAdapter(BrapiProgramActivity.this.buildProgramsArrayAdapter(programs));
+                        programsView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+                            @Override
+                            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                                brapiProgram = programs.get(position);
+                            }
+                        });
+                        programsView.setVisibility(View.VISIBLE);
+                        findViewById(R.id.loadingPanel).setVisibility(View.GONE);
+                    }
+                });
+                return null;
+            }
+        }, new Function<String, Void>() {
+            @Override
+            public Void apply(String input) {
+                (BrapiProgramActivity.this).runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        // Show error message. We don't finish the activity intentionally.
+                        findViewById(R.id.loadingPanel).setVisibility(View.GONE);
+                        Toast.makeText(getApplicationContext(), input, Toast.LENGTH_LONG).show();
+                    }
+                });
+                return null;
+            }
+        });
+    }
+
+    private ListAdapter buildProgramsArrayAdapter(List<BrapiProgram> programs) {
+        List<Object> itemDataList = new ArrayList<>();
+        for (BrapiProgram program : programs) {
+            itemDataList.add(program.getProgramName());
+        }
+        ListAdapter adapter = new ArrayAdapter(this, android.R.layout.simple_list_item_single_choice, itemDataList);
+        return adapter;
+    }
+
+    public void buttonClicked(View view) {
+       switch (view.getId()) {
+           case R.id.loadPrograms:
+               loadPrograms();
+               break;
+           case R.id.selectProgram:
+               Intent intent = new Intent();
+               intent.setData(Uri.parse(this.brapiProgram.getProgramDbId()));
+               setResult(RESULT_OK, intent);
+               finish();
+               break;
+       }
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiTrialActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiTrialActivity.java
@@ -1,0 +1,142 @@
+package com.fieldbook.tracker.activities;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.arch.core.util.Function;
+
+import com.fieldbook.tracker.R;
+import com.fieldbook.tracker.brapi.BrAPIService;
+import com.fieldbook.tracker.brapi.BrapiTrial;
+import com.fieldbook.tracker.database.DataHelper;
+import com.fieldbook.tracker.utilities.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BrapiTrialActivity extends AppCompatActivity {
+    private BrAPIService brAPIService;
+    private BrapiTrial brapiTrial;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (Utils.isConnected(this)) {
+            if (BrAPIService.hasValidBaseUrl(this)) {
+                setContentView(R.layout.activity_brapi_trials);
+                String brapiBaseURL = BrAPIService.getBrapiUrl(this);
+                brAPIService = new BrAPIService(brapiBaseURL, new DataHelper(BrapiTrialActivity.this));
+
+                TextView baseURLText = findViewById(R.id.brapiBaseURL);
+                baseURLText.setText(brapiBaseURL);
+
+                loadToolbar();
+                loadTrials();
+            } else {
+                Toast.makeText(getApplicationContext(), R.string.brapi_must_configure_url, Toast.LENGTH_SHORT).show();
+                finish();
+            }
+        } else {
+            Toast.makeText(getApplicationContext(), R.string.device_offline_warning, Toast.LENGTH_SHORT).show();
+            finish();
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void loadToolbar() {
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setTitle(null);
+            getSupportActionBar().getThemedContext();
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setHomeButtonEnabled(true);
+        }
+    }
+
+    private void loadTrials() {
+        ListView trialsView = findViewById(R.id.brapiTrials);
+        trialsView.setVisibility(View.GONE);
+        findViewById(R.id.loadingPanel).setVisibility(View.VISIBLE);
+
+        String programDbId = getIntent().getStringExtra(BrapiActivity.PROGRAM_DB_ID_INTENT_PARAM);
+
+        brAPIService.getTrials(BrAPIService.getBrapiToken(this), programDbId, new Function<List<BrapiTrial>, Void>() {
+            @Override
+            public Void apply(List<BrapiTrial> trials) {
+                (BrapiTrialActivity.this).runOnUiThread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        trialsView.setAdapter(BrapiTrialActivity.this.buildTrialsArrayAdapter(trials));
+                        trialsView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+                            @Override
+                            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                                brapiTrial = trials.get(position);
+                            }
+                        });
+                        trialsView.setVisibility(View.VISIBLE);
+                        findViewById(R.id.loadingPanel).setVisibility(View.GONE);
+                    }
+                });
+                return null;
+            }
+        }, new Function<String, Void>() {
+            @Override
+            public Void apply(String input) {
+                (BrapiTrialActivity.this).runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        // Show error message. We don't finish the activity intentionally.
+                        findViewById(R.id.loadingPanel).setVisibility(View.GONE);
+                        Toast.makeText(getApplicationContext(), input, Toast.LENGTH_LONG).show();
+                    }
+                });
+                return null;
+            }
+        });
+    }
+
+    private ListAdapter buildTrialsArrayAdapter(List<BrapiTrial> trials) {
+        List<Object> itemDataList = new ArrayList<>();
+        for (BrapiTrial trial : trials) {
+            itemDataList.add(trial.getTrialName());
+        }
+        ListAdapter adapter = new ArrayAdapter(this, android.R.layout.simple_list_item_single_choice, itemDataList);
+        return adapter;
+    }
+
+    public void buttonClicked(View view) {
+       switch (view.getId()) {
+           case R.id.loadTrials:
+               loadTrials();
+               break;
+           case R.id.selectTrial:
+               Intent intent = new Intent();
+               intent.setData(Uri.parse(this.brapiTrial.getTrialDbId()));
+               setResult(RESULT_OK, intent);
+               finish();
+               break;
+       }
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiProgram.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiProgram.java
@@ -1,0 +1,22 @@
+package com.fieldbook.tracker.brapi;
+
+public class BrapiProgram {
+    private String programName;
+    private String programDbId;
+
+    public String getProgramName() {
+        return programName;
+    }
+
+    public void setProgramName(String programName) {
+        this.programName = programName;
+    }
+
+    public String getProgramDbId() {
+        return programDbId;
+    }
+
+    public void setProgramDbId(String programDbId) {
+        this.programDbId = programDbId;
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiTrial.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiTrial.java
@@ -1,0 +1,22 @@
+package com.fieldbook.tracker.brapi;
+
+public class BrapiTrial {
+    private String trialName;
+    private String trialDbId;
+
+    public String getTrialName() {
+        return trialName;
+    }
+
+    public void setTrialName(String trialName) {
+        this.trialName = trialName;
+    }
+
+    public String getTrialDbId() {
+        return trialDbId;
+    }
+
+    public void setTrialDbId(String trialDbId) {
+        this.trialDbId = trialDbId;
+    }
+}

--- a/app/src/main/res/layout/activity_brapi.xml
+++ b/app/src/main/res/layout/activity_brapi.xml
@@ -7,16 +7,6 @@
     android:background="#FFFFFF"
     android:orientation="vertical">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/main_primary"
-        android:fitsSystemWindows="true"
-        android:minHeight="?attr/actionBarSize"
-        app:popupTheme="@style/AppToolbar"
-        app:theme="@style/AppToolbar" />
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_brapi_programs.xml
+++ b/app/src/main/res/layout/activity_brapi_programs.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#FFFFFF"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/main_primary"
+        android:fitsSystemWindows="true"
+        android:minHeight="?attr/actionBarSize"
+        app:popupTheme="@style/AppToolbar"
+        app:theme="@style/AppToolbar" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/loadPrograms"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginLeft="5dp"
+            android:layout_marginTop="5dp"
+            android:onClick="buttonClicked"
+            android:text="@string/brapi_programs_load"
+            android:textColor="@color/s_text"
+            android:textSize="20sp" />
+
+        <TextView
+            android:id="@+id/brapiBaseURL"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="15sp" />
+
+    </LinearLayout>
+
+    <ListView
+        android:id="@+id/brapiPrograms"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:layout_weight="1"
+        android:choiceMode="singleChoice">
+
+    </ListView>
+
+    <RelativeLayout
+        android:id="@+id/loadingPanel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0"
+        android:gravity="center"
+        android:visibility="visible">
+
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            tools:visibility="visible" />
+    </RelativeLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="bottom|center"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/selectProgram"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginLeft="5dp"
+            android:layout_marginTop="5dp"
+            android:onClick="buttonClicked"
+            android:text="@string/brapi_programs_select"
+            android:textColor="@color/s_text"
+            android:textSize="20sp" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_brapi_trials.xml
+++ b/app/src/main/res/layout/activity_brapi_trials.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#FFFFFF"
+    android:orientation="vertical">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/main_primary"
+        android:fitsSystemWindows="true"
+        android:minHeight="?attr/actionBarSize"
+        app:popupTheme="@style/AppToolbar"
+        app:theme="@style/AppToolbar" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/loadTrials"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginLeft="5dp"
+            android:layout_marginTop="5dp"
+            android:onClick="buttonClicked"
+            android:text="@string/brapi_trials_load"
+            android:textColor="@color/s_text"
+            android:textSize="20sp" />
+
+        <TextView
+            android:id="@+id/brapiBaseURL"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="15sp" />
+
+    </LinearLayout>
+
+    <ListView
+        android:id="@+id/brapiTrials"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:layout_weight="1"
+        android:choiceMode="singleChoice">
+
+    </ListView>
+
+    <RelativeLayout
+        android:id="@+id/loadingPanel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0"
+        android:gravity="center"
+        android:visibility="visible">
+
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            tools:visibility="visible" />
+    </RelativeLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="bottom|center"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/selectTrial"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="5dp"
+            android:layout_marginLeft="5dp"
+            android:layout_marginTop="5dp"
+            android:onClick="buttonClicked"
+            android:text="@string/brapi_trials_select"
+            android:textColor="@color/s_text"
+            android:textSize="20sp" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_fields_brapi.xml
+++ b/app/src/main/res/menu/menu_fields_brapi.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/filter_by_program"
+        android:title="@string/brapi_fields_filter_by_program" />
+    <item
+        android:id="@+id/filter_by_trial"
+        android:title="@string/brapi_fields_filter_by_trial" />
+
+</menu>

--- a/app/src/main/res/menu/menu_fields_brapi.xml
+++ b/app/src/main/res/menu/menu_fields_brapi.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
         android:id="@+id/filter_by_program"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -396,6 +396,12 @@
     <string name="brapi_ontology_error">Error al cargar variables desde BrAPI.</string>
     <string name="brapi_save_field_error">Error al guardar el Campo</string>
     <string name="brapi_field_not_selected">El Campo seleccionado debe importarse desde BrAPI.</string>
+    <string name="brapi_fields_filter_by_program">Filtrar por programa</string>
+    <string name="brapi_fields_filter_by_trial">Filtrar por trial</string>
+    <string name="brapi_programs_load">Cargar programas</string>
+    <string name="brapi_programs_select">Seleccionar programa</string>
+    <string name="brapi_trials_load">Cargar trials</string>
+    <string name="brapi_trials_select">Seleccionar trial</string>
     <string name="brapi_save_trait">Guardar variables</string>
     <string name="brapi_must_configure_url">Debe configurar una URL de BrAPI válida en Ajustes antes de continuar</string>
     <string name="brapi_export_failed">Exportación por BrAPI fallida</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -454,6 +454,12 @@
     <string name="brapi_ontology_error">Error loadings traits from BrAPI.</string>
     <string name="brapi_save_field_error">Error Saving Field</string>
     <string name="brapi_field_not_selected">Selected Field Must Be Imported From BrAPI.</string>
+    <string name="brapi_fields_filter_by_program">Filter by program</string>
+    <string name="brapi_fields_filter_by_trial">Filter by trial</string>
+    <string name="brapi_programs_load">Load programs</string>
+    <string name="brapi_programs_select">Select program</string>
+    <string name="brapi_trials_load">Load trials</string>
+    <string name="brapi_trials_select">Select trial</string>
     <string name="brapi_save_trait">Save Traits</string>
     <string name="brapi_must_configure_url">Must configure a valid BrAPI URL in settings before proceeding</string>
     <string name="brapi_export_failed">BrAPI Export Failed</string>

--- a/app/src/test/java/BrapiServiceTest.java
+++ b/app/src/test/java/BrapiServiceTest.java
@@ -40,6 +40,8 @@ public class BrapiServiceTest {
     List<NewObservationDbIdsObservations> putObservationsResponse;
     Image postImageMetaDataResponse;
     Bitmap missingImage;
+    private String programDbId = "1";
+    private String trialDbId = "1";
 
 
     @Before
@@ -59,7 +61,7 @@ public class BrapiServiceTest {
         final CountDownLatch signal = new CountDownLatch(1);
 
         // Call our get studies endpoint with the same parsing that our classes use.
-        this.brAPIService.getStudies(brapiToken, new Function<List<BrapiStudySummary>, Void>() {
+        this.brAPIService.getStudies(brapiToken, this.programDbId, this.trialDbId, new Function<List<BrapiStudySummary>, Void>() {
             @Override
             public Void apply(List<BrapiStudySummary> input) {
                 // Check that there is atleast one study returned.


### PR DESCRIPTION
# Description

- New options menu in BrAPI Select fields activity:
   - Filter by program
   - Filter by trial
- New Select Programs activity: select one programDbId and return it
- New Select Trial activity:
   - Trial list filtered by programDbId (if available).
   - Select one trialDbId and return it.
- BrAPIService:
   - getPrograms
   - getTrials
   - getStudies: filter by programDbId and trialDbId

To fix a style issue, 
![filter-style-issue](https://user-images.githubusercontent.com/19394293/87673584-2a0a1580-c74b-11ea-8c44-e07cf55467c6.png)
I had to switch to `AppThemeAction` in `BrapiActivity` (select fields from BrAPI) 7d0dd05

Fixes #134

![ksu-fieldbook-filter-fields-v2](https://user-images.githubusercontent.com/19394293/87675575-ec5abc00-c74d-11ea-8d11-ac777ed0949b.gif)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested with:

- Android Studio emulator - Pixel 2 API 28 
- and generated Apk on 
    - Moto G6 Plus
    - Galaxy Tab A, SM-T510

Tests:

- Test A - BMS
   - [x] Filter by program
   - [x] Filter by trial
       - [x] Fix date format in bmsapi https://github.com/IntegratedBreedingPlatform/Middleware/pull/834
   - [x] Select study
   - [x] sync collected data
- Test B - Cassavabase
   - [x] Filter by program
   - [ ] Filter by trial **(Failed)**
     `org.threeten.bp.format.DateTimeParseException: Text '' could not be parsed at index 0`
     I assume a similar fix to #121 can be applied to `/trials`? returning null or omitting the field?
     @MFlores2021

**Test Configuration**:
* Hardware: 
* SDK: 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] My changes generate no new warnings

@trife @BrapiCoordinatorSelby @mcrimi @clarysabel @lukasmueller
