### PR TITLE
Bug/field book testing issues

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
@@ -56,7 +56,6 @@ public class BrapiActivity extends AppCompatActivity {
     public void onResume() {
         super.onResume();
         brAPIService.authorizeClient();
-        loadStudiesList();
     }
 
     @Override
@@ -69,6 +68,7 @@ public class BrapiActivity extends AppCompatActivity {
                 paginationManager = new BrapiPaginationManager(this);
 
                 brAPIService = BrAPIServiceFactory.getBrAPIService(BrapiActivity.this);
+                brAPIService.authorizeClient();
                 brapiLoadDialog = new BrapiLoadDialog(this);
 
                 String brapiBaseURL = BrAPIService.getBrapiUrl(this);

--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
@@ -68,7 +68,6 @@ public class BrapiActivity extends AppCompatActivity {
                 paginationManager = new BrapiPaginationManager(this);
 
                 brAPIService = BrAPIServiceFactory.getBrAPIService(BrapiActivity.this);
-                brAPIService.authorizeClient();
                 brapiLoadDialog = new BrapiLoadDialog(this);
 
                 String brapiBaseURL = BrAPIService.getBrapiUrl(this);

--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiTraitActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiTraitActivity.java
@@ -56,7 +56,6 @@ public class BrapiTraitActivity extends AppCompatActivity {
                 loadToolbar();
                 // Get the setting information for our brapi integration
                 brAPIService = BrAPIServiceFactory.getBrAPIService(this);
-                brAPIService.authorizeClient();
 
                 // Make a clean list to track our selected traits
                 selectedTraits = new ArrayList<>();

--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiTraitActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiTraitActivity.java
@@ -40,6 +40,7 @@ public class BrapiTraitActivity extends AppCompatActivity {
     @Override
     public void onResume() {
         super.onResume();
+        brAPIService.authorizeClient();
     }
 
     @Override
@@ -55,6 +56,7 @@ public class BrapiTraitActivity extends AppCompatActivity {
                 loadToolbar();
                 // Get the setting information for our brapi integration
                 brAPIService = BrAPIServiceFactory.getBrAPIService(this);
+                brAPIService.authorizeClient();
 
                 // Make a clean list to track our selected traits
                 selectedTraits = new ArrayList<>();

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceFactory.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceFactory.java
@@ -15,6 +15,7 @@ public class BrAPIServiceFactory {
             brAPIService = new BrAPIServiceV2(context);
         else
             brAPIService = new BrAPIServiceV1(context);
+        brAPIService.authorizeClient();
 
         return brAPIService;
     }

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -804,10 +804,12 @@ public class BrAPIServiceV2 implements BrAPIService{
 
     private String buildCategoryList(List<BrAPIScaleValidValuesCategories> categories) {
         StringBuilder sb = new StringBuilder();
-        for (int j = 0; j < categories.size(); ++j) {
-            sb.append(categories.get(j).getLabel());
-            if (j != categories.size() - 1) {
-                sb.append("/");
+        if (categories != null) {
+            for (int j = 0; j < categories.size(); ++j) {
+                sb.append(categories.get(j).getLabel());
+                if (j != categories.size() - 1) {
+                    sb.append("/");
+                }
             }
         }
         return sb.toString();

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -156,10 +156,10 @@ public class BrAPIServiceV2 implements BrAPIService{
         request.setDescription(image.getDescription());
         request.setDescriptiveOntologyTerms(image.getDescriptiveOntologyTerms());
         request.setFileName(image.getImageFileName());
-        request.setFileSize((int) image.getImageFileSize());
-        request.setHeight(image.getImageHeight());
+        if (image.getImageFileSize() != null) request.setFileSize((int) image.getImageFileSize());
+        if (image.getImageHeight() != null) request.setHeight(image.getImageHeight());
+        if (image.getImageWidth() != null) request.setWidth(image.getImageWidth());
         request.setImageName(image.getImageName());
-        request.setWidth(image.getImageWidth());
         request.setMimeType(image.getMimeType());
         request.setUnitDbId(image.getObservationUnitDbId());
         request.setDbId(image.getImageDbId());

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
@@ -66,7 +66,7 @@ class ObservationDao {
         """.trimIndent(), arrayOf(hostUrl)).toTable()
                     .map { row -> FieldBookImage(getStringVal(row, "value"), missingPhoto).apply {
                         unitDbId = getStringVal(row, "uniqueName")
-                        setDescriptiveOntologyTerms(listOf(getStringVal(row, "firstName")))
+                        setDescriptiveOntologyTerms(listOf(getStringVal(row, "external_db_id")))
                         setDescription(getStringVal(row, "observation_variable_details"))
                         setTimestamp(getStringVal(row, "observation_time_stamp"))
                         fieldBookDbId = getStringVal(row, "id")


### PR DESCRIPTION
# Description
1. Fixes a bug with null categories when parsing `GET variables` responses. 
2. Fixes the issue of the auth token not being set on studies and traits
3. Removes extra GET studies call on the `BrAPIActivity` page. 
4. Fix the descriptiveOntologyTerm in the images to be the trait external db id instead of observation unit name. 
5. Allow for null imageFileSize, imageHeight, imageWidth returns on PUT images, PUT images/{imageId}/imagecontent calls

The issues have more descriptions on reproducing the errors. 


Fixes:
1. https://github.com/PhenoApps/Field-Book/issues/282
2. https://github.com/PhenoApps/Field-Book/issues/281
3. https://github.com/PhenoApps/Field-Book/issues/284
4. https://github.com/PhenoApps/Field-Book/issues/286
5. https://github.com/PhenoApps/Field-Book/issues/288

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Successfully went through a trait import with traits containing categories and with categories = null.
2. Went through two workflows of importing traits and studies:
  - First workflow: 
    - I "logged out" of brapi in the settings
    - Imported traits
    - Confirmed that a login prompt was shown
    - Logged in
    - Confirmed I was able to import traits. 
    - Logged out again
    - Repeated the same steps for studies
  - Second workflow: 
    - Imported traits
    - Confirmed that a login prompt was NOT shown
    - Confirmed I was able to import traits. 
    - Repeated the same steps for studies
3. Debugged the app when opening the 'Fields' paged and confirmed that `getStudies` was only called once. 
4. For this one, if you try to save images to a BreedBase instance, you will get an error without the fix. The easiest way to test and confirm the fix though is to put a breakpoint in BrAPIServicev2.postImageMetaData() right after the `BrAPIImage request = mapImage(image);` line. 
5. For this one a successful save to an instance of Breeding Insights fork of BreedBase will work as a passing test. 
  - Some fixes were needed for the BreedBase brapi image endpoints to work with Field Book. 

**Test Configuration**:
* Hardware: Pixel 3a
* SDK: Android 10 (I think)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
