### PR TITLE
Added skip entries preference modes.

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/preferences/BehaviorPreferencesFragment.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/BehaviorPreferencesFragment.java
@@ -21,6 +21,20 @@ public class BehaviorPreferencesFragment extends PreferenceFragmentCompat implem
 
         setPreferencesFromResource(R.xml.preferences_behavior, rootKey);
 
+        Preference skipEntriesPref = this.findPreference("IgnoreExisting");
+
+        if (skipEntriesPref != null) {
+
+            //set preference change listener to change summary when needed
+            skipEntriesPref.setOnPreferenceChangeListener(this);
+
+            //also initialize the summary whenever the fragment is opened, or else it defaults to "disabled"
+            String skipMode = prefMgr.getSharedPreferences().getString(GeneralKeys.HIDE_ENTRIES_WITH_DATA, "1");
+
+            switchSkipPreferenceMode(skipMode, skipEntriesPref);
+
+        }
+
         ((PreferencesActivity) this.getActivity()).getSupportActionBar().setTitle(getString(R.string.preferences_behavior_title));
     }
 
@@ -35,6 +49,47 @@ public class BehaviorPreferencesFragment extends PreferenceFragmentCompat implem
     @Override
     public boolean onPreferenceChange(Preference preference, Object newValue) {
 
-        return false;
+
+        //When the skip entries preference is changed, update the summary that is defined in string.xml.
+        if (preference.hasKey()) {
+
+            if (preference.getKey().equals("IgnoreExisting")) {
+
+                switchSkipPreferenceMode((String) newValue, preference);
+
+            }
+        }
+
+        return true;
+    }
+
+    private void switchSkipPreferenceMode(String mode, Preference preference) {
+
+        switch (mode) {
+
+            case "2": {
+
+                preference.setSummary(R.string.preferences_general_skip_entries_with_data_description);
+
+                break;
+
+            }
+
+            case "3": {
+
+                preference.setSummary(R.string.preferences_general_skip_entries_across_all_traits_description);
+
+                break;
+
+            }
+
+            default: {
+
+                preference.setSummary(R.string.preferences_general_skip_entries_disabled);
+
+                break;
+
+            }
+        }
     }
 }

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -73,6 +73,19 @@
         <item>brapi</item>
     </string-array>
 
+    <!-- Yes, they are entry entries -->
+    <string-array name="pref_behavior_skip_entries_entries">
+        <item>@string/preferences_general_skip_entries_disabled</item>
+        <item>@string/preferences_general_skip_entries_with_data</item>
+        <item>@string/preferences_general_skip_entries_across_all_traits</item>
+    </string-array>
+
+    <string-array name="pref_behavior_skip_entries_values">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
+
     <string-array name="pref_brapi_version">
         <item>@string/preferences_brapi_version_v1</item>
         <item>@string/preferences_brapi_version_v2</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,6 +234,9 @@
     <string name="preferences_general_use_day_number_description">Use day of year when collecting data instead of the date</string>
     <string name="preferences_general_skip_entries_with_data">Skip entries with data</string>
     <string name="preferences_general_skip_entries_with_data_description">Skips entries that have data for the current trait</string>
+    <string name="preferences_general_skip_entries_across_all_traits">Skip entries across all traits</string>
+    <string name="preferences_general_skip_entries_across_all_traits_description">Skip entries that have data for all traits</string>
+    <string name="preferences_general_skip_entries_disabled">Disabled</string>
     <string name="preferences_general_share_disable">Disable file sharing</string>
     <string name="preferences_general_share_disable_description">When files are exported, the share dialog will not be displayed</string>
     <string name="preferences_general_barcode_camera">Move to entry via barcode</string>

--- a/app/src/main/res/xml/preferences_behavior.xml
+++ b/app/src/main/res/xml/preferences_behavior.xml
@@ -47,12 +47,14 @@
         android:summary="@string/preferences_general_use_day_number_description"
         android:title="@string/preferences_general_use_day_number" />
 
-    <CheckBoxPreference
-        android:defaultValue="false"
+    <ListPreference
         android:icon="@drawable/ic_adv_hide_entries"
         android:key="IgnoreExisting"
-        android:summary="@string/preferences_general_skip_entries_with_data_description"
-        android:title="@string/preferences_general_skip_entries_with_data" />
+        android:summary="@string/preferences_general_skip_entries_disabled"
+        android:title="@string/preferences_general_skip_entries_with_data"
+        android:entries="@array/pref_behavior_skip_entries_entries"
+        android:entryValues="@array/pref_behavior_skip_entries_values"
+        android:defaultValue="1"/>
 
     <CheckBoxPreference
         android:defaultValue="false"


### PR DESCRIPTION
# Description

Adjusted behavior preferences to allow three different modes for skipping entries.
Modes:
1. Disabled, no entry is skipped
2. Skip entries that have already observed the active trait.
3. Skip entries that have already observed all visible traits.
