### PR TITLE
Added sanitized column names, added empty column check on import

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationUnitPropertyDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationUnitPropertyDao.kt
@@ -71,11 +71,17 @@ class ObservationUnitPropertyDao {
             plot_id = ""
         }
 
+        /**
+         * This function's parameter trait is not always a trait and can be an observation unit property column.
+         * For example this is used when selecting the top-left drop down in the collect activity.
+         */
         fun getDropDownRange(uniqueName: String, trait: String, plotId: String): Array<String>? = withDatabase { db ->
 
+            //added sanitation to the uniqueName in case it has a space
+            val unique = if ("`" in uniqueName) uniqueName else "`$uniqueName`"
             db.query(sObservationUnitPropertyViewName,
                     select = arrayOf(trait),
-                    where = "$uniqueName LIKE ?",
+                    where = "$unique LIKE ?",
                     whereArgs = arrayOf(plotId)).toTable().map {
                 it[trait].toString()
             }.toTypedArray()


### PR DESCRIPTION
This branch has a couple of bugfixes.
1. The  getDropDownRange(uniqueName: String, trait: String, plotId: String): Array<String>
The second parameter can actually be an observation unit property name, which needs to be sanitized. In some cases Unique is used which is an Sqlite keyword or it contains spaces.
2. In FieldEditorActivity empty strings could be selected when importing a field file.
The solution was to not add empty strings to the selection.

