### PR TITLE
issue 257 duplicate plots

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -450,9 +450,6 @@ public class BrAPIServiceV1 implements BrAPIService {
                             }
                         }
 
-                        //every time
-                        study.getValues().addAll(mapAttributeValues(study.getAttributes(), response.getResult().getData()));
-
                         recursiveCounter[0] = recursiveCounter[0] + 1;
 
                         // Stop after 50 iterations (for safety)


### PR DESCRIPTION
# Description

In the BrAPI v1 service there was a line that was adding the plots to the study details twice. I removed that line to fix the duplicate plot issue. I wasn't able to reproduce the issue from the bug, but I was able to see the duplicates in the `observation_units` table in the database. 

I checked out BrAPI Service v2 and it looks like it doesn't have this bug. 

Fixes # https://github.com/PhenoApps/Field-Book/issues/257

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I was not able to reproduce the bug on the issue, https://github.com/PhenoApps/Field-Book/issues/257, but I was able to see the duplicates in the database. You need to use brapi v1 for this test, so there are some hack-arounds with the token to interact with the brapi test server. 

- Go into the code and change `BrAPIServicev1.getBrapiToken` to return "Bearer YYYY"
  - The v1 endpoints in the test server don't use the real tokens yet. 
- Keep test-server.brapi.org as your brapi server
- Select brapi version v1
- Authorize with the brapi test server using "OAuth 2 Implicit Grant"
- Go to Fields
- Import BrAPI fields
- Select "Study 1" from the options
- Save that field
- Open up an android database inspector and inspect the `observation_units` table
  - You should see only 4 studies (it was 8 with the bug that duplicated them)

**Test Configuration**:
* Hardware: Pixel 3a API 29
* SDK: 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
