### PR TITLE
Modifying fetching of plots to use BRAPI_PAGE_SIZE setting

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -421,7 +421,8 @@ public class BrAPIServiceV1 implements BrAPIService {
                                final Function<Integer, Void> failFunction) {
         try {
             final Integer[] recursiveCounter = {0};
-            final Integer pageSize = 1000;
+            final Integer pageSize = Integer.parseInt(context.getSharedPreferences("Settings", 0)
+                    .getString(GeneralKeys.BRAPI_PAGE_SIZE, "1000"));
             final BrapiStudyDetails study = new BrapiStudyDetails();
             study.setValues(new ArrayList<>());
 
@@ -431,14 +432,6 @@ public class BrAPIServiceV1 implements BrAPIService {
 
                     //bugfix for index out of bounds occurring when no data is in response
                     if (response.getResult().getData().size() > 0) {
-
-                        final BrapiStudyDetails study = new BrapiStudyDetails();
-                        study.setNumberOfPlots(response.getMetadata().getPagination().getTotalCount());
-                        study.setAttributes(mapAttributes(response.getResult().getData().get(0)));
-                        study.setValues(mapAttributeValues(study.getAttributes(), response.getResult().getData()));
-
-                        function.apply(study);
-
                         int page = response.getMetadata().getPagination().getCurrentPage();
                         if(page == 0){
                             //one time code
@@ -451,6 +444,8 @@ public class BrAPIServiceV1 implements BrAPIService {
                                 e.printStackTrace();
                             }
                         }
+
+                        study.getValues().addAll(mapAttributeValues(study.getAttributes(), response.getResult().getData()));
 
                         recursiveCounter[0] = recursiveCounter[0] + 1;
 

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -402,7 +402,8 @@ public class BrAPIServiceV2 implements BrAPIService{
                                final Function<Integer, Void> failFunction) {
         try {
             final Integer[] recursiveCounter = {0};
-            final Integer pageSize = 1000;
+            final Integer pageSize = Integer.parseInt(context.getSharedPreferences("Settings", 0)
+                    .getString(GeneralKeys.BRAPI_PAGE_SIZE, "1000"));
             final BrapiStudyDetails study = new BrapiStudyDetails();
             study.setAttributes(new ArrayList<>());
             study.setValues(new ArrayList<>());

--- a/app/src/test/java/BrapiServiceTest.java
+++ b/app/src/test/java/BrapiServiceTest.java
@@ -51,11 +51,7 @@ public class BrapiServiceTest {
     @Before
     public void setUp() throws Exception {
         // Instantiate our brapi service class
-<<<<<<< HEAD
         this.brAPIService = new BrAPIServiceV1(null);
-=======
-        this.brAPIService = new BrAPIService(brapiBaseUrl, null, null);
->>>>>>> develop
         Bitmap.Config conf = Bitmap.Config.ARGB_8888;
         Bitmap missingImage = Bitmap.createBitmap(100, 100, conf);
     }
@@ -193,17 +189,14 @@ public class BrapiServiceTest {
         BrapiPaginationManager pageMan = new BrapiPaginationManager(0, 1000);
 
         // Call our get study details endpoint with the same parsing that our classes use.
-        this.brAPIService.getOntology(pageMan, new Function<List<TraitObject>, Void>() {
-            @Override
-            public Void apply(List<TraitObject> input) {
+        this.brAPIService.getOntology(pageMan, (traitObjects, integer) -> {
                 // Check that we are getting some results back
-                BrapiServiceTest.this.checkGetOntologyResult = input.size() > 0;
+                BrapiServiceTest.this.checkGetOntologyResult = traitObjects.size() > 0;
 
                 // Notify the countdown that we are finish
                 signal.countDown();
 
                 return null;
-            }
         }, new Function<Integer, Void>() {
             @Override
             public Void apply(Integer input) {
@@ -283,7 +276,7 @@ public class BrapiServiceTest {
         testObservations.add(testObservation);
 
         // Call our get study details endpoint with the same parsing that our classes use.
-        this.brAPIService.putObservations(testObservations, new Function<List<Observation>, Void>() {
+        this.brAPIService.updateObservations(testObservations,  new Function<List<Observation>, Void>() {
                     @Override
                     public Void apply(final List<Observation> observationDbIds) {
 


### PR DESCRIPTION
# Description

Modified `BrAPIServiceV1#getPlotDetails` and `BrAPIServiceV2#getPlotDetails` to use the `BRAPI_PAGE_SIZE` setting.  In `BrAPIServiceV1#getPlotDetails` fixed a bug where plots fetched on each page request override plots fetched on previous page request.

Fixes #335 

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Prereq: setup BrAPI connection info:
1. URL to a BrAPI server with a study with more than 1000 observationUnits
2. BrAPI V1

Test A:
1. Go to Fields
2. Click on the + to add a new field
3. Choose "BrAPI"
4. Choose appropriate study
5. Click "Save Field"
6. Click "Ok"
7. Go to Collect
8. Cycle through observationunits to see that all observationunits are present

Test B:
1. Modify the `pageSize` BrAPI setting to 500
2. Go to Fields
2. Click on the + to add a new field
3. Choose "BrAPI"
4. Choose appropriate study
5. Click "Save Field"
6. Click "Ok"
7. Go to Collect
8. Cycle through observationunits to see that all observationunits are present

**Test Configuration**:
* Hardware: Pixel C emulator
* SDK: 10

# Checklist:

- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to documentation
- [ x ] My changes generate no new warnings
