### PR TITLE
V5.3/features/274

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
@@ -59,6 +59,7 @@ import com.fieldbook.tracker.utilities.ZipUtil;
 import com.getkeepsafe.taptargetview.TapTarget;
 import com.getkeepsafe.taptargetview.TapTargetSequence;
 import com.getkeepsafe.taptargetview.TapTargetView;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.michaelflisar.changelog.ChangelogBuilder;
 import com.michaelflisar.changelog.classes.ImportanceChangelogSorter;
 import com.michaelflisar.changelog.internal.ChangelogDialogFragment;
@@ -132,6 +133,14 @@ public class ConfigActivity extends AppCompatActivity {
         loadScreen();
     }
 
+    private void setCrashlyticsUserId() {
+
+        String id = ep.getString(GeneralKeys.CRASHLYTICS_ID, "");
+        FirebaseCrashlytics instance = FirebaseCrashlytics.getInstance();
+        instance.setUserId(id);
+        instance.setCustomKey(GeneralKeys.CRASHLYTICS_KEY_USER_TOKEN, id);
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -141,6 +150,7 @@ public class ConfigActivity extends AppCompatActivity {
 
         ep = getSharedPreferences(GeneralKeys.SHARED_PREF_FILE_NAME, 0);
 
+        setCrashlyticsUserId();
         invalidateOptionsMenu();
         loadScreen();
 

--- a/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
@@ -3,6 +3,14 @@ package com.fieldbook.tracker.preferences;
 public class GeneralKeys {
     // @formatter:off
 
+    //Crashlytics
+    public static final String CRASHLYTICS_KEY_USER_TOKEN           = "user_token";
+
+    //Profile
+    public static final String CRASHLYTICS_ID_ENABLED               = "com.tracker.fieldbook.preference.crashlytics.user_id_enabled";
+    public static final String CRASHLYTICS_ID_REFRESH               = "com.tracker.fieldbook.preference.crashlytics.refresh";
+    public static final String CRASHLYTICS_ID                       = "com.tracker.fieldbook.preference.crashlytics.id";
+
     // Appearance
     public static final String TOOLBAR_CUSTOMIZE                    = "TOOLBAR_CUSTOMIZE";
     public static final String INFOBAR_NUMBER                       = "INFOBAR_NUMBER";

--- a/app/src/main/java/com/fieldbook/tracker/preferences/ProfilePreferencesFragment.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/ProfilePreferencesFragment.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
@@ -14,6 +15,7 @@ import android.widget.EditText;
 import android.widget.LinearLayout;
 
 import androidx.appcompat.app.AlertDialog;
+import androidx.preference.CheckBoxPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
@@ -21,11 +23,17 @@ import androidx.preference.PreferenceManager;
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.location.GPSTracker;
 import com.fieldbook.tracker.utilities.DialogUtils;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import pub.devrel.easypermissions.AfterPermissionGranted;
 import pub.devrel.easypermissions.EasyPermissions;
 
 public class ProfilePreferencesFragment extends PreferenceFragmentCompat implements Preference.OnPreferenceChangeListener {
+
+    private static final String TAG = ProfilePreferencesFragment.class.getSimpleName();
 
     PreferenceManager prefMgr;
     Context context;
@@ -304,6 +312,95 @@ public class ProfilePreferencesFragment extends PreferenceFragmentCompat impleme
         return truncated.toString();
     }
 
+    private String refreshIdSummary(Preference refresh) {
+
+        String newId = UUID.randomUUID().toString();
+
+        prefMgr.getSharedPreferences().edit().putString(GeneralKeys.CRASHLYTICS_ID, newId).apply();
+
+        refresh.setSummary(newId);
+
+        FirebaseCrashlytics instance = FirebaseCrashlytics.getInstance();
+        instance.setUserId(newId);
+        instance.setCustomKey(GeneralKeys.CRASHLYTICS_KEY_USER_TOKEN, newId);
+
+        return newId;
+    }
+
+    private void setupCrashlyticsPreference() {
+
+        try {
+
+            CheckBoxPreference enablePref = findPreference(GeneralKeys.CRASHLYTICS_ID_ENABLED);
+            Preference refreshPref = findPreference(GeneralKeys.CRASHLYTICS_ID_REFRESH);
+
+            //check both preferences are found
+            if (enablePref != null && refreshPref != null) {
+
+                //check box listener, setup refresh visibility / on click implementation
+                enablePref.setOnPreferenceChangeListener((pref, newValue) -> {
+
+                    //get current id, might be null
+                    AtomicReference<String> id = new AtomicReference<>(prefMgr.getSharedPreferences().getString(GeneralKeys.CRASHLYTICS_ID, null));
+
+                    boolean enabled = (boolean) newValue;
+
+                    refreshPref.setVisible(enabled);
+
+                    //when refresh is clicked, update the unique id in the preferencs and update summary
+                    refreshPref.setOnPreferenceClickListener((v) -> {
+
+                        if (enabled) {
+
+                            id.set(refreshIdSummary(refreshPref));
+
+                        }
+
+                        return true;
+                    });
+
+                    if (enabled && id.get() == null) {
+
+                        id.set(refreshIdSummary(refreshPref));
+
+                    } else if (!enabled) {
+
+                        FirebaseCrashlytics instance = FirebaseCrashlytics.getInstance();
+                        instance.setUserId("");
+                        instance.setCustomKey(GeneralKeys.CRASHLYTICS_KEY_USER_TOKEN, "");
+                    }
+
+                    return true;
+                });
+
+                //get current id, might be null
+                String id = prefMgr.getSharedPreferences().getString(GeneralKeys.CRASHLYTICS_ID, null);
+
+                //when checkbox is initialized, check if id is null and update refresh vis
+                //update refresh summary as well
+                refreshPref.setVisible(enablePref.isChecked());
+
+                if (id != null) {
+
+                    refreshPref.setSummary(id);
+
+                    refreshPref.setOnPreferenceClickListener((v) -> {
+
+                        refreshIdSummary(refreshPref);
+
+                        return true;
+                    });
+                }
+            }
+
+        } catch (Exception e) {
+
+            e.printStackTrace();
+
+            Log.d(TAG, "Crashlytics setup failed.");
+        }
+    }
+
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
@@ -327,5 +424,12 @@ public class ProfilePreferencesFragment extends PreferenceFragmentCompat impleme
             EasyPermissions.requestPermissions(this, getString(R.string.permission_rationale_location),
                     PERMISSIONS_REQUEST_LOCATION, perms);
         }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        setupCrashlyticsPreference();
     }
 }

--- a/app/src/main/res/drawable/ic_card_account_details_outline.xml
+++ b/app/src/main/res/drawable/ic_card_account_details_outline.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M22,3H2C0.91,3.04 0.04,3.91 0,5V19C0.04,20.09 0.91,20.96 2,21H22C23.09,20.96 23.96,20.09 24,19V5C23.96,3.91 23.09,3.04 22,3M22,19H2V5H22V19M14,17V15.75C14,14.09 10.66,13.25 9,13.25C7.34,13.25 4,14.09 4,15.75V17H14M9,7A2.5,2.5 0,0 0,6.5 9.5A2.5,2.5 0,0 0,9 12A2.5,2.5 0,0 0,11.5 9.5A2.5,2.5 0,0 0,9 7M14,7V8H20V7H14M14,9V10H20V9H14M14,11V12H18V11H14"/>
+</vector>

--- a/app/src/main/res/drawable/ic_refresh.xml
+++ b/app/src/main/res/drawable/ic_refresh.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4A8,8 0,0 0,4 12A8,8 0,0 0,12 20C15.73,20 18.84,17.45 19.73,14H17.65C16.83,16.33 14.61,18 12,18A6,6 0,0 1,6 12A6,6 0,0 1,12 6C13.66,6 15.14,6.69 16.22,7.78L13,11H20V4L17.65,6.35Z"/>
+</vector>

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -4,6 +4,7 @@
         versionCode="530"
         versionName="v5.3">
         <new>Expanded options available for next entry with no data setting</new>
+        <new>Added option to provide anonymous identifier in profile</new>
     </release>
 
     <release

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -707,5 +707,10 @@
     <string name="brapi_chunk_size">Chunk Size</string>
 
     <string name="permission_ask_bluetooth">Please accept bluetooth permissions.</string>
+    <string name="preferences_profile_crashlytics">Crashlytics</string>
+    <string name="pref_profile_crashlytics_user_id_enabled">Unique ID</string>
+    <string name="pref_profile_crashlytics_user_id_enabled_summary">If enabled, this setting will log a unique ID which will help the developers solve certain issues.</string>
+    <string name="pref_profile_crashlytics_refresh_title">Refresh ID</string>
+    <string name="pref_profile_crashlytics_refresh_summary">This will assign a new unique ID.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -709,7 +709,7 @@
     <string name="permission_ask_bluetooth">Please accept bluetooth permissions.</string>
     <string name="preferences_profile_crashlytics">Crashlytics</string>
     <string name="pref_profile_crashlytics_user_id_enabled">Unique ID</string>
-    <string name="pref_profile_crashlytics_user_id_enabled_summary">If enabled, this setting will log a unique ID which will help the developers solve certain issues.</string>
+    <string name="pref_profile_crashlytics_user_id_enabled_summary">This optional setting will log an anonymous, unique ID that will help the development team track and solve crashes.</string>
     <string name="pref_profile_crashlytics_refresh_title">Refresh ID</string>
     <string name="pref_profile_crashlytics_refresh_summary">This will assign a new unique ID.</string>
 

--- a/app/src/main/res/xml/preferences_profile.xml
+++ b/app/src/main/res/xml/preferences_profile.xml
@@ -33,4 +33,25 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:key="crashlytics_category"
+        android:title="@string/preferences_profile_crashlytics"
+        app:iconSpaceReserved="false">
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:icon="@drawable/ic_card_account_details_outline"
+            android:key="com.tracker.fieldbook.preference.crashlytics.user_id_enabled"
+            android:title="@string/pref_profile_crashlytics_user_id_enabled"
+            android:summary="@string/pref_profile_crashlytics_user_id_enabled_summary"/>
+
+        <Preference
+            app:isPreferenceVisible="false"
+            android:icon="@drawable/ic_refresh"
+            android:key="com.tracker.fieldbook.preference.crashlytics.refresh"
+            android:summary="@string/pref_profile_crashlytics_refresh_summary"
+            android:title="@string/pref_profile_crashlytics_refresh_title" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
issue #274 

Added user id to crashlytics. This id can be refreshed/enabled in the profile preferences. The id is saved in the shared preferences, and the crashlytics api is updated when config activity starts, or the id is updated. The preference is disabled by default. The user id is also added as a data key under "user_token".
