### PR TITLE
Bugfixes from refactor merge

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiObservation.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiObservation.java
@@ -46,10 +46,7 @@ public class BrapiObservation {
         OffsetDateTime converted = null;
         try {
             //TODO: locale
-            //TODO: changed the commented line, is the ZZZZZ a typo?
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ");
-
-//            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZZZZZ");
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZZZZZ");
             converted = OffsetDateTime.parse(time, formatter);
         } catch (DateTimeParseException e) {
             e.printStackTrace();

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -1263,16 +1263,16 @@ public class DataHelper {
      */
     public int[] getAllRangeID() {
 
-//        if (!isTableExists("ObservationUnitProperty")) {
-//
-//            ArrayList<FieldObject> fields = StudyDao.Companion.getAllFieldObjects();
-//
-//            if (!fields.isEmpty()) {
-//
-//                StudyDao.Companion.switchField(fields.get(0).getExp_id());
-//
-//            }
-//        }
+        if (!isTableExists("ObservationUnitProperty")) {
+
+            ArrayList<FieldObject> fields = StudyDao.Companion.getAllFieldObjects();
+
+            if (!fields.isEmpty()) {
+
+                StudyDao.Companion.switchField(fields.get(0).getExp_id());
+
+            }
+        }
 
         Integer[] result = ObservationUnitPropertyDao.Companion.getAllRangeId();
 

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
@@ -198,7 +198,11 @@ class ObservationDao {
 
             val internalTraitId = ObservationVariableDao.getTraitId(parent)
 
-            val timestamp = OffsetDateTime.now().format(internalTimeFormatter)
+            val timestamp = try {
+                OffsetDateTime.now().format(internalTimeFormatter)
+            } catch (e: Exception) { //ZoneRulesException
+                String()
+            }
 
             db.insert(Observation.tableName, null, contentValuesOf(
                     "observation_variable_name" to parent,


### PR DESCRIPTION
Changed brapi observation time formatter back to SSSZZZZZ

Bug fix for AOB exception occurring if the range table wasn't created when getAllRangeID is called.

Bugfix (I think just for emulators) if the SSSZZZZZ format can't parse due to not having a time zone, an empty string is given.
