### PR TITLE
fix duplicated images in brapi export (#260 but for images)

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
@@ -35,7 +35,7 @@ class ObservationDao {
         fun getHostImageObservations(hostUrl: String, missingPhoto: Bitmap): List<FieldBookImage> = withDatabase { db ->
 
             db.rawQuery("""
-                SELECT props.observationUnitDbId AS uniqueName,
+                SELECT DISTINCT props.observationUnitDbId AS uniqueName,
                        props.observationUnitName AS firstName,
                 obs.${Observation.PK} AS id, 
                 obs.value AS value, 


### PR DESCRIPTION
# Description

#260 but for images

Fixes #257 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Verified that images are no longer duplicated in BrAPI export window:

![image](https://user-images.githubusercontent.com/19394293/123467045-6cc4a680-d5c6-11eb-8cd8-8db3d28ba703.png)

![image](https://user-images.githubusercontent.com/19394293/123467380-d5138800-d5c6-11eb-9a79-4f2d96bb20b6.png)




