### PR TITLE
Allowing >64 traits in table export

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
@@ -901,10 +901,10 @@ public class ConfigActivity extends AppCompatActivity {
                 return (0);
             }
 
-            if (exportTraits.length > 64) {
-                tooManyTraits = true;
-                return (0);
-            }
+//            if (exportTraits.length > 64) {
+//                tooManyTraits = true;
+//                return (0);
+//            }
 
             if (checkDbBool) {
                 if (exportData.getCount() > 0) {

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationUnitPropertyDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationUnitPropertyDao.kt
@@ -193,27 +193,39 @@ class ObservationUnitPropertyDao {
             }
         }
 
+        /**
+         * Called in ConfigActivity
+         * This will print all observation data (if a trait is not observed it is null/empty string) for all observation units.
+         * The user decides whether to print all plot-related fields s.a unique id, primary/secondary name or just the unique name.
+         * The select variable dynamically builds what the user chooses from the col parameter.
+         * The maxStatements parameter builds aggregate case statements for each variable, this way the output has column names that are one-to-one with variable names.
+         *  Where the column observation_variable_name value will be the observation value.
+         * Left join is used to capture all observation_units, even if they did not make an observation.
+         * Finally group by props.id to output the aggregation for all observation units, otherwise only a single column would aggregate.
+         * Inputs:
+         * @param uniqueName the preference string that user chooses on field selection for unique plot names
+         * @param col the plot descriptors, this will be either the unique name or all plot descriptors
+         * @param traits the list of traits to print, either all traits or just the active ones
+         * @return a cursor that is used in CSVWriter and closed elsewhere
+         */
         fun convertDatabaseToTable(uniqueName: String, col: Array<String?>, traits: Array<String>): Cursor? = withDatabase { db ->
 
-            val query: String
-            val rangeArgs = arrayOfNulls<String>(col.size)
-            val traitArgs = arrayOfNulls<String>(traits.size)
-            var joinArgs = ""
+            val select = col.joinToString(",") { "props.$it" }
 
-            for (i in col.indices) {
-                rangeArgs[i] = "prop.`${col[i]}`"
+            val maxStatements = arrayListOf<String>()
+            traits.forEach {
+                maxStatements.add(
+                    "MAX (CASE WHEN o.observation_variable_name='$it' THEN o.value ELSE NULL END) AS '$it'"
+                )
             }
 
-            for (i in traits.indices) {
-                traitArgs[i] = "m" + i + ".value AS '" + traits[i] + "'"
-                joinArgs = (joinArgs + "LEFT JOIN observations m" + i + " ON prop.`$uniqueName`"
-                        + " = m" + i + ".observation_unit_id AND m" + i + ".observation_variable_name = '" + traits[i] + "' ")
-            }
-
-            query = "SELECT " + rangeArgs.joinToString(",") + " , " + traitArgs.joinToString(",") +
-                    " FROM $sObservationUnitPropertyViewName AS prop " + joinArgs + " GROUP BY prop.`$uniqueName` ORDER BY prop.id"
-
-            println(query)
+            val query = """
+                SELECT $select,
+                ${maxStatements.joinToString(",\n")}
+                FROM ObservationUnitProperty as props
+                LEFT JOIN observations o ON props.${uniqueName} = o.observation_unit_id
+                GROUP BY props.id
+            """.trimIndent()
 
             db.rawQuery(query, null)
         }


### PR DESCRIPTION
# Description

Previously the convertDatabaseToTable function used left joins to pivot our EAV data where observation variable names would appear as headers. SQLite has a limitation on the number of left joins that can occur in a query (65). This implementation uses aggregation case statements to pivot the table, removing the need for multiple left joins.

Example: (more detail described in documentation of convertDatabaseToTable)
``` 
SELECT props.*,
MAX(CASE WHEN (o.observation_variable_name='height') THEN o.value ELSE NULL END) AS 'height',
MAX (CASE WHEN o.observation_variable_name='flowering' THEN o.value ELSE NULL END) AS 'flowering',
MAX (CASE WHEN o.observation_variable_name='insect damage' THEN o.value ELSE NULL END) AS 'insect damage'
FROM ObservationUnitProperty as props
LEFT JOIN observations o ON o.observation_unit_id = props.plot_id
GROUP BY props.id
```

Fixes # 111

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Attached a zip file containing the test db with >64 traits. Multiple plots of various observations across the traits. I tested the feature by exporting table format with both unique and all imported columns selected.

[testdb64.zip](https://github.com/PhenoApps/Field-Book/files/7017524/testdb64.zip)
