### PR TITLE
Added default empty string when null traits are migrated

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/database/Migrator.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/Migrator.kt
@@ -202,9 +202,9 @@ class Migrator {
                 traits.forEachIndexed { index, trait ->
                     //iterate trhough mapping of the old columns that are now attr/vals
                     mapOf(
-                            "validValuesMin" to trait.minimum as String,
-                            "validValuesMax" to trait.maximum as String,
-                            "category" to trait.categories as String,
+                            "validValuesMin" to (trait.minimum ?: ""),
+                            "validValuesMax" to (trait.maximum ?: ""),
+                            "category" to (trait.categories ?: ""),
                     ).asSequence().forEach { attrValue ->
 
                         //TODO: commenting this out would create a sparse table from the unused attribute values


### PR DESCRIPTION
# Description
fixes #224 

Null traits where causing a crash during migration from v8 -> v9. I added a check to convert the null values to empty strings before they are migrated.

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

On emulator:
installed v8, inserted a null value category, installed develop branch and migrated to v9 (no crash)
