### PR TITLE
issue 250 trait import brapi v2 error

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiTraitActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiTraitActivity.java
@@ -23,6 +23,7 @@ import com.fieldbook.tracker.utilities.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.BiFunction;
 
 import com.fieldbook.tracker.objects.TraitObject;
 
@@ -103,13 +104,20 @@ public class BrapiTraitActivity extends AppCompatActivity {
         paginationManager.refreshPageIndicator();
 
         // Call our API to get the data
-        brAPIService.getOntology(paginationManager, new Function<List<TraitObject>, Void>() {
+        brAPIService.getOntology(paginationManager, new BiFunction<List<TraitObject>, Integer, Void>() {
             @Override
-            public Void apply(final List<TraitObject> traits) {
+            public Void apply(final List<TraitObject> traits, Integer variablesMissingTrait) {
 
                 (BrapiTraitActivity.this).runOnUiThread(new Runnable() {
                     @Override
                     public void run() {
+
+                            if (variablesMissingTrait > 0) {
+                                Toast.makeText(getApplicationContext(),
+                                        getString(R.string.brapi_skipped_traits, variablesMissingTrait),
+                                        Toast.LENGTH_LONG).show();
+                            }
+
                             // Build our array adapter
                             traitList.setAdapter(BrapiTraitActivity.this.buildTraitsArrayAdapter(traits));
 

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
@@ -39,6 +39,7 @@ package com.fieldbook.tracker.brapi.service;
         import java.net.MalformedURLException;
         import java.net.URL;
         import java.util.List;
+        import java.util.function.BiFunction;
 
 public interface BrAPIService {
 
@@ -144,7 +145,7 @@ public interface BrAPIService {
 
     public void getPlotDetails(final String studyDbId, final Function<BrapiStudyDetails, Void> function, final Function<Integer, Void> failFunction);
 
-    public void getOntology(BrapiPaginationManager paginationManager, final Function<List<TraitObject>, Void> function, final Function<Integer, Void> failFunction);
+    public void getOntology(BrapiPaginationManager paginationManager, final BiFunction<List<TraitObject>, Integer, Void> function, final Function<Integer, Void> failFunction);
 
     public void createObservations(List<Observation> observations,
                                    final Function<List<Observation>, Void> function,

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -3,6 +3,7 @@ package com.fieldbook.tracker.brapi.service;
 import android.app.Activity;
 import android.content.Context;
 import android.util.Log;
+import android.util.Pair;
 
 import androidx.arch.core.util.Function;
 
@@ -60,6 +61,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 public class BrAPIServiceV2 implements BrAPIService{
 
@@ -541,7 +543,7 @@ public class BrAPIServiceV2 implements BrAPIService{
     }
 
     public void getOntology(final BrapiPaginationManager paginationManager,
-                            final Function<List<TraitObject>, Void> function,
+                            final BiFunction<List<TraitObject>, Integer, Void> function,
                             final Function<Integer, Void> failFunction) {
         Integer initPage = paginationManager.getPage();
         try {
@@ -555,9 +557,9 @@ public class BrAPIServiceV2 implements BrAPIService{
                         updatePageInfo(paginationManager, response.getMetadata());
                         // Result contains a list of observation variables
                         List<BrAPIObservationVariable> brapiTraitList = response.getResult().getData();
-                        final List<TraitObject> traitsList = mapTraits(brapiTraitList);
+                        final Pair<List<TraitObject>, Integer> traitsResult = mapTraits(brapiTraitList);
 
-                        function.apply(traitsList);
+                        function.apply(traitsResult.first, traitsResult.second);
                     }
                 }
 
@@ -701,7 +703,7 @@ public class BrAPIServiceV2 implements BrAPIService{
                 @Override
                 public void onSuccess(BrAPIObservationVariableListResponse response, int i, Map<String, List<String>> map) {
                     //every time
-                    study.getTraits().addAll(mapTraits(response.getResult().getData()));
+                    study.getTraits().addAll(mapTraits(response.getResult().getData()).first);
                     recursiveCounter[0] = recursiveCounter[0] + 1;
 
                     int page = response.getMetadata().getPagination().getCurrentPage();
@@ -743,12 +745,14 @@ public class BrAPIServiceV2 implements BrAPIService{
         }
     }
 
-    private List<TraitObject> mapTraits(List<BrAPIObservationVariable> variables) {
+    private Pair<List<TraitObject>, Integer> mapTraits(List<BrAPIObservationVariable> variables) {
         List<TraitObject> traits = new ArrayList<>();
+        Integer variablesMissingTrait = 0;
         for (BrAPIObservationVariable var : variables) {
 
             // Skip the trait if there brapi trait field isn't present
             if (var.getTrait() == null) {
+                variablesMissingTrait += 1;
                 continue;
             }
 
@@ -805,7 +809,8 @@ public class BrAPIServiceV2 implements BrAPIService{
 
             traits.add(trait);
         }
-        return traits;
+
+        return Pair.create(traits, variablesMissingTrait);
     }
 
     private String buildCategoryList(List<BrAPIScaleValidValuesCategories> categories) {

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -746,6 +746,12 @@ public class BrAPIServiceV2 implements BrAPIService{
     private List<TraitObject> mapTraits(List<BrAPIObservationVariable> variables) {
         List<TraitObject> traits = new ArrayList<>();
         for (BrAPIObservationVariable var : variables) {
+
+            // Skip the trait if there brapi trait field isn't present
+            if (var.getTrait() == null) {
+                continue;
+            }
+
             TraitObject trait = new TraitObject();
             trait.setDefaultValue(var.getDefaultValue());
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -548,6 +548,7 @@
     <string name="brapi_auth_btn">Log In to Site</string>
     <string name="brapi_pagination">Page Size</string>
     <string name="brapi_timeout">Server Timeout</string>
+    <string name="brapi_skipped_traits">Successfully fetched traits. %1$d traits ignored because of missing brapi \'trait\' field</string>
 
     <string name="brapi_study_incompatible">This BrAPI study is currently incompatible with Field Book. Studies must include row and column in the header.</string>
 


### PR DESCRIPTION
# Description

The issue was that the brapi server had variables with only a variable name and a `null` in the `trait` field. It looks as if the trait information is required for the field book trait, so I skipped any variable that did not have the `trait` field. 

Fixes # https://github.com/PhenoApps/Field-Book/issues/250

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I tested it by following @chaneylc bug reproduction steps:

1. Enable V2 and authorize on the test server.
2. Go to Traits from config activity.
3. Go to import -> brapi
4. Crash

You can confirm that the brapi test server has variables that would cause an error with the fix by using an api client to inspect the result of `GET https://test-server.brapi.org/brapi/v2/variables`.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
