### PR TITLE
Issue 217

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -18,6 +18,8 @@ import android.os.Handler;
 import android.os.Message;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.constraintlayout.widget.ConstraintSet;
 import androidx.core.content.FileProvider;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.appcompat.widget.Toolbar;
@@ -251,7 +253,6 @@ public class CollectActivity extends AppCompatActivity {
         traitBox = new TraitBox(this);
         rangeBox = new RangeBox(this);
         initCurrentVals();
-
     }
 
     private void refreshMain() {
@@ -1157,12 +1158,28 @@ public class CollectActivity extends AppCompatActivity {
             newTraits = new HashMap();
 
             traitType = findViewById(R.id.traitType);
-            traitLeft = findViewById(R.id.traitLeft);
-            traitRight = findViewById(R.id.traitRight);
+
+            //determine trait button function based on user-preferences
+            //issues217 introduces the ability to swap trait and plot arrows
+            boolean flipFlopArrows = ep.getBoolean("FLIP_FLOP_ARROWS", false);
+            if (flipFlopArrows) {
+                traitLeft = findViewById(R.id.rangeLeft);
+                traitRight = findViewById(R.id.rangeRight);
+            } else {
+                traitLeft = findViewById(R.id.traitLeft);
+                traitRight = findViewById(R.id.traitRight);
+            }
+
             traitDetails = findViewById(R.id.traitDetails);
 
-            traitLeft.setOnTouchListener(createTraitOnTouchListener(traitLeft, R.drawable.main_trait_left_arrow_unpressed,
-                    R.drawable.main_trait_left_arrow_pressed));
+            //change click-arrow based on preferences
+            if (flipFlopArrows) {
+                traitLeft.setOnTouchListener(createTraitOnTouchListener(traitLeft, R.drawable.main_entry_left_unpressed,
+                        R.drawable.main_entry_left_pressed));
+            } else {
+                traitLeft.setOnTouchListener(createTraitOnTouchListener(traitLeft, R.drawable.main_trait_left_arrow_unpressed,
+                        R.drawable.main_trait_left_arrow_pressed));
+            }
 
             // Go to previous trait
             traitLeft.setOnClickListener(new OnClickListener() {
@@ -1172,8 +1189,14 @@ public class CollectActivity extends AppCompatActivity {
                 }
             });
 
-            traitRight.setOnTouchListener(createTraitOnTouchListener(traitRight, R.drawable.main_trait_right_unpressed,
-                    R.drawable.main_trait_right_pressed));
+            //change click-arrow based on preferences
+            if (flipFlopArrows) {
+                traitRight.setOnTouchListener(createTraitOnTouchListener(traitRight, R.drawable.main_entry_right_unpressed,
+                        R.drawable.main_entry_right_pressed));
+            } else {
+                traitRight.setOnTouchListener(createTraitOnTouchListener(traitRight, R.drawable.main_trait_right_unpressed,
+                        R.drawable.main_trait_right_pressed));
+            }
 
             // Go to next trait
             traitRight.setOnClickListener(new OnClickListener() {
@@ -1505,8 +1528,16 @@ public class CollectActivity extends AppCompatActivity {
             rangeName = findViewById(R.id.rangeName);
             plotName = findViewById(R.id.plotName);
 
-            rangeLeft = findViewById(R.id.rangeLeft);
-            rangeRight = findViewById(R.id.rangeRight);
+            //determine range button function based on user-preferences
+            //issues217 introduces the ability to swap trait and plot arrows
+            boolean flipFlopArrows = ep.getBoolean("FLIP_FLOP_ARROWS", false);
+            if (flipFlopArrows) {
+                rangeLeft = findViewById(R.id.traitLeft);
+                rangeRight = findViewById(R.id.traitRight);
+            } else {
+                rangeLeft = findViewById(R.id.rangeLeft);
+                rangeRight = findViewById(R.id.rangeRight);
+            }
 
             tvRange = findViewById(R.id.tvRange);
             tvPlot = findViewById(R.id.tvPlot);
@@ -1613,16 +1644,34 @@ public class CollectActivity extends AppCompatActivity {
 
         private OnTouchListener createOnLeftTouchListener() {
             Runnable actionLeft = createRunnable("left");
-            return createOnTouchListener(rangeLeft, actionLeft,
-                    R.drawable.main_entry_left_pressed,
-                    R.drawable.main_entry_left_unpressed);
+
+            //change click-arrow based on preferences
+            boolean flipFlopArrows = ep.getBoolean("FLIP_FLOP_ARROWS", false);
+            if (flipFlopArrows) {
+                return createOnTouchListener(rangeLeft, actionLeft,
+                        R.drawable.main_trait_left_arrow_pressed,
+                        R.drawable.main_trait_left_arrow_unpressed);
+            } else {
+                return createOnTouchListener(rangeLeft, actionLeft,
+                        R.drawable.main_entry_left_pressed,
+                        R.drawable.main_entry_left_unpressed);
+            }
         }
 
         private OnTouchListener createOnRightTouchListener() {
             Runnable actionRight = createRunnable("right");
-            return createOnTouchListener(rangeRight, actionRight,
-                    R.drawable.main_entry_right_pressed,
-                    R.drawable.main_entry_right_unpressed);
+
+            //change click-arrow based on preferences
+            boolean flipFlopArrows = ep.getBoolean("FLIP_FLOP_ARROWS", false);
+            if (flipFlopArrows) {
+                return createOnTouchListener(rangeRight, actionRight,
+                        R.drawable.main_trait_right_pressed,
+                        R.drawable.main_trait_right_unpressed);
+            } else {
+                return createOnTouchListener(rangeRight, actionRight,
+                        R.drawable.main_entry_right_pressed,
+                        R.drawable.main_entry_right_unpressed);
+            }
         }
 
         private OnTouchListener createOnTouchListener(final ImageView control,

--- a/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
@@ -25,7 +25,7 @@ public class GeneralKeys {
     public static final String VOLUME_NAVIGATION                    = "VOLUME_NAVIGATION";
     public static final String CYCLING_TRAITS_ADVANCES              = "CycleTraits";
     public static final String DISABLE_ENTRY_ARROW_NO_DATA          = "DISABLE_ENTRY_ARROW_NO_DATA";
-
+    public static final String FLIP_FLOP_COLLECT_ARROWS             = "FLIP_FLOP_TRAIT_ARROWS";
 
     // General
     public static final String TUTORIAL_MODE                        = "Tips";

--- a/app/src/main/res/drawable/ic_gesture_tap.xml
+++ b/app/src/main/res/drawable/ic_gesture_tap.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M10,9A1,1 0,0 1,11 8A1,1 0,0 1,12 9V13.47L13.21,13.6L18.15,15.79C18.68,16.03 19,16.56 19,17.14V21.5C18.97,22.32 18.32,22.97 17.5,23H11C10.62,23 10.26,22.85 10,22.57L5.1,18.37L5.84,17.6C6.03,17.39 6.3,17.28 6.58,17.28H6.8L10,19V9M11,5A4,4 0,0 1,15 9C15,10.5 14.2,11.77 13,12.46V11.24C13.61,10.69 14,9.89 14,9A3,3 0,0 0,11 6A3,3 0,0 0,8 9C8,9.89 8.39,10.69 9,11.24V12.46C7.8,11.77 7,10.5 7,9A4,4 0,0 1,11 5Z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -580,4 +580,6 @@
     <string name="dialog_back">Back</string>
 
     <string name="data_helper_backup_v8_error">An error occurred when backing up v8 database.</string>
+    <string name="preferences_general_flip_flop_arrows_description">Swaps the trait and plot arrows when collecting.</string>
+    <string name="preferences_general_flip_flop_arrows">Flip Flop Collect Arrows</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -580,6 +580,6 @@
     <string name="dialog_back">Back</string>
 
     <string name="data_helper_backup_v8_error">An error occurred when backing up v8 database.</string>
-    <string name="preferences_general_flip_flop_arrows_description">Swaps the trait and plot arrows when collecting.</string>
-    <string name="preferences_general_flip_flop_arrows">Flip Flop Collect Arrows</string>
+    <string name="preferences_general_flip_flop_arrows_description">Swaps the trait and plot arrow functions</string>
+    <string name="preferences_general_flip_flop_arrows">Flip Flop Arrows</string>
 </resources>

--- a/app/src/main/res/xml/preferences_behavior.xml
+++ b/app/src/main/res/xml/preferences_behavior.xml
@@ -54,4 +54,11 @@
         android:summary="@string/preferences_general_skip_entries_with_data_description"
         android:title="@string/preferences_general_skip_entries_with_data" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:icon="@drawable/ic_gesture_tap"
+        android:key="FLIP_FLOP_ARROWS"
+        android:summary="@string/preferences_general_flip_flop_arrows_description"
+        android:title="@string/preferences_general_flip_flop_arrows" />
+
 </PreferenceScreen>


### PR DESCRIPTION
# Description

Adds a behavior preferences for swapping range and trait arrow functionality. Range and trait box logic was added to determine resource id based on the chosen preference. This is changed in initialization and click listeners, so that the proper "pressed" resource is used.

Fixes #217

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on Pixel 2 emulator.