### PR TITLE
Fixed crash when navigating to Collect with a study that has 0 plots

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -2529,13 +2529,25 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
             setAllRangeID();
             if (rangeID != null) {
 
-                updateCurrentRange(rangeID[0]);
+                //if the study has no plots this would cause an AIOB exception
+                if (rangeID.length > 0) {
 
-                //TODO NullPointerException
-                lastRange = cRange.range;
-                display();
+                    updateCurrentRange(rangeID[0]);
 
-                traitBox.setNewTraits(cRange.plot_id);
+                    //TODO NullPointerException
+                    lastRange = cRange.range;
+                    display();
+
+                    traitBox.setNewTraits(cRange.plot_id);
+
+                } else { //if no fields, print a message and finish with result canceled
+
+                    Utils.makeToast(thisActivity, getString(R.string.act_collect_no_plots));
+
+                    setResult(RESULT_CANCELED);
+
+                    finish();
+                }
             }
         }
 

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -365,10 +365,12 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
                             ((Activity) context).finish();
                         });
 
-                if (brapiControllerResponse.message == BrAPIService.notUniqueFieldMessage) {
+                if (brapiControllerResponse.message.equals(BrAPIService.notUniqueFieldMessage)) {
                     alertDialogBuilder.setMessage(R.string.fields_study_exists_message);
-                } else if (brapiControllerResponse.message == BrAPIService.notUniqueIdMessage) {
+                } else if (brapiControllerResponse.message.equals(BrAPIService.notUniqueIdMessage)) {
                     alertDialogBuilder.setMessage(R.string.import_error_unique);
+                } else if (brapiControllerResponse.message.equals(BrAPIService.noPlots)) {
+                    alertDialogBuilder.setMessage(R.string.act_collect_no_plots);
                 } else {
                     Log.e("error-ope", brapiControllerResponse.message);
                     alertDialogBuilder.setMessage(R.string.brapi_save_field_error);

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
@@ -34,6 +34,7 @@ public interface BrAPIService {
 
     public static String notUniqueFieldMessage = "not_unique";
     public static String notUniqueIdMessage = "not_unique_id";
+    public static String noPlots = "no_plots";
 
     // Helper functions for brapi configurations
     public static Boolean isLoggedIn(Context context) {

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -962,6 +962,10 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
             // Check that there are not duplicate unique ids in the database
             HashMap<String, String> checkMap = new HashMap<>();
 
+            if (studyDetails.getValues().isEmpty()) {
+                return new BrapiControllerResponse(false, this.noPlots);
+            }
+            
             // Construct our map to check for uniques
             for (List<String> dataRow : studyDetails.getValues()) {
                 Integer idColumn = studyDetails.getAttributes().indexOf(observationLevel);

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -972,6 +972,10 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
             // Check that there are not duplicate unique ids in the database
             HashMap<String, String> checkMap = new HashMap<>();
 
+            if (studyDetails.getValues().isEmpty()) {
+                return new BrapiControllerResponse(false, this.noPlots);
+            }
+
             // Construct our map to check for uniques
             for (List<String> dataRow : studyDetails.getValues()) {
                 Integer idColumn = studyDetails.getAttributes().indexOf(observationLevel);

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationUnitAttributeDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationUnitAttributeDao.kt
@@ -12,7 +12,7 @@ class ObservationUnitAttributeDao {
             db.query(ObservationUnitAttribute.tableName,
                     where = "${Study.FK} = ?",
                     whereArgs = arrayOf(eid.toString())).toTable()
-                .map { it["observation_unit_attribute_name"] as String }
+                .map { it["observation_unit_attribute_name"] as? String ?: "" }
                 .filter { it.isNotBlank() && it.isNotEmpty() }
                 .toTypedArray()
         } ?: emptyArray()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -668,4 +668,5 @@
     <string name="trait_counter_layout_failed">Counter failed to save, please recreate this trait.</string>
     <string name="dialog_date_picker_neutral_button">Today</string>
     <string name="preferences_brapi_traits_title">BrAPI Variables</string>
+    <string name="act_collect_no_plots">This study has no plots saved.</string>
 </resources>


### PR DESCRIPTION
Added checks in BrAPI code that disallows importing studies with 0 plots.

Added check in Collect activity that will finish activity if 0 plots are found (instead of crashing).

Fixes #299