### PR TITLE
Handle http error status in BrAPI Field and Traits activities

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiExportActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiExportActivity.java
@@ -15,6 +15,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.arch.core.util.Function;
 
+import com.fieldbook.tracker.brapi.ApiError;
 import com.fieldbook.tracker.brapi.BrAPIService;
 import com.fieldbook.tracker.brapi.BrapiAuthDialog;
 import com.fieldbook.tracker.brapi.BrapiControllerResponse;
@@ -402,21 +403,26 @@ public class BrapiExportActivity extends AppCompatActivity {
 
     private UploadError processErrorCode(Integer code) {
         UploadError retVal;
+        ApiError apiError = ApiError.processErrorCode(code);
 
-        switch (code) {
-            case 403:
+        if (apiError == null) {
+            return UploadError.API_CALLBACK_ERROR;
+        }
+
+        switch (apiError) {
+            case FORBIDDEN:
                 // Warn that they do not have permissions to push traits
                 retVal = UploadError.API_PERMISSION_ERROR;
                 break;
-            case 401:
+            case UNAUTHORIZED:
                 // Start the login process
                 retVal = UploadError.API_UNAUTHORIZED_ERROR;
                 break;
-            case 400:
+            case BAD_REQUEST:
                 // Bad request
                 retVal = UploadError.API_CALLBACK_ERROR;
                 break;
-            case 404:
+            case NOT_FOUND:
                 // End point not supported
                 retVal = UploadError.API_NOTSUPPORTED_ERROR;
                 break;

--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiTraitActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiTraitActivity.java
@@ -16,7 +16,9 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.fieldbook.tracker.brapi.ApiError;
 import com.fieldbook.tracker.brapi.BrAPIService;
+import com.fieldbook.tracker.brapi.BrapiAuthDialog;
 import com.fieldbook.tracker.brapi.BrapiListResponse;
 import com.fieldbook.tracker.database.DataHelper;
 import com.fieldbook.tracker.R;
@@ -200,14 +202,39 @@ public class BrapiTraitActivity extends AppCompatActivity {
                     @Override
                     public void run() {
                         // Display error message but don't finish the activity.
+                        String message = getMessageForErrorCode(input.getCode());
                         findViewById(R.id.loadingPanel).setVisibility(View.GONE);
-                        Toast.makeText(getApplicationContext(), R.string.brapi_ontology_error, Toast.LENGTH_LONG).show();
+                        Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG).show();
                     }
                 });
 
                 return null;
             }
         });
+    }
+
+    private String getMessageForErrorCode(int code) {
+        ApiError apiError = ApiError.processErrorCode(code);
+
+        if (apiError == null) {
+            return getString(R.string.brapi_ontology_error);
+        }
+
+        switch (apiError) {
+            case UNAUTHORIZED:
+                // Start the login process
+                BrapiAuthDialog brapiAuth = new BrapiAuthDialog(BrapiTraitActivity.this, null);
+                brapiAuth.show();
+                return getString(R.string.brapi_auth_deny);
+            case FORBIDDEN:
+                return getString(R.string.brapi_auth_permission_deny);
+            case NOT_FOUND:
+                return getString(R.string.brapi_not_found);
+            case BAD_REQUEST:
+                return getString(R.string.brapi_ontology_error);
+            default:
+                return null;
+        }
     }
 
     // Transforms the trait data to display it on the screen.

--- a/app/src/main/java/com/fieldbook/tracker/brapi/ApiError.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/ApiError.java
@@ -1,0 +1,29 @@
+package com.fieldbook.tracker.brapi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ApiError {
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    NOT_FOUND(404),
+    FORBIDDEN(403);
+
+    private static final Map<Integer, ApiError> apiErrorsByCode = new HashMap<>();
+
+    static {
+        for (ApiError apiError : ApiError.values()) {
+            apiErrorsByCode.put(apiError.code, apiError);
+        }
+    }
+
+    private final int code;
+
+    ApiError(int code) {
+        this.code = code;
+    }
+
+    public static ApiError processErrorCode(Integer code) {
+        return apiErrorsByCode.get(code);
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrAPIService.java
@@ -325,7 +325,7 @@ public class BrAPIService {
 
     }
 
-    public void getStudies(final String brapiToken, final Function<List<BrapiStudySummary>, Void> function, final Function<String, Void> failFunction) {
+    public void getStudies(final String brapiToken, final Function<List<BrapiStudySummary>, Void> function, final Function<ApiException, Void> failFunction) {
         try {
 
             BrapiApiCallBack<StudiesResponse> callback = new BrapiApiCallBack<StudiesResponse>() {
@@ -345,7 +345,7 @@ public class BrAPIService {
                 public void onFailure(ApiException error, int i, Map<String, List<String>> map) {
 
                     // Close our current study and report failure
-                    failFunction.apply("Error when loading studies.");
+                    failFunction.apply(error);
 
                 }
             };

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -380,6 +380,7 @@
     <string name="brapi_auth_success">Autorización por BrAPI exitosa</string>
     <string name="brapi_auth_deny">Autorización BrAPI denegada</string>
     <string name="brapi_auth_error_starting">Error al iniciar la autenticación BrAPI</string>
+    <string name="brapi_auth_permission_deny">ERROR: no tiene los permisos necesarios para el sistema especificado.</string>
     <string name="brapi_btn_auth_summary">Brapi está actualmente autorizado con %1$s</string>
     <string name="brapi_base_url_default">https://test-server.brapi.org</string>
     <string name="brapi_load_data_button">Cargar Campos</string>
@@ -390,6 +391,8 @@
     <string name="brapi_study_location">Ubicación</string>
     <string name="brapi_study_num_plots">Parcela</string>
     <string name="brapi_study_num_traits">Variables</string>
+    <string name="brapi_not_found">ERROR: El sistema de destino no admite esta operación vía BrAPI.</string>
+    <string name="brapi_studies_error">Error al cargar los estudios.</string>
     <string name="brapi_study_detail_error">Error al cargar los detalles del estudio. Estudio no guardado.</string>
     <string name="brapi_plot_detail_error">Error al cargar las parcelas del estudio. Estudio no guardado.</string>
     <string name="brapi_study_traits_error">Error al cargar las variables del estudio. Estudio no guardado.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -438,6 +438,7 @@
     <string name="brapi_auth_success">BrAPI Authorization Successful</string>
     <string name="brapi_auth_deny">BrAPI Authorization Denied</string>
     <string name="brapi_auth_error_starting">Error Starting BrAPI Auth</string>
+    <string name="brapi_auth_permission_deny">ERROR: You do not have the permissions necessary for the specified system.</string>
     <string name="brapi_btn_auth_summary">Brapi is currently authorized with %1$s</string>
     <string name="brapi_base_url_default">https://test-server.brapi.org</string>
     <string name="brapi_load_data_button">Load Fields</string>
@@ -448,6 +449,8 @@
     <string name="brapi_study_location">Location</string>
     <string name="brapi_study_num_plots"> Plots</string>
     <string name="brapi_study_num_traits"> Traits</string>
+    <string name="brapi_not_found">ERROR: Target system does not support this operation via BrAPI.</string>
+    <string name="brapi_studies_error">Error when loading studies.</string>
     <string name="brapi_study_detail_error">Error when loading study details for study. Study not saved.</string>
     <string name="brapi_plot_detail_error">Error when loading plots for study. Study not saved.</string>
     <string name="brapi_study_traits_error">Error when loading traits for study. Study not saved.</string>

--- a/app/src/test/java/BrapiServiceTest.java
+++ b/app/src/test/java/BrapiServiceTest.java
@@ -70,9 +70,9 @@ public class BrapiServiceTest {
 
                 return null;
             }
-        }, new Function<String, Void>() {
+        }, new Function<ApiException, Void>() {
             @Override
-            public Void apply(String input) {
+            public Void apply(ApiException error) {
                 BrapiServiceTest.this.checkGetStudiesResult = false;
                 // Notify the countdown that we are finish
                 signal.countDown();


### PR DESCRIPTION
# Description

- Display a special error message for http status 400, 403 and 404
- If http status 401, start BrapiAuthDialog
- Consolidate error codes in ApiError enum

Basically this branch implements a similar workflow already available in the BrAPI export activity.

Fixes #130

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested with:

- Android Studio emulator - Pixel 2 API 28 
- and generated Apk on Moto G6 Plus

Tests:
- In the BrAPI authorization settings, log in to BMS with a user with no permission for studies, and authorize Field book.
- Go to Fields and load studies. See special error message: _ERROR: You do not have the permissions necessary for the specified system._

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] My changes generate no new warnings

cc @trife @BrapiCoordinatorSelby @mcrimi @clarysabel