### PR TITLE
Fix brapi additional info bug

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'
     implementation "com.github.skydoves:colorpickerpreference:2.0.4"
 
-    implementation "org.brapi:brapi-java-client:2.0-SNAPSHOT"
+    implementation "org.brapi:brapi-java-client:2.0.1"
     implementation 'net.openid:appauth:0.9.0'
     implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava' //google messed up some packages, this package is temporary until the issue is fixed (Feb 2021)
     

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -135,7 +135,6 @@ public class BrAPIServiceV2 implements BrAPIService{
 
     private BrAPIImage mapImage(FieldBookImage image) {
         BrAPIImage request = new BrAPIImage();
-        request.setAdditionalInfo(image.getAdditionalInfo());
         request.setCopyright(image.getCopyright());
         request.setDescription(image.getDescription());
         request.setDescriptiveOntologyTerms(image.getDescriptiveOntologyTerms());
@@ -154,7 +153,6 @@ public class BrAPIServiceV2 implements BrAPIService{
 
     private FieldBookImage mapToImage(BrAPIImage image) {
         FieldBookImage request = new FieldBookImage();
-        request.setAdditionalInfo(image.getAdditionalInfo());
         request.setDescription(image.getDescription());
         request.setDescriptiveOntologyTerms(image.getDescriptiveOntologyTerms());
         request.setFileName(image.getImageFileName());


### PR DESCRIPTION
# Description

Updates the brapi client library to the newest version which allows for any object in the additional info fields. 

Instead of refactoring the image additional info fields, I just removed them since they weren't being used. My thoughts were that we can add that field back in the future if there is a need for it. I can also refactor it now if you would rather do that. 

Fixes # https://github.com/PhenoApps/Field-Book/issues/295

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe any tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I tested this against the brapi test server:

1. Set brapi test server as the Field Book server
2. Checked that GET /variables returns additional info with non-string objects
3. Load in studies via Field Book
4. Load in traits via Field Book
5. Collect some data
6. Export data to brapi
7. Everything should work

**Test Configuration**:
* Hardware: Pixel 2 Emulator 
* SDK: API 28

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
