### PR TITLE
[BRAPI] - Enabling Repeated Measures/Subobservations

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -302,7 +302,7 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
                     if (traitBox.existsNewTraits() & trait != null)
                         updateTrait(trait.getTrait(), trait.getFormat(), en.toString());
                 } else {
-                    if (traitBox.existsNewTraits() & trait != null) {
+                    if (traitBox.existsNewTraits() & trait != null & !replicateInProgress) {
                         removeTrait(trait.getTrait());
                     }
                 }
@@ -902,8 +902,10 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
         //Uservalue can't be empty string or for text values the observation is deleted
         updateTrait(parent, trait, "", true);
         //Sets the text to null for display
-        //Because null, doesn't trigger a second updateTrait in TextWatcher
+        //Because null, doesn't trigger a second updateTrait in TextWatcher...well in theory. less so now.
+        replicateInProgress = true;
         etCurVal.setText(null);
+        replicateInProgress = false;
     }
 
     /**
@@ -940,6 +942,7 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
             dt.deleteTrait(exp_id, rangeBox.getPlotID(), parent);
         } else if (!newReplicate) {
             dt.deleteTraitByReplicate(exp_id, rangeBox.getPlotID(), parent); //for now current and max replicate are the same, in the future update
+            //todo check if problem here
         }
 
         dt.insertUserTraits(rangeBox.getPlotID(), parent, trait, value,
@@ -2249,7 +2252,6 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
 
             String exp_id = Integer.toString(ep.getInt(PrefsConstants.SELECTED_FIELD_ID, 0));
 
-            //hello
             //Determine if repeated observations or overwrite
             Boolean repeatObs = ep.getBoolean(GeneralKeys.REPEAT_OBSERVATIONS, false);
 
@@ -2258,8 +2260,8 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
                 dt.deleteTrait(exp_id, plotID, traitName);
             } else {
                 dt.deleteTraitByReplicate(exp_id, plotID, traitName);
-                //TODO If previous replicate, want to display its value
-                //traitBox.getCurrentTrait().
+                //TODO In case of deleting on empty string, should display value of previous replicate
+                //etCurVal.setText(<highestReplicate>) or some reload perhaps?
             }
         }
 

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -306,6 +306,7 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
                         removeTrait(trait.getTrait());
                     }
                 }
+                //tNum.setSelection(tNum.getText().length());
             }
 
             public void beforeTextChanged(CharSequence arg0, int arg1,
@@ -897,14 +898,11 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
      * Helper function to add repeated trait measure
      */
     public void addRepeatedMeasure(String parent, String trait) {
-        //Two conflicting factors that will require other changes to resolve
-        //Uservalue can't be null or errors
-        //Uservalue can't be empty string or for text values the observation is deleted
+        //Uservalue can't be null or errors, so went with workarounds to handle empty string deletion logic
         updateTrait(parent, trait, "", true);
-        //Sets the text to null for display
-        //Because null, doesn't trigger a second updateTrait in TextWatcher...well in theory. less so now.
+        //Resets text for display
         replicateInProgress = true;
-        etCurVal.setText(null);
+        etCurVal.setText(""); //TODO need more effective way to refresh view
         replicateInProgress = false;
     }
 
@@ -942,7 +940,6 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
             dt.deleteTrait(exp_id, rangeBox.getPlotID(), parent);
         } else if (!newReplicate) {
             dt.deleteTraitByReplicate(exp_id, rangeBox.getPlotID(), parent); //for now current and max replicate are the same, in the future update
-            //todo check if problem here
         }
 
         dt.insertUserTraits(rangeBox.getPlotID(), parent, trait, value,
@@ -952,7 +949,6 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
 
         //update the info bar in case a variable is used
         infoBarAdapter.notifyItemRangeChanged(0, infoBarAdapter.getItemCount());
-        //oops now crashes on click
     }
 
     private void brapiDelete(String parent, Boolean hint) {

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -890,10 +890,14 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
         String observationDbId = observation.getDbId();
         OffsetDateTime lastSyncedTime = observation.getLastSyncedTime();
 
+        //Determine if repeated observations or overwrite
+        Boolean repeatObs = ep.getBoolean(GeneralKeys.REPEAT_OBSERVATIONS, false);
 
-        // Always remove existing trait before inserting again
+        // If no repeated measures, remove existing trait before inserting again
         // Based on plot_id, prevent duplicates
-        dt.deleteTrait(exp_id, rangeBox.getPlotID(), parent);
+        if (!repeatObs) {
+            dt.deleteTrait(exp_id, rangeBox.getPlotID(), parent);
+        }
 
         dt.insertUserTraits(rangeBox.getPlotID(), parent, trait, value,
                 ep.getString("FirstName", "") + " " + ep.getString("LastName", ""),

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -1660,6 +1660,14 @@ public class DataHelper {
 
     /**
      * Helper function
+     */
+    public void deleteTraitByReplicate(String exp_id, String rid, String parent) {
+
+        ObservationDao.Companion.deleteTraitByReplicate(exp_id, rid, parent);
+    }
+
+    /**
+     * Helper function
      * v2 - Delete trait
      */
     public void deleteTrait(String id) {

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
@@ -333,6 +333,20 @@ class ObservationDao {
                     arrayOf(id, rid, parent))
         }
 
+        /**
+         * Deletes all observations for a given variable on a plot for the highest replicate
+         * TODO In future will modify to retrieve for current replicate
+         * @param id: the study id
+         * @param rid: the unique plot name
+         * @param parent: the observation variable (trait) name
+         */
+        fun deleteTraitByReplicate(id: String, rid: String, parent: String) = withDatabase { db ->
+            val rep = getRep(rid, parent).toString();
+            db.delete(Observation.tableName,
+                    "${Study.FK} = ? AND ${ObservationUnit.FK} LIKE ? AND observation_variable_name LIKE ? AND rep = ?",
+                    arrayOf(id, rid, parent, rep))
+        }
+
         fun deleteTraitByValue(expId: String, rid: String, parent: String, value: String) = withDatabase { db ->
 
             db.delete(Observation.tableName,

--- a/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
@@ -27,6 +27,7 @@ public class GeneralKeys {
     public static final String CYCLING_TRAITS_ADVANCES              = "CycleTraits";
     public static final String DISABLE_ENTRY_ARROW_NO_DATA          = "DISABLE_ENTRY_ARROW_NO_DATA";
     public static final String FLIP_FLOP_COLLECT_ARROWS             = "FLIP_FLOP_TRAIT_ARROWS";
+    public static final String REPEAT_OBSERVATIONS                  = "REPEAT_OBSERVATIONS";
 
     // General
     public static final String TUTORIAL_MODE                        = "Tips";

--- a/app/src/main/res/drawable/ic_plus.xml
+++ b/app/src/main/res/drawable/ic_plus.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_repeat.xml
+++ b/app/src/main/res/drawable/ic_repeat.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M7,7h10v3l4,-4 -4,-4v3L5,5v6h2L7,7zM17,17L7,17v-3l-4,4 4,4v-3h12v-6h-2v4z"/>
+</vector>

--- a/app/src/main/res/drawable/round_button_background.xml
+++ b/app/src/main/res/drawable/round_button_background.xml
@@ -1,0 +1,11 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+
+    <solid android:color="@color/colorAccent" />
+
+    <padding
+        android:left="10dp"
+        android:top="10dp"
+        android:right="10dp"
+        android:bottom="10dp" />
+</shape>

--- a/app/src/main/res/layout/activity_collect.xml
+++ b/app/src/main/res/layout/activity_collect.xml
@@ -267,6 +267,31 @@
         app:layout_constraintTop_toBottomOf="@id/traitDetails"
         app:layout_constraintHeight_percent="0.13" />
 
+    <Spinner
+        android:id="@+id/replicateVal"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        app:layout_constraintBottom_toTopOf="parent"
+        app:layout_constraintLeft_toRightOf="@id/rangeLeft"
+        app:layout_constraintRight_toLeftOf="@+id/repeated_values_add_btn"
+        app:layout_constraintTop_toBottomOf="parent" />
+
+    <ImageButton
+        android:id="@+id/repeated_values_add_btn"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:adjustViewBounds="false"
+        android:background="@drawable/round_button_background"
+        android:cropToPadding="false"
+        android:elevation="5dp"
+        android:fitsSystemWindows="true"
+        android:scaleType="fitCenter"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_plus" />
+
     <EditText
         android:id="@+id/etCurVal"
         android:layout_width="match_parent"
@@ -284,7 +309,7 @@
         app:layout_constraintBottom_toTopOf="@id/svTraitContainer"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/valuesPlotRangeHolder" />
+        app:layout_constraintTop_toBottomOf="@id/repeated_values_add_btn" />
 
     <ScrollView
         android:id="@+id/svTraitContainer"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,8 @@
     <string name="preferences_behavior_disable_entry_arrow_right">Right</string>
     <string name="preferences_behavior_disable_entry_arrow_both">Both</string>
     <string name="preferences_behavior_disable_entry_arrow_neither">Neither</string>
+    <string name="preferences_behavior_repeat_observations_description">Enables collecting repeat observations. When unchecked, collecting again on a unit will overwrite the previous observation.</string>
+    <string name="preferences_behavior_repeat_observations">Enable Repeated Observations</string>
 
     <string name="preferences_brapi_core_title">Configuration</string>
     <string name="preferences_brapi_advanced_title">Advanced Auth Settings</string>

--- a/app/src/main/res/xml/preferences_behavior.xml
+++ b/app/src/main/res/xml/preferences_behavior.xml
@@ -64,4 +64,11 @@
         android:summary="@string/preferences_general_flip_flop_arrows_description"
         android:title="@string/preferences_general_flip_flop_arrows" />
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:icon="@drawable/ic_repeat"
+        android:key="REPEAT_OBSERVATIONS"
+        android:summary="@string/preferences_behavior_repeat_observations_description"
+        android:title="@string/preferences_behavior_repeat_observations" />
+
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences_brapi.xml
+++ b/app/src/main/res/xml/preferences_brapi.xml
@@ -88,7 +88,7 @@
         android:title="@string/preferences_brapi_traits_title"
         app:iconSpaceReserved="false">
         <ListPreference
-            android:defaultValue="@array/pref_collect_customize_labelval_default"
+            android:defaultValue="@string/preferences_appearance_collect_labelval_customize_value"
             android:dialogTitle="@string/preferences_appearance_collect_labelval_customize"
             android:entries="@array/pref_collect_labelval_customize_title"
             android:entryValues="@array/pref_collect_customize_labelval"


### PR DESCRIPTION
# Description

Initial steps for implementing subobservations in the form of repeated measures. Having the ability to record multiple observations for a single observation variable/observation unit pair will be greatly helpful for collection in cases like time series data.

**Most Recent Commit**

- "Enable Repeated Observations" is added as a new checkbox option in Settings/Behavior.
- An add repeated measure button has been added to the collect screen, which shows if "Enable Repeated Observations" has been checked.
- When "Enable Repeated Observations" is selected, adding and deleting observations is done on a by-replicate basis, so deletion will only delete one observation for an observation unit/observation value pair. 
- When plus button clicked, new entry in observations table created utilizing existing rep column, collection will now be done on this new repeated observation

**Notes**

- "Enable Repeated Observations" uses the same icon image as "Cycling traits advances entry" but as the file the latter uses "@drawable/ic_adv_cycle_traits_advances" is functionality specific, for "Enable Repeated Observations" a different import of the same icon was made under the more generic "@drawable/ic_repeat".
- Currently the start of a display of the replicate number in activity_collect.xml but ran out of time to retrieve replicate number.
- This PR also fixes a minor bug where there wasn't a default value for label/value selection in settings.

**Future Steps:**

- On collect page for a given observation unit/observation variable pair:
-- Display current replicate number
-- Display to toggle through displaying/editing different repeated observations 
- Improve refreshing of observation display on new replicate
-- Category should deselect
-- Date should reset
-- Finding some way to refresh would be preferable to piecemeal resetting each value type
- Determine how to handle user toggling off repeated observations and effect on database
- Import/Export from/to BrAPI, utilizing "observationlevels"/"observation hierarchy"
- May want to reconsider text functionality of deleting observation on empty string when replicates active?

**Commit 1:** documented in case need to go back to simplest commit
"Enable Repeated Observations" is added as a new checkbox option in Settings/Behavior. When "Enable Repeated Observations" is selected, each collection activity will generate a new replicate and most recent value will be displayed. When "Enable Repeated Observations" is deselected, collection activity will overwrite all replicates and replace them with one entry.

- This leads to two problems:
- deselecting a value counts as a collection activity and generates a replicate with a blank value. selecting a new value generates another replicate, so we have the blank value replicate stuck there
- each keystroke for a text value generates a new replicate, so we get "t" "te" "tes" "test" for trying to enter "test"

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe any tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] "Enable Repeated Observations" is visible under Settings/Behavior and can be enabled/disabled
- [X] Plus button on Collect screen is visible when "Enable Repeated Observations" is selected and not visible when deselected
- [X] When plus button is clicked, a new entry in observations table is added with a rep value one greater than the previous highest rep for that observation unit/observation value combo and a blank value.
- [X] When plus button is clicked, text should clear
- [X] When user selects a category after creating a replicate, the value for the new replicate should be the one that updates
- [X] When user types text after creating a replicate, the value for the new replicate should be the one that updates

**Test Configuration**:
* Hardware: Pixel 2 API 30
* SDK: Android Studio

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [ ] My changes generate no new warnings