### PR TITLE
Improved quick goto search.

### DIFF
--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -10,6 +10,7 @@
         <new>New sound for missing barcodes when navigating</new>
         <info>Improved import file sanitation</info>
         <info>Added warnings for failed file imports</info>
+        <bugfix>Quick GoTo can now use both primary/secondary ID</bugfix>
         <bugfix>Numerous bug fixes</bugfix>
     </release>
 


### PR DESCRIPTION
QuickGoto search now uses both primary/secondary terms if they are changed. Otherwise it does the default search with the last changed term.

Fixes #157
