### PR TITLE
Import BrAPI Study at specific ObservationLevel

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
@@ -80,7 +80,6 @@ public class BrapiActivity extends AppCompatActivity {
                 baseURLText.setText(brapiBaseURL);
 
                 loadToolbar();
-//                loadStudiesList();
                 loadObservationLevels();
             } else {
                 Toast.makeText(getApplicationContext(), R.string.brapi_must_configure_url, Toast.LENGTH_SHORT).show();
@@ -100,7 +99,7 @@ public class BrapiActivity extends AppCompatActivity {
 
     private void loadToolbar() {
         if (getSupportActionBar() != null) {
-            getSupportActionBar().setTitle("BrAPI Field Import");
+            getSupportActionBar().setTitle(R.string.import_dialog_title_brapi_fields);
             getSupportActionBar().getThemedContext();
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
             getSupportActionBar().setHomeButtonEnabled(true);
@@ -192,13 +191,11 @@ public class BrapiActivity extends AppCompatActivity {
     private void loadObservationLevels() {
         brAPIService.getObservationLevels(programDbId, input -> {
             this.observationLevels = input;
-//            brapiLoadDialog.setObservationLevels(input);
             runOnUiThread(() -> {
                 setupObservationLevelsSpinner();
                 loadStudiesList();
             });
         }, failureInput -> {
-//            brapiLoadDialog.setObservationLevels(new ArrayList<>());
         });
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
@@ -239,9 +239,12 @@ public class BrapiActivity extends AppCompatActivity {
     private void saveStudy() {
         if(this.selectedStudy != null) {
             brapiLoadDialog.setSelectedStudy(this.selectedStudy);
+            brapiLoadDialog.setObservationLevel(this.selectedObservationLevel);
             brapiLoadDialog.show();
-        }else{
-            Toast.makeText(getApplicationContext(), R.string.brapi_warning_select_study, Toast.LENGTH_SHORT).show();
+        } else{
+            Toast toast = Toast.makeText(getApplicationContext(), R.string.brapi_warning_select_study, Toast.LENGTH_LONG);
+            toast.setGravity(Gravity.CENTER_VERTICAL|Gravity.CENTER_HORIZONTAL, 0, 0);
+            toast.show();
         }
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiExportActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiExportActivity.java
@@ -18,7 +18,6 @@ import androidx.arch.core.util.Function;
 import com.fieldbook.tracker.brapi.ApiErrorCode;
 import com.fieldbook.tracker.brapi.service.BrAPIService;
 import com.fieldbook.tracker.brapi.service.BrAPIServiceFactory;
-import com.fieldbook.tracker.brapi.BrapiAuthDialog;
 import com.fieldbook.tracker.brapi.BrapiControllerResponse;
 import com.fieldbook.tracker.brapi.model.FieldBookImage;
 import com.fieldbook.tracker.brapi.model.Observation;

--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiExportActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiExportActivity.java
@@ -15,7 +15,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.arch.core.util.Function;
 
-import com.fieldbook.tracker.brapi.ApiError;
+import com.fieldbook.tracker.brapi.ApiErrorCode;
 import com.fieldbook.tracker.brapi.service.BrAPIService;
 import com.fieldbook.tracker.brapi.service.BrAPIServiceFactory;
 import com.fieldbook.tracker.brapi.BrapiAuthDialog;
@@ -450,13 +450,13 @@ public class BrapiExportActivity extends AppCompatActivity {
 
     private UploadError processErrorCode(Integer code) {
         UploadError retVal;
-        ApiError apiError = ApiError.processErrorCode(code);
+        ApiErrorCode apiErrorCode = ApiErrorCode.processErrorCode(code);
 
-        if (apiError == null) {
+        if (apiErrorCode == null) {
             return UploadError.API_CALLBACK_ERROR;
         }
 
-        switch (apiError) {
+        switch (apiErrorCode) {
             case FORBIDDEN:
                 // Warn that they do not have permissions to push traits
                 retVal = UploadError.API_PERMISSION_ERROR;

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -83,6 +83,7 @@ import com.fieldbook.tracker.objects.RangeObject;
 import com.fieldbook.tracker.utilities.DialogUtils;
 import com.fieldbook.tracker.utilities.GeodeticUtils;
 import com.fieldbook.tracker.utilities.SnackbarUtils;
+import com.fieldbook.tracker.utilities.PrefsConstants;
 import com.fieldbook.tracker.utilities.Utils;
 
 import com.getkeepsafe.taptargetview.TapTarget;
@@ -400,7 +401,7 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
             public void onClick(View v) {
 
                 // if a brapi observation that has been synced, don't allow deleting
-                String exp_id = Integer.toString(ep.getInt("SelectedFieldExpId", 0));
+                String exp_id = Integer.toString(ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
                 TraitObject currentTrait = traitBox.getCurrentTrait();
                 if (dt.isBrapiSynced(exp_id, rangeBox.getPlotID(), currentTrait.getTrait())) {
                     if (currentTrait.getFormat().equals("photo")) {
@@ -723,7 +724,7 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
         }
 
         traitBox.update(parent, value);
-        String exp_id = Integer.toString(ep.getInt("SelectedFieldExpId", 0));
+        String exp_id = Integer.toString(ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
         Observation observation = dt.getObservation(exp_id, rangeBox.getPlotID(), parent);
         String observationDbId = observation.getDbId();
@@ -757,7 +758,7 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
             return;
         }
 
-        String exp_id = Integer.toString(ep.getInt("SelectedFieldExpId", 0));
+        String exp_id = Integer.toString(ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
         TraitObject trait = traitBox.getCurrentTrait();
         if (dt.isBrapiSynced(exp_id, rangeBox.getPlotID(), trait.getTrait())) {
             brapiDelete(parent, true);
@@ -1688,7 +1689,7 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
 
         TraitObject trait = getCurrentTrait();
 
-        String studyId = Integer.toString(ep.getInt("SelectedFieldExpId", 0));
+        String studyId = Integer.toString(ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
         dt.insertUserTraits(rangeBox.getPlotID(), trait.getFormat(), trait.getTrait(), size,
                 ep.getString("FirstName", "") + " " + ep.getString("LastName", ""),
@@ -1923,7 +1924,7 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
             if (newTraits.containsKey(traitName))
                 newTraits.remove(traitName);
 
-            String exp_id = Integer.toString(ep.getInt("SelectedFieldExpId", 0));
+            String exp_id = Integer.toString(ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
             dt.deleteTrait(exp_id, plotID, traitName);
         }

--- a/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
@@ -53,6 +53,7 @@ import com.fieldbook.tracker.utilities.CSVWriter;
 import com.fieldbook.tracker.utilities.Constants;
 import com.fieldbook.tracker.adapters.ImageListAdapter;
 import com.fieldbook.tracker.utilities.DialogUtils;
+import com.fieldbook.tracker.utilities.PrefsConstants;
 import com.fieldbook.tracker.utilities.Utils;
 
 import com.getkeepsafe.taptargetview.TapTarget;
@@ -290,7 +291,7 @@ public class ConfigActivity extends AppCompatActivity {
 
         String traits = dt.getTraitColumnsAsString();
 
-        if (!ep.getBoolean("ImportFieldFinished", false) || ep.getInt("SelectedFieldExpId", -1) == -1) {
+        if (!ep.getBoolean("ImportFieldFinished", false) || ep.getInt(PrefsConstants.SELECTED_FIELD_ID, -1) == -1) {
             Utils.makeToast(getApplicationContext(),getString(R.string.warning_field_missing));
             return -1;
         } else if (traits == null || traits.isEmpty()) {
@@ -535,7 +536,7 @@ public class ConfigActivity extends AppCompatActivity {
 
     private void exportBrAPI() {
         // Get our active field
-        Integer activeFieldId = ep.getInt("SelectedFieldExpId", -1);
+        Integer activeFieldId = ep.getInt(PrefsConstants.SELECTED_FIELD_ID, -1);
         FieldObject activeField;
         if (activeFieldId != -1) {
             activeField = dt.getFieldObject(activeFieldId);
@@ -964,7 +965,7 @@ public class ConfigActivity extends AppCompatActivity {
 
             if (!fail) {
                 showCitationDialog();
-                dt.updateExpTable(false, false, true, ep.getInt("SelectedFieldExpId", 0));
+                dt.updateExpTable(false, false, true, ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
             }
 
             if (fail) {

--- a/app/src/main/java/com/fieldbook/tracker/activities/FieldEditorActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/FieldEditorActivity.java
@@ -1,7 +1,6 @@
 package com.fieldbook.tracker.activities;
 
 import android.Manifest;
-import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -21,7 +20,6 @@ import androidx.appcompat.app.AlertDialog;
 
 import android.provider.OpenableColumns;
 import android.text.Html;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.AdapterView;
@@ -58,7 +56,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -85,7 +82,7 @@ public class FieldEditorActivity extends AppCompatActivity {
     private static final int DIALOG_LOAD_FIELDFILEEXCEL = 1001;
     public static ListView fieldList;
     public static FieldAdapter mAdapter;
-    public static Activity thisActivity;
+    public static AppCompatActivity thisActivity;
     public static EditText trait;
     private static Handler mHandler = new Handler();
     private static FieldFileObject.FieldFileBase fieldFile;

--- a/app/src/main/java/com/fieldbook/tracker/activities/FieldEditorActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/FieldEditorActivity.java
@@ -70,6 +70,7 @@ import java.util.Optional;
 
 import com.fieldbook.tracker.utilities.DialogUtils;
 import com.fieldbook.tracker.utilities.GeodeticUtils;
+import com.fieldbook.tracker.utilities.PrefsConstants;
 import com.fieldbook.tracker.utilities.Utils;
 import com.getkeepsafe.taptargetview.TapTarget;
 import com.getkeepsafe.taptargetview.TapTargetSequence;
@@ -158,7 +159,7 @@ public class FieldEditorActivity extends AppCompatActivity {
             ConfigActivity.dt = new DataHelper(this);
         }
         ConfigActivity.dt.open();
-        ConfigActivity.dt.updateExpTable(false, true, false, ep.getInt("SelectedFieldExpId", 0));
+        ConfigActivity.dt.updateExpTable(false, true, false, ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
         fieldList = findViewById(R.id.myList);
         mAdapter = new FieldAdapter(thisActivity, ConfigActivity.dt.getAllFieldObjects());
         fieldList.setAdapter(mAdapter);
@@ -884,7 +885,7 @@ public class FieldEditorActivity extends AppCompatActivity {
                 ed.putString("ImportFirstName", firstName);
                 ed.putString("ImportSecondName", secondName);
                 ed.putBoolean("ImportFieldFinished", true);
-                ed.putInt("SelectedFieldExpId", exp_id);
+                ed.putInt(PrefsConstants.SELECTED_FIELD_ID, exp_id);
 
                 ed.apply();
 

--- a/app/src/main/java/com/fieldbook/tracker/adapters/FieldAdapter.java
+++ b/app/src/main/java/com/fieldbook/tracker/adapters/FieldAdapter.java
@@ -46,12 +46,11 @@ public class FieldAdapter extends BaseAdapter {
     private static final int PRIMARY = 0;
     private static final int SECONDARY = 1;
     private static final int TERTIARY = 2;
-    private static final String PLACEHOLDER_OPTION = "Choose an option";
+    private final String PLACEHOLDER_OPTION;
 
     private LayoutInflater mLayoutInflater;
     private ArrayList<FieldObject> list;
     private Context context;
-    private View parentView;
     private SharedPreferences ep;
     private String selectedPrimary;
     private String selectedSecondary;
@@ -61,6 +60,8 @@ public class FieldAdapter extends BaseAdapter {
         this.context = context;
         mLayoutInflater = LayoutInflater.from(context);
         this.list = list;
+
+        PLACEHOLDER_OPTION = context.getString(R.string.sort_placeholder);
     }
 
     public int getCount() {
@@ -295,7 +296,7 @@ public class FieldAdapter extends BaseAdapter {
                     } catch (Exception e) {
                         Log.e("FieldAdapter", "Error updating sorting", e);
 
-                        new AlertDialog.Builder(context).setTitle(R.string.dialog_error_title)
+                        new AlertDialog.Builder(context).setTitle(R.string.dialog_save_error_title)
                                 .setPositiveButton(R.string.okButtonText, (dInterface, i) -> Log.d("FieldAdapter", "Sort save error dialog dismissed"))
                                 .setMessage(R.string.sort_dialog_error_saving)
                                 .create()

--- a/app/src/main/java/com/fieldbook/tracker/adapters/FieldAdapter.java
+++ b/app/src/main/java/com/fieldbook/tracker/adapters/FieldAdapter.java
@@ -24,6 +24,7 @@ import com.fieldbook.tracker.brapi.BrapiInfoDialog;
 import com.fieldbook.tracker.activities.FieldEditorActivity;
 import com.fieldbook.tracker.objects.FieldObject;
 import com.fieldbook.tracker.utilities.DialogUtils;
+import com.fieldbook.tracker.utilities.PrefsConstants;
 
 import java.util.ArrayList;
 
@@ -66,13 +67,13 @@ public class FieldAdapter extends BaseAdapter {
         boolean has_contents = item != null;
         if (has_contents) {
             ed.putString("FieldFile", item.getExp_name());
-            ed.putInt("SelectedFieldExpId", item.getExp_id());
+            ed.putInt(PrefsConstants.SELECTED_FIELD_ID, item.getExp_id());
             ed.putString("ImportUniqueName", item.getUnique_id());
             ed.putString("ImportFirstName", item.getPrimary_id());
             ed.putString("ImportSecondName", item.getSecondary_id());
         } else {
             ed.putString("FieldFile", null);
-            ed.putInt("SelectedFieldExpId", -1);
+            ed.putInt(PrefsConstants.SELECTED_FIELD_ID, -1);
             ed.putString("ImportUniqueName", null);
             ed.putString("ImportFirstName", null);
             ed.putString("ImportSecondName", null);
@@ -195,7 +196,7 @@ public class FieldAdapter extends BaseAdapter {
 
                 ConfigActivity.dt.deleteField(getItem(position).getExp_id());
 
-                if (getItem(position).getExp_id() == ep.getInt("SelectedFieldExpId", -1)) {
+                if (getItem(position).getExp_id() == ep.getInt(PrefsConstants.SELECTED_FIELD_ID, -1)) {
                     setEditorItem(ep, null);
                 }
 
@@ -227,7 +228,7 @@ public class FieldAdapter extends BaseAdapter {
         setEditorItem(ep, selectedField);
 
         SharedPreferences.Editor ed = ep.edit();
-        ed.putInt("SelectedFieldExpId", selectedField.getExp_id());
+        ed.putInt(PrefsConstants.SELECTED_FIELD_ID, selectedField.getExp_id());
         ed.apply();
 
         ConfigActivity.dt.switchField(selectedField.getExp_id());

--- a/app/src/main/java/com/fieldbook/tracker/adapters/FieldAdapter.java
+++ b/app/src/main/java/com/fieldbook/tracker/adapters/FieldAdapter.java
@@ -198,7 +198,6 @@ public class FieldAdapter extends BaseAdapter {
                     DialogUtils.styleDialogs(alert);
                 } else if (item.getItemId() == R.id.sort) {
                     AlertDialog alert = showSortDialog(position);
-//                    alert.show();
                     DialogUtils.styleDialogs(alert);
                 }
 

--- a/app/src/main/java/com/fieldbook/tracker/brapi/ApiError.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/ApiError.java
@@ -1,29 +1,24 @@
 package com.fieldbook.tracker.brapi;
 
-import java.util.HashMap;
-import java.util.Map;
+public class ApiError {
+    private ApiErrorCode errorCode;
+    private String responseBody;
 
-public enum ApiError {
-    BAD_REQUEST(400),
-    UNAUTHORIZED(401),
-    NOT_FOUND(404),
-    FORBIDDEN(403);
-
-    private static final Map<Integer, ApiError> apiErrorsByCode = new HashMap<>();
-
-    static {
-        for (ApiError apiError : ApiError.values()) {
-            apiErrorsByCode.put(apiError.code, apiError);
-        }
+    public ApiErrorCode getErrorCode() {
+        return errorCode;
     }
 
-    private final int code;
-
-    ApiError(int code) {
-        this.code = code;
+    public ApiError setErrorCode(ApiErrorCode errorCode) {
+        this.errorCode = errorCode;
+        return this;
     }
 
-    public static ApiError processErrorCode(Integer code) {
-        return apiErrorsByCode.get(code);
+    public String getResponseBody() {
+        return responseBody;
+    }
+
+    public ApiError setResponseBody(String responseBody) {
+        this.responseBody = responseBody;
+        return this;
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/brapi/ApiErrorCode.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/ApiErrorCode.java
@@ -1,0 +1,29 @@
+package com.fieldbook.tracker.brapi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ApiErrorCode {
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    NOT_FOUND(404),
+    FORBIDDEN(403);
+
+    private static final Map<Integer, ApiErrorCode> apiErrorsByCode = new HashMap<>();
+
+    static {
+        for (ApiErrorCode apiErrorCode : ApiErrorCode.values()) {
+            apiErrorsByCode.put(apiErrorCode.code, apiErrorCode);
+        }
+    }
+
+    private final int code;
+
+    ApiErrorCode(int code) {
+        this.code = code;
+    }
+
+    public static ApiErrorCode processErrorCode(Integer code) {
+        return apiErrorsByCode.get(code);
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -1,7 +1,7 @@
 package com.fieldbook.tracker.brapi;
 
 import android.app.Activity;
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.Context;
@@ -27,6 +27,7 @@ import com.fieldbook.tracker.brapi.model.BrapiStudyDetails;
 import com.fieldbook.tracker.brapi.service.BrAPIService;
 import com.fieldbook.tracker.brapi.service.BrAPIServiceFactory;
 import com.fieldbook.tracker.R;
+import com.fieldbook.tracker.utilities.DialogUtils;
 
 import java.util.ArrayList;
 import java.util.Locale;
@@ -391,7 +392,9 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
                 // Finish our BrAPI import activity
                 ((Activity) context).finish();
             } else {
-                alertDialogBuilder.create().show();
+                AlertDialog alertDialog = alertDialogBuilder.create();
+                alertDialog.show();
+                DialogUtils.styleDialogs(alertDialog);
             }
 
         }

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -29,6 +29,7 @@ import com.fieldbook.tracker.brapi.service.BrAPIServiceFactory;
 import com.fieldbook.tracker.R;
 
 import java.util.ArrayList;
+import java.util.Locale;
 
 public class BrapiLoadDialog extends Dialog implements android.view.View.OnClickListener {
 
@@ -84,14 +85,18 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
     }
 
     private String makePlural(String observationLevelName) {
-        StringBuilder plural = new StringBuilder(observationLevelName.substring(0, 1).toUpperCase());
-        if(observationLevelName.endsWith("y")) {
-            plural.append(observationLevelName.substring(1, observationLevelName.length() - 1)).append("ies");
-        } else {
-            plural.append(observationLevelName.substring(1)).append("s");
-        }
+        if(Locale.getDefault().getLanguage().equals("en")) {
+            StringBuilder plural = new StringBuilder(observationLevelName.substring(0, 1).toUpperCase());
+            if (observationLevelName.endsWith("y")) {
+                plural.append(observationLevelName.substring(1, observationLevelName.length() - 1)).append("ies");
+            } else {
+                plural.append(observationLevelName.substring(1)).append("s");
+            }
 
-        return plural.toString();
+            return plural.toString();
+        } else {
+            return observationLevelName;
+        }
     }
 
     private void buildStudyDetails() {
@@ -160,7 +165,7 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
                     @Override
                     public void run() {
                         findViewById(R.id.loadingPanel).setVisibility(View.GONE);
-                        new AlertDialog.Builder(context).setTitle(R.string.dialog_error_title)
+                        new AlertDialog.Builder(context).setTitle(R.string.dialog_save_error_title)
                                 .setPositiveButton(R.string.okButtonText, (dialogInterface, i) -> {
                                     ((Activity) context).finish();
                                 }).setMessage(R.string.brapi_plot_detail_error).create().show();
@@ -353,7 +358,7 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
             // Display our message.
             if (!brapiControllerResponse.status) {
                 alertDialogBuilder = new AlertDialog.Builder(context);
-                alertDialogBuilder.setTitle("Import Error")
+                alertDialogBuilder.setTitle(R.string.dialog_save_error_title)
                         .setPositiveButton(R.string.dialog_ok, (dialogInterface, i) -> {
                             // Finish our BrAPI import activity
                             ((Activity) context).finish();
@@ -374,7 +379,7 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
             if (fail) {
                 Log.e("error-opef", brapiControllerResponse.message);
                 alertDialogBuilder = new AlertDialog.Builder(context);
-                alertDialogBuilder.setTitle("Import Error")
+                alertDialogBuilder.setTitle(R.string.dialog_save_error_title)
                         .setPositiveButton(R.string.okButtonText, (dialogInterface, i) -> {
                             // Finish our BrAPI import activity
                             ((Activity) context).finish();

--- a/app/src/main/java/com/fieldbook/tracker/brapi/model/BrapiObservationLevel.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/model/BrapiObservationLevel.java
@@ -1,0 +1,14 @@
+package com.fieldbook.tracker.brapi.model;
+
+public class BrapiObservationLevel {
+    private String observationLevelName;
+
+    public String getObservationLevelName() {
+        return observationLevelName;
+    }
+
+    public BrapiObservationLevel setObservationLevelName(String observationLevelName) {
+        this.observationLevelName = observationLevelName;
+        return this;
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/AbstractBrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/AbstractBrAPIService.java
@@ -1,0 +1,32 @@
+package com.fieldbook.tracker.brapi.service;
+
+import android.content.Context;
+import android.util.Log;
+
+import com.fieldbook.tracker.preferences.GeneralKeys;
+
+public abstract class AbstractBrAPIService implements BrAPIService {
+
+    protected Integer getTimeoutValue(Context context) {
+        String timeoutString = context.getSharedPreferences("Settings", 0)
+                .getString(GeneralKeys.BRAPI_TIMEOUT, "120");
+
+        int timeout = 120;
+
+        try {
+            if (timeoutString != null) {
+                timeout = Integer.parseInt(timeoutString);
+            }
+        } catch (NumberFormatException nfe) {
+            String message = nfe.getLocalizedMessage();
+            if (message != null) {
+                Log.d("FieldBookError", nfe.getLocalizedMessage());
+            } else {
+                Log.d("FieldBookError", "Timeout Preference number format error.");
+            }
+            nfe.printStackTrace();
+        }
+
+        return timeout;
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
@@ -1,19 +1,12 @@
 package com.fieldbook.tracker.brapi.service;
 
-        import android.app.Activity;
-        import android.app.PendingIntent;
-        import android.content.ActivityNotFoundException;
         import android.content.Context;
-        import android.content.Intent;
         import android.content.SharedPreferences;
-        import android.net.Uri;
         import android.util.Log;
         import android.util.Patterns;
         import android.widget.Toast;
 
-        import androidx.annotation.Nullable;
         import androidx.arch.core.util.Function;
-        import androidx.browser.customtabs.CustomTabsIntent;
 
         import com.fieldbook.tracker.R;
         import com.fieldbook.tracker.brapi.ApiError;
@@ -28,15 +21,7 @@ package com.fieldbook.tracker.brapi.service;
         import com.fieldbook.tracker.brapi.model.Observation;
         import com.fieldbook.tracker.preferences.GeneralKeys;
         import com.fieldbook.tracker.objects.TraitObject;
-        import com.fieldbook.tracker.preferences.PreferencesActivity;
         import com.fieldbook.tracker.utilities.Constants;
-
-        import net.openid.appauth.AuthorizationException;
-        import net.openid.appauth.AuthorizationRequest;
-        import net.openid.appauth.AuthorizationService;
-        import net.openid.appauth.AuthorizationServiceConfiguration;
-        import net.openid.appauth.ResponseTypeValues;
-        import net.openid.appauth.browser.CustomTabManager;
         import com.fieldbook.tracker.utilities.FailureFunction;
         import com.fieldbook.tracker.utilities.SuccessFunction;
 

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
@@ -20,6 +20,7 @@ package com.fieldbook.tracker.brapi.service;
         import com.fieldbook.tracker.brapi.ApiErrorCode;
         import com.fieldbook.tracker.brapi.BrapiAuthDialog;
         import com.fieldbook.tracker.brapi.BrapiControllerResponse;
+        import com.fieldbook.tracker.brapi.model.BrapiObservationLevel;
         import com.fieldbook.tracker.brapi.model.BrapiProgram;
         import com.fieldbook.tracker.brapi.model.BrapiStudyDetails;
         import com.fieldbook.tracker.brapi.model.BrapiTrial;
@@ -36,6 +37,8 @@ package com.fieldbook.tracker.brapi.service;
         import net.openid.appauth.AuthorizationServiceConfiguration;
         import net.openid.appauth.ResponseTypeValues;
         import net.openid.appauth.browser.CustomTabManager;
+        import com.fieldbook.tracker.utilities.FailureFunction;
+        import com.fieldbook.tracker.utilities.SuccessFunction;
 
         import java.net.MalformedURLException;
         import java.net.URL;
@@ -173,4 +176,6 @@ public interface BrAPIService {
     public BrapiControllerResponse saveStudyDetails(BrapiStudyDetails studyDetails);
 
     public void authorizeClient();
+
+    void getObservationLevels(String programDbId, final SuccessFunction<List<BrapiObservationLevel>> successFn, final FailureFunction<ApiError> failFn);
 }

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
@@ -17,6 +17,7 @@ package com.fieldbook.tracker.brapi.service;
 
         import com.fieldbook.tracker.R;
         import com.fieldbook.tracker.brapi.ApiError;
+        import com.fieldbook.tracker.brapi.ApiErrorCode;
         import com.fieldbook.tracker.brapi.BrapiAuthDialog;
         import com.fieldbook.tracker.brapi.BrapiControllerResponse;
         import com.fieldbook.tracker.brapi.model.BrapiProgram;
@@ -107,10 +108,10 @@ public interface BrAPIService {
     }
 
     public static void handleConnectionError(Context context, int code) {
-        ApiError apiError = ApiError.processErrorCode(code);
+        ApiErrorCode apiErrorCode = ApiErrorCode.processErrorCode(code);
         String toastMsg = "";
 
-        switch (apiError) {
+        switch (apiErrorCode) {
             case UNAUTHORIZED:
                 // Start the login process
                 BrapiAuthDialog brapiAuth = new BrapiAuthDialog(context);

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
@@ -147,7 +147,7 @@ public interface BrAPIService {
 
     public void getStudyDetails(final String studyDbId, final Function<BrapiStudyDetails, Void> function, final Function<Integer, Void> failFunction);
 
-    public void getPlotDetails(final String studyDbId, final Function<BrapiStudyDetails, Void> function, final Function<Integer, Void> failFunction);
+    public void getPlotDetails(final String studyDbId, BrapiObservationLevel observationLevel, final Function<BrapiStudyDetails, Void> function, final Function<Integer, Void> failFunction);
 
     public void getOntology(BrapiPaginationManager paginationManager, final BiFunction<List<TraitObject>, Integer, Void> function, final Function<Integer, Void> failFunction);
 
@@ -173,7 +173,7 @@ public interface BrAPIService {
 
     public void getTraits(final String studyDbId, final Function<BrapiStudyDetails, Void> function, final Function<Integer, Void> failFunction);
 
-    public BrapiControllerResponse saveStudyDetails(BrapiStudyDetails studyDetails);
+    public BrapiControllerResponse saveStudyDetails(BrapiStudyDetails studyDetails, BrapiObservationLevel selectedObservationLevel, String primaryId, String secondaryId);
 
     public void authorizeClient();
 

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -69,7 +69,7 @@ import io.swagger.client.model.StudySummary;
 import io.swagger.client.model.TrialSummary;
 import io.swagger.client.model.TrialsResponse;
 
-public class BrAPIServiceV1 implements BrAPIService {
+public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService {
     private final Context context;
     private final ImagesApi imagesApi;
     private final StudiesApi studiesApi;
@@ -91,29 +91,6 @@ public class BrAPIServiceV1 implements BrAPIService {
         this.traitsApi = new ObservationVariablesApi(apiClient);
         this.phenotypesApi = new PhenotypesApi(apiClient);
         this.observationsApi = new ObservationsApi(apiClient);
-    }
-
-    private Integer getTimeoutValue(Context context) {
-        String timeoutString = context.getSharedPreferences("Settings", 0)
-                .getString(GeneralKeys.BRAPI_TIMEOUT, "120");
-
-        int timeout = 120;
-
-        try {
-            if (timeoutString != null) {
-                timeout = Integer.parseInt(timeoutString);
-            }
-        } catch (NumberFormatException nfe) {
-            String message = nfe.getLocalizedMessage();
-            if (message != null) {
-                Log.d("FieldBookError", nfe.getLocalizedMessage());
-            } else {
-                Log.d("FieldBookError", "Timeout Preference number format error.");
-            }
-            nfe.printStackTrace();
-        }
-
-        return timeout;
     }
 
     @Override
@@ -970,7 +947,6 @@ public class BrAPIServiceV1 implements BrAPIService {
             field.setUnique_id("observationUnitDbId");
             field.setPrimary_id(primaryId);
             field.setSecondary_id(secondaryId);
-            field.setExp_sort(observationLevel);
 
             // Do a pre-check to see if the field exists so we can show an error
             Integer FieldUniqueStatus = dataHelper.checkFieldName(field.getExp_name());

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -903,15 +903,13 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
         //TODO: Check these out and make sure they match with fieldbook data types.
         switch (dataType) {
             case "Nominal":
+            case "Ordinal": // All Field Book categories are ordered, so this works
                 return "categorical";
             case "Date":
                 return "date";
             case "Numerical":
             case "Duration":
                 return "numeric";
-            case "Ordinal":
-                // All Field Book categories are ordered, so this works
-                return "categorical";
             case "Code": // Not the ideal solution for this conversion
             case "Text":
             default:

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -8,6 +8,7 @@ import android.util.Pair;
 
 import androidx.arch.core.util.Function;
 
+import com.fieldbook.tracker.brapi.ApiErrorCode;
 import com.fieldbook.tracker.brapi.BrapiControllerResponse;
 import com.fieldbook.tracker.brapi.model.BrapiProgram;
 import com.fieldbook.tracker.brapi.model.BrapiStudyDetails;

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -74,7 +74,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
-public class BrAPIServiceV2 implements BrAPIService{
+public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService {
 
     private final Context context;
     private final BrAPIClient apiClient;
@@ -89,7 +89,7 @@ public class BrAPIServiceV2 implements BrAPIService{
     public BrAPIServiceV2(Context context) {
         this.context = context;
         // Make timeout longer. Set it to 60 seconds for now
-        this.apiClient = new BrAPIClient(BrAPIService.getBrapiUrl(context), 60000);
+        this.apiClient = new BrAPIClient(BrAPIService.getBrapiUrl(context), getTimeoutValue(context) * 1000);
 
         this.imagesApi = new ImagesApi(apiClient);
         this.studiesApi = new StudiesApi(apiClient);
@@ -958,7 +958,6 @@ public class BrAPIServiceV2 implements BrAPIService{
             field.setUnique_id("ObservationUnitDbId");
             field.setPrimary_id(primaryId);
             field.setSecondary_id(secondaryId);
-            field.setExp_sort(observationLevel);
 
             // Do a pre-check to see if the field exists so we can show an error
             Integer FieldUniqueStatus = dataHelper.checkFieldName(field.getExp_name());

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -7,6 +7,7 @@ import android.util.Pair;
 
 import androidx.arch.core.util.Function;
 
+import com.fieldbook.tracker.brapi.ApiErrorCode;
 import com.fieldbook.tracker.brapi.BrapiControllerResponse;
 import com.fieldbook.tracker.brapi.model.BrapiProgram;
 import com.fieldbook.tracker.brapi.model.BrapiStudyDetails;

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -11,15 +11,12 @@ import android.database.sqlite.SQLiteStatement;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Log;
-import android.widget.Toast;
 
-import com.fieldbook.tracker.activities.CollectActivity;
 import com.fieldbook.tracker.activities.ConfigActivity;
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.brapi.model.FieldBookImage;
 import com.fieldbook.tracker.brapi.model.Observation;
 import com.fieldbook.tracker.database.dao.ObservationDao;
-import com.fieldbook.tracker.database.dao.ObservationUnitAttributeDao;
 import com.fieldbook.tracker.database.dao.ObservationUnitDao;
 import com.fieldbook.tracker.database.dao.ObservationUnitPropertyDao;
 import com.fieldbook.tracker.database.dao.ObservationVariableDao;
@@ -53,8 +50,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static com.fieldbook.tracker.activities.ConfigActivity.dt;
 
 /**
  * All database related functions are here
@@ -1318,7 +1313,8 @@ public class DataHelper {
             }
         }
 
-        Integer[] result = ObservationUnitPropertyDao.Companion.getAllRangeId();
+        Integer[] result = ObservationUnitPropertyDao.Companion.getAllRangeId(context.getSharedPreferences("Settings", 0)
+                .getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
         int[] data = new int[result.length];
 

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -31,6 +31,7 @@ import com.fieldbook.tracker.objects.FieldObject;
 import com.fieldbook.tracker.objects.RangeObject;
 import com.fieldbook.tracker.objects.SearchData;
 import com.fieldbook.tracker.objects.TraitObject;
+import com.fieldbook.tracker.utilities.PrefsConstants;
 import com.fieldbook.tracker.utilities.Utils;
 
 import org.threeten.bp.OffsetDateTime;
@@ -320,7 +321,7 @@ public class DataHelper {
      */
     public List<Observation> getUserTraitObservations() {
 
-        String exp_id = Integer.toString(ep.getInt("SelectedFieldExpId", 0));
+        String exp_id = Integer.toString(ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
         return ObservationDao.Companion.getUserTraitObservations(exp_id);
 
@@ -367,7 +368,7 @@ public class DataHelper {
      */
     public List<FieldBookImage> getUserTraitImageObservations() {
 
-        String exp_id = Integer.toString(ep.getInt("SelectedFieldExpId", 0));
+        String exp_id = Integer.toString(ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
         return ObservationDao.Companion.getUserTraitImageObservations(exp_id, missingPhoto);
 
@@ -1198,7 +1199,7 @@ public class DataHelper {
      */
     public HashMap getUserDetail(String plotId) {
 
-        String exp_id = Integer.toString(ep.getInt("SelectedFieldExpId", 0));
+        String exp_id = Integer.toString(ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
         return ObservationDao.Companion.getUserDetail(exp_id, plotId);
 
@@ -2175,7 +2176,7 @@ public class DataHelper {
 
         SharedPreferences.Editor edit = ep.edit();
 
-        edit.putInt("SelectedFieldExpId", -1).apply();
+        edit.putInt(PrefsConstants.SELECTED_FIELD_ID, -1).apply();
         edit.putString("ImportUniqueName", "");
         edit.putString("ImportFirstName", "");
         edit.putString("ImportSecondName", "");
@@ -2558,7 +2559,7 @@ public class DataHelper {
                 
                 Migrator.Companion.migrateSchema(db, getAllTraitObjects(db));
 
-                ep2.edit().putInt("SelectedFieldExpId", -1).apply();
+                ep2.edit().putInt(PrefsConstants.SELECTED_FIELD_ID, -1).apply();
             }
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationUnitPropertyDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationUnitPropertyDao.kt
@@ -15,10 +15,24 @@ class ObservationUnitPropertyDao {
 //            db.query(sObservationUnitPropertyViewName).toTable().toTypedArray()
 //        }
 
-        fun getAllRangeId(): Array<Int> = withDatabase { db ->
+        fun getAllRangeId(exp_id:Int): Array<Int> = withDatabase { db ->
+            var sortCols = db.query(
+                Study.tableName,
+                select = arrayOf("study_sort_name"),
+                where = "${Study.PK} = ?",
+                whereArgs = arrayOf(exp_id.toString()),
+                orderBy = Study.PK
+            ).toFirst().get("study_sort_name")
+
+            if(sortCols != null) {
+                sortCols = "$sortCols, id"
+            } else {
+                sortCols = "id"
+            }
+
             val table = db.query(sObservationUnitPropertyViewName,
                     select = arrayOf("id"),
-                    orderBy = "id").toTable()
+                    orderBy = sortCols).toTable()
 
             table.map { (it["id"] as Int) }
                     .toTypedArray()
@@ -93,8 +107,8 @@ class ObservationUnitPropertyDao {
             var data: Array<String?>? = null
 
             if (cursor.moveToFirst()) {
-                val i = cursor.columnCount - 1
-                data = arrayOfNulls(i)
+//                val i = cursor.columnCount - 1
+                data = arrayOfNulls(cursor.columnCount)
                 var k = 0
                 for (j in 0 until cursor.columnCount) {
                     if (cursor.getColumnName(j) != "id") {
@@ -119,8 +133,8 @@ class ObservationUnitPropertyDao {
             var data: Array<String?>? = null
 
             if (cursor.moveToFirst()) {
-                val i = cursor.columnCount - 1
-                data = arrayOfNulls(i)
+//                val i = cursor.columnCount - 1
+                data = arrayOfNulls(cursor.columnCount)
                 var k = 0
                 for (j in 0 until cursor.columnCount) {
                     if (cursor.getColumnName(j) != "id") {

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/StudyDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/StudyDao.kt
@@ -122,6 +122,7 @@ class StudyDao {
             it.primary_id = this["study_primary_id_name"].toString()
             it.secondary_id = this["study_secondary_id_name"].toString()
             it.date_import = this["date_import"].toString()
+            it.exp_sort = this["study_sort_name"].toString()
             it.date_edit = when (val date = this["date_edit"]?.toString()) {
                 null, "null" -> ""
                 else -> date
@@ -162,7 +163,8 @@ class StudyDao {
                             "date_import",
                             "date_edit",
                             "date_export",
-                            "study_source"),
+                            "study_source",
+                            "study_sort_name"),
                     where = "${Study.PK} = ?",
                     whereArgs = arrayOf(exp_id.toString()),
                     orderBy = Study.PK).toFirst().toFieldObject()
@@ -361,6 +363,16 @@ class StudyDao {
             if (modifyDate) modifyDate(db, exp_id)
 
             if (updateExportDate) updateExportDate(db, exp_id)
+        }
+
+        fun updateStudySort(sort: String?, exp_id: Int) = withDatabase { db ->
+            var contentVals = ContentValues();
+            if(sort == null) {
+                contentVals.putNull("study_sort_name")
+            } else {
+                contentVals.put("study_sort_name", sort)
+            }
+            db.update(Study.tableName, contentVals, "${Study.PK} = ?", arrayOf("$exp_id"))
         }
 
         /**

--- a/app/src/main/java/com/fieldbook/tracker/traits/GNSSTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/GNSSTraitLayout.kt
@@ -27,6 +27,7 @@ import com.fieldbook.tracker.location.gnss.GNSSResponseReceiver.Companion.ACTION
 import com.fieldbook.tracker.location.gnss.NmeaParser
 import com.fieldbook.tracker.preferences.GeneralKeys
 import com.fieldbook.tracker.utilities.GeodeticUtils.Companion.truncateFixQuality
+import com.fieldbook.tracker.utilities.PrefsConstants
 import org.json.JSONObject
 
 /**
@@ -204,7 +205,7 @@ class GNSSTraitLayout : BaseTraitLayout, GPSTracker.GPSTrackerListener {
 
         if (latitude.isNotBlank() && longitude.isNotBlank()) {
 
-            val studyDbId = prefs.getInt("SelectedFieldExpId", 0).toString()
+            val studyDbId = prefs.getInt(PrefsConstants.SELECTED_FIELD_ID, 0).toString()
 
             //geo json object : elevation (stored in obs. units, used in navigation)
             //geo json has properties map for additional info

--- a/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.java
@@ -37,6 +37,7 @@ import com.fieldbook.tracker.preferences.GeneralKeys;
 import com.fieldbook.tracker.utilities.Constants;
 import com.fieldbook.tracker.adapters.GalleryImageAdapter;
 import com.fieldbook.tracker.utilities.DialogUtils;
+import com.fieldbook.tracker.utilities.PrefsConstants;
 import com.fieldbook.tracker.utilities.Utils;
 
 import java.io.File;
@@ -102,7 +103,7 @@ public class PhotoTraitLayout extends BaseTraitLayout {
 
     public void loadLayoutWork() {
 
-        String exp_id = Integer.toString(getPrefs().getInt("SelectedFieldExpId", 0));
+        String exp_id = Integer.toString(getPrefs().getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
         // Always set to null as default, then fill in with trait value
         photoLocation = new ArrayList<>();
@@ -260,7 +261,7 @@ public class PhotoTraitLayout extends BaseTraitLayout {
 
             newTraits.put(parent, value);
 
-            String exp_id = Integer.toString(getPrefs().getInt("SelectedFieldExpId", 0));
+            String exp_id = Integer.toString(getPrefs().getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
             //Observation observation = ConfigActivity.dt.getObservation(getCRange().plot_id, parent);
             Observation observation = ConfigActivity.dt.getObservationByValue(exp_id, getCRange().plot_id, parent, value);
@@ -282,7 +283,7 @@ public class PhotoTraitLayout extends BaseTraitLayout {
 
     private void deletePhotoWarning(final Boolean brapiDelete, final Map newTraits) {
 
-        String exp_id = Integer.toString(getPrefs().getInt("SelectedFieldExpId", 0));
+        String exp_id = Integer.toString(getPrefs().getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
 

--- a/app/src/main/java/com/fieldbook/tracker/utilities/FailureFunction.java
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/FailureFunction.java
@@ -1,0 +1,5 @@
+package com.fieldbook.tracker.utilities;
+
+public interface FailureFunction<T> {
+    void apply(T failureInput);
+}

--- a/app/src/main/java/com/fieldbook/tracker/utilities/PrefsConstants.java
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/PrefsConstants.java
@@ -1,0 +1,18 @@
+package com.fieldbook.tracker.utilities;
+
+public class PrefsConstants {
+    public static final String IMPORT_SECOND_NAME = "ImportSecondName";
+    public static final String UPDATE_VERSION = "UpdateVersion";
+    public static final String REGION = "region";
+    public static final String IMPORT_FIRST_NAME = "ImportFirstName";
+    public static final String TIPS = "Tips";
+    public static final String TRAITS_EXPORTED = "TraitsExported";
+    public static final String LAST_PLOT = "lastplot";
+    public static final String IMPORT_UNIQUE_NAME = "ImportUniqueName";
+    public static final String IMPORT_FIELD_FINISHED = "ImportFieldFinished";
+    public static final String FIELD_FILE = "FieldFile";
+    public static final String LANGUAGE = "language";
+    public static final String TIPS_CONFIGURED = "TipsConfigured";
+    public static final String SELECTED_FIELD_ID = "SelectedFieldExpId";
+    public static final String CREATE_TRAIT_FINISHED = "CreateTraitFinished";
+}

--- a/app/src/main/java/com/fieldbook/tracker/utilities/SuccessFunction.java
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/SuccessFunction.java
@@ -1,0 +1,5 @@
+package com.fieldbook.tracker.utilities;
+
+public interface SuccessFunction<T> {
+    void apply(T input);
+}

--- a/app/src/main/res/layout-sw600dp/listitem_field.xml
+++ b/app/src/main/res/layout-sw600dp/listitem_field.xml
@@ -93,12 +93,12 @@
     <ImageView
         android:id="@+id/popupMenu"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_gravity="center_vertical|right"
         android:paddingTop="3dp"
         android:paddingRight="20dp"
         android:paddingLeft="10dp"
         android:src="@drawable/ic_more_vert"
-        android:scaleType="fitEnd"/>
+        android:scaleType="fitCenter"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout-sw600dp/listitem_field.xml
+++ b/app/src/main/res/layout-sw600dp/listitem_field.xml
@@ -15,26 +15,14 @@
         android:layout_gravity="center_vertical|end"
         android:checked="false"
         android:scaleX="1.55"
-        android:scaleY="1.55" />
-
-    <ImageView
-        android:id="@+id/popupMenu"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical|left"
-        android:paddingLeft="5dp"
-        android:paddingTop="3dp"
-        android:src="@drawable/ic_more_vert" />
-
-    <View
-        android:id="@+id/spacer1"
-        android:layout_width="15dp"
-        android:layout_height="wrap_content" />
+        android:scaleY="1.55"
+        android:layout_marginRight="20dp"/>
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:layout_weight="1">
 
         <TextView
             android:id="@+id/field_name"
@@ -101,5 +89,16 @@
             android:textSize="@dimen/text_size_small" />
 
     </LinearLayout>
+
+    <ImageView
+        android:id="@+id/popupMenu"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical|right"
+        android:paddingTop="3dp"
+        android:paddingRight="20dp"
+        android:paddingLeft="10dp"
+        android:src="@drawable/ic_more_vert"
+        android:scaleType="fitEnd"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout-sw600dp/selector_dropdown.xml
+++ b/app/src/main/res/layout-sw600dp/selector_dropdown.xml
@@ -8,7 +8,7 @@
 
     <Spinner
         android:id="@+id/selectorSpinner"
-        android:layout_width="100dp"
+        android:layout_width="250dp"
         android:layout_height="wrap_content"
         android:text="@string/main_infobar_title"
         android:textColor="@color/s_text"

--- a/app/src/main/res/layout/activity_brapi.xml
+++ b/app/src/main/res/layout/activity_brapi.xml
@@ -13,6 +13,55 @@
         android:layout_weight="0"
         android:orientation="horizontal">
 
+        <TextView
+            android:id="@+id/brapiBaseURLLbl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="10dp"
+            android:paddingRight="10dp"
+            android:paddingBottom="5dp"
+            android:text="@string/brapi_base_url"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_small"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/brapiBaseURL"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/text_size_small" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <TextView
+            android:id="@+id/observationLevelLbl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="10dp"
+            android:paddingBottom="5dp"
+            android:text="@string/brapi_observation_level"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_small"
+            android:textStyle="bold" />
+
+        <Spinner
+            android:id="@+id/studyObservationLevels"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="10dp"
+            android:paddingBottom="10dp"
+            android:paddingStart="10dp"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_medium"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
         <Button
             android:id="@+id/loadStudies"
             android:layout_width="wrap_content"
@@ -24,13 +73,6 @@
             android:text="@string/brapi_load_data_button"
             android:textColor="@color/s_text"
             android:textSize="20sp" />
-
-        <TextView
-            android:id="@+id/brapiBaseURL"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="15sp" />
-
     </LinearLayout>
 
     <ListView

--- a/app/src/main/res/layout/dialog_brapi_import.xml
+++ b/app/src/main/res/layout/dialog_brapi_import.xml
@@ -112,7 +112,6 @@
             android:layout_height="wrap_content"
             android:paddingLeft="10dp"
             android:paddingBottom="10dp"
-            android:text="@string/brapi_study_num_plots"
             android:textColor="#000000"
             android:textSize="@dimen/text_size_medium"
             android:textStyle="bold" />
@@ -147,6 +146,56 @@
     </LinearLayout>
 
     <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="0"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/studyPrimaryKeyLbl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="10dp"
+            android:paddingBottom="5dp"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_medium"
+            android:textStyle="bold"
+            android:text="@string/import_dialog_primary" />
+
+        <Spinner
+            android:id="@+id/studyPrimaryKey"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="10dp"
+            android:paddingBottom="5dp"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_weight="0"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/studySecondaryKeyLbl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="10dp"
+            android:paddingBottom="5dp"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_medium"
+            android:textStyle="bold"
+            android:text="@string/import_dialog_secondary" />
+
+        <Spinner
+            android:id="@+id/studySecondaryKey"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="10dp"
+            android:paddingBottom="5dp"/>
+    </LinearLayout>
+
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
@@ -159,7 +208,7 @@
             android:layout_gravity="center_horizontal"
             android:minWidth="@dimen/button_default_width"
             android:onClick="dialogButtonClicked"
-            android:text="@string/dialog_ok"
+            android:text="@string/dialog_save"
             android:textColor="#000000"
             android:textSize="@dimen/text_size_large"
             android:textStyle="bold" />

--- a/app/src/main/res/layout/dialog_brapi_import.xml
+++ b/app/src/main/res/layout/dialog_brapi_import.xml
@@ -149,7 +149,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_weight="0"
-        android:orientation="horizontal">
+        android:orientation="vertical">
 
         <TextView
             android:id="@+id/studyPrimaryKeyLbl"
@@ -174,7 +174,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_weight="0"
-        android:orientation="horizontal">
+        android:orientation="vertical">
 
         <TextView
             android:id="@+id/studySecondaryKeyLbl"

--- a/app/src/main/res/layout/dialog_sort.xml
+++ b/app/src/main/res/layout/dialog_sort.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="#FFFFFF"
+    android:orientation="vertical"
+    android:paddingLeft="20dp"
+    android:paddingTop="5dp"
+    android:paddingRight="20dp"
+    android:paddingBottom="5dp">
+
+    <TextView
+        android:id="@+id/sortError"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="@color/design_default_color_error"
+        android:layout_marginTop="15dp"
+        android:textSize="@dimen/text_size_small"
+        android:textStyle="bold"
+        android:visibility="gone" />
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="5dp"
+        android:layout_marginTop="15dp"
+        android:weightSum="1">
+
+        <TextView
+            android:id="@+id/primaryCol"
+            android:layout_width="150dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="0.4"
+            android:paddingRight="10dp"
+            android:text="@string/sort_dialog_primary"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_small" />
+
+        <Spinner
+            android:id="@+id/primarySpin"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.6"
+            android:textColor="#FFFFFF"
+            android:textSize="@dimen/text_size_medium" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="5dp"
+        android:layout_marginTop="10dp"
+        android:weightSum="1">
+
+        <TextView
+            android:id="@+id/secondaryCol"
+            android:layout_width="150dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="0.4"
+            android:paddingRight="10dp"
+            android:text="@string/sort_dialog_secondary"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_small" />
+
+        <Spinner
+            android:id="@+id/secondarySpin"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.6"
+            android:textColor="#FFFFFF"
+            android:textSize="@dimen/text_size_medium" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="5dp"
+        android:layout_marginTop="10dp"
+        android:weightSum="1">
+
+        <TextView
+            android:id="@+id/tertiaryCol"
+            android:layout_width="150dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_weight="0.4"
+            android:paddingRight="10dp"
+            android:text="@string/sort_dialog_tertiary"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_small" />
+
+        <Spinner
+            android:id="@+id/tertiarySpin"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.6"
+            android:textColor="#FFFFFF"
+            android:textSize="@dimen/text_size_medium" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/listitem_field.xml
+++ b/app/src/main/res/layout/listitem_field.xml
@@ -15,25 +15,14 @@
         android:layout_gravity="center_vertical|end"
         android:checked="false"
         android:scaleX="1.1"
-        android:scaleY="1.1" />
-
-    <ImageView
-        android:id="@+id/popupMenu"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical|left"
-        android:paddingTop="3dp"
-        android:src="@drawable/ic_more_vert" />
-
-    <View
-        android:id="@+id/spacer1"
-        android:layout_width="10dp"
-        android:layout_height="wrap_content" />
+        android:scaleY="1.1"
+        android:layout_marginRight="15dp"/>
 
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:layout_weight="1">
 
         <TextView
             android:id="@+id/field_name"
@@ -89,7 +78,6 @@
                 android:textSize="@dimen/text_size_small" />
         </LinearLayout>
 
-
         <TextView
             android:id="@+id/field_count"
             android:layout_width="wrap_content"
@@ -100,5 +88,16 @@
             android:textColor="@color/main_details"
             android:textSize="@dimen/text_size_small" />
     </LinearLayout>
+
+    <ImageView
+        android:id="@+id/popupMenu"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical|right"
+        android:paddingTop="3dp"
+        android:paddingRight="20dp"
+        android:paddingLeft="10dp"
+        android:src="@drawable/ic_more_vert"
+        android:scaleType="fitEnd"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/listitem_field.xml
+++ b/app/src/main/res/layout/listitem_field.xml
@@ -92,12 +92,12 @@
     <ImageView
         android:id="@+id/popupMenu"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_gravity="center_vertical|right"
         android:paddingTop="3dp"
         android:paddingRight="20dp"
         android:paddingLeft="10dp"
         android:src="@drawable/ic_more_vert"
-        android:scaleType="fitEnd"/>
+        android:scaleType="fitCenter"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/selector_dropdown.xml
+++ b/app/src/main/res/layout/selector_dropdown.xml
@@ -8,8 +8,9 @@
 
     <Spinner
         android:id="@+id/selectorSpinner"
-        android:layout_width="100dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_weight="0.2"
         android:text="@string/main_infobar_title"
         android:textColor="@color/s_text"
         android:textSize="@dimen/text_size_xlarge"
@@ -19,9 +20,10 @@
         android:id="@+id/selectorText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_weight="1"
         android:ellipsize="end"
         android:maxLines="1"
-        android:paddingLeft="10dp"
+        android:layout_marginLeft="10dp"
         android:scrollHorizontally="true"
         android:textColor="#000000"
         android:textSize="@dimen/text_size_xlarge"

--- a/app/src/main/res/menu/menu_field_listitem.xml
+++ b/app/src/main/res/menu/menu_field_listitem.xml
@@ -2,6 +2,9 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
 
     <item
+        android:id="@+id/sort"
+        android:title="@string/fields_sort_update" />
+    <item
         android:id="@+id/delete"
         android:title="@string/fields_delete" />
 

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -8,10 +8,15 @@
         <new>Identify and navigate to closest plot</new>
         <new>New setting to adjust polling rate, angle, and GNSS device</new>
         <new>Use internal GPS with GNSS trait</new>
-        <info>Improved calendar picker behavior</info>
+        <new>Fields can be sorted to allow for different collection orders</new>
+        <new>Observation level can now be selected for BrAPI imported fields</new>
+        <new>Primary/Secondary ID can now be selected for BrAPI imported fields</new>
         <new>Use Label or Value for BrAPI categorical traits</new>
+        <info>Improved calendar picker behavior</info>
         <info>Increased required minimum Android version to 5.1</info>
+        <info>Primary/Secondary Order are now referred to internally as Primary/Secondary ID</info>
         <bugfix>Fixed 'Move to unique identifier' setting</bugfix>
+        <bugfix>Numerous bug fixes</bugfix>
     </release>
 
     <release

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -499,6 +499,7 @@
     <string name="brapi_study_name">Name</string>
     <string name="brapi_study_description">Description</string>
     <string name="brapi_study_location">Location</string>
+    <string name="brapi_observation_level">Observation Level</string>
     <string name="brapi_study_num_plots"> Plots</string>
     <string name="brapi_study_num_traits"> Traits</string>
     <string name="brapi_not_found">ERROR: Target system does not support this operation via BrAPI.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,8 +72,9 @@
     <string name="sort_dialog_error_missing_secondary">Please choose a secondary order</string>
     <string name="sort_dialog_error_duplicates">Ordering choices cannot be duplicated</string>
     <string name="sort_dialog_saved">Sorting updated</string>
-    <string name="dialog_error_title">Save Error</string>
+    <string name="dialog_save_error_title">Save Error</string>
     <string name="sort_dialog_error_saving">Error updating sorting</string>
+    <string name="sort_placeholder">Choose an option</string>
 
     <!-- Settings Activity  -->
     <string name="settings_fields">Fields</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -418,6 +418,7 @@
     <string name="import_source_ask">Always ask</string>
 
     <string name="import_dialog_title_fields">Import field</string>
+    <string name="import_dialog_title_brapi_fields">BrAPI Field Import</string>
     <string name="import_dialog_title_traits">Import traits</string>
     <string name="import_dialog_unique">Unique identifier</string>
     <string name="import_dialog_primary">Primary identifier</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -408,8 +408,8 @@
     <string name="import_dialog_title_fields">Import field</string>
     <string name="import_dialog_title_traits">Import traits</string>
     <string name="import_dialog_unique">Unique identifier</string>
-    <string name="import_dialog_primary">Primary order</string>
-    <string name="import_dialog_secondary">Secondary order</string>
+    <string name="import_dialog_primary">Primary identifier</string>
+    <string name="import_dialog_secondary">Secondary identifier</string>
     <string name="import_dialog_importing">Please wait…</string>
 
     <string name="import_error_general">Error importing</string>
@@ -495,7 +495,7 @@
 
     <string name="brapi_load_data_button">Load Fields</string>
     <string name="brapi_load_traits_button">Load Traits</string>
-    <string name="brapi_save_data_button">Save Field</string>
+    <string name="brapi_save_data_button">Preview Field</string>
     <string name="brapi_study_name">Name</string>
     <string name="brapi_study_description">Description</string>
     <string name="brapi_study_location">Location</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
 
     <!-- Fields Activity  -->
     <string name="fields_delete_study">Delete field</string>
+    <string name="fields_update_sort_study">Update Sorting</string>
     <string name="fields_delete_study_confirmation">Are you sure you want to delete this field? This will delete all data from this field.</string>
     <string name="fields_study_exists_message">This field already exists.</string>
     <string name="fields_select_study">Select or import a field.</string>
@@ -58,11 +59,21 @@
     <string name="fields_options">Options</string>
     <string name="fields_study_statistics">Statistics</string>
     <string name="fields_sort">Sort</string>
+    <string name="fields_sort_update">Unit Sorting</string>
     <string name="fields_delete">Delete</string>
     <string name="fields_filter">Filter</string>
     <string name="fields_reimport">Reimport</string>
     <string name="fields_archive">Archive</string>
     <string name="fields_toolbar_add_field">Import Field</string>
+    <string name="sort_dialog_primary">Primary order</string>
+    <string name="sort_dialog_secondary">Secondary order</string>
+    <string name="sort_dialog_tertiary">Tertiary order</string>
+    <string name="sort_dialog_error_missing_primary">Please choose a primary order</string>
+    <string name="sort_dialog_error_missing_secondary">Please choose a secondary order</string>
+    <string name="sort_dialog_error_duplicates">Ordering choices cannot be duplicated</string>
+    <string name="sort_dialog_saved">Sorting updated</string>
+    <string name="dialog_error_title">Save Error</string>
+    <string name="sort_dialog_error_saving">Error updating sorting</string>
 
     <!-- Settings Activity  -->
     <string name="settings_fields">Fields</string>

--- a/app/src/test/java/BrapiServiceTest.java
+++ b/app/src/test/java/BrapiServiceTest.java
@@ -3,13 +3,13 @@ import android.os.Build;
 
 import androidx.arch.core.util.Function;
 
+import com.fieldbook.tracker.brapi.model.BrapiObservationLevel;
 import com.fieldbook.tracker.brapi.service.BrAPIService;
 import com.fieldbook.tracker.brapi.service.BrAPIServiceV1;
 import com.fieldbook.tracker.brapi.service.BrapiPaginationManager;
 import com.fieldbook.tracker.brapi.model.BrapiStudyDetails;
 import com.fieldbook.tracker.brapi.model.FieldBookImage;
 import com.fieldbook.tracker.brapi.model.Observation;
-import com.fieldbook.tracker.objects.TraitObject;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -22,10 +22,6 @@ import org.threeten.bp.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-
-import io.swagger.client.ApiException;
-import io.swagger.client.model.Image;
-import io.swagger.client.model.NewObservationDbIdsObservations;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -147,7 +143,7 @@ public class BrapiServiceTest {
         final String brapiToken = "Bearer YYYY";
 
         // Call our get study details endpoint with the same parsing that our classes use.
-        this.brAPIService.getPlotDetails(studyDbId, new Function<BrapiStudyDetails, Void>() {
+        this.brAPIService.getPlotDetails(studyDbId, new BrapiObservationLevel().setObservationLevelName("plot"), new Function<BrapiStudyDetails, Void>() {
             @Override
             public Void apply(BrapiStudyDetails input) {
                 // Check that we are getting some results back


### PR DESCRIPTION
# Description

Implemented the ability to choose the ObservationLevel to import ObservationUnits at.  User is able to choose the observationLevel before previewing the import, then see the number of observationUnits at that level before confirming the import.

Additional functionality was implemented to allow user to set the sort order of the observationUnits after import.  This change is applicable to any study, no matter how it was imported.  This fixes #84 

Bug fixes were added for removing hard coding of BrAPI timeout in BrAPIServiceV2, and some code cleanup was done.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

**Test Configuration**:
* Hardware: Pixel C emulator
* SDK: 10

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
