### PR TITLE
Keep signingConfig commented out by default?

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
-            signingConfig signingConfigs.playStoreConfig //Add your own signing config
+            // signingConfig signingConfigs.playStoreConfig //Add your own signing config
         }
 
         debug {


### PR DESCRIPTION
# Description

Is is possible to keep the signingConfig commented out by default? 

# How Has This Been Tested?

Debugged using android studio.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
