### PR TITLE
hotfix/photoTraitLayoutImageSaving

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -86,7 +86,6 @@ import com.fieldbook.tracker.traits.BaseTraitLayout;
 import com.fieldbook.tracker.traits.LayoutCollections;
 import com.fieldbook.tracker.traits.PhotoTraitLayout;
 import com.fieldbook.tracker.utilities.DialogUtils;
-import com.fieldbook.tracker.utilities.DocumentTreeUtil;
 import com.fieldbook.tracker.utilities.GeodeticUtils;
 import com.fieldbook.tracker.utilities.Utils;
 import com.getkeepsafe.taptargetview.TapTarget;
@@ -97,7 +96,6 @@ import com.google.zxing.integration.android.IntentResult;
 
 import org.jetbrains.annotations.NotNull;
 import org.phenoapps.security.SecureBluetoothActivityImpl;
-import org.phenoapps.security.Security;
 import org.phenoapps.utils.BaseDocumentTreeUtil;
 import org.threeten.bp.OffsetDateTime;
 
@@ -1846,11 +1844,12 @@ public class CollectActivity extends AppCompatActivity implements SensorEventLis
                 }
                 break;
             case 252:
-                if (resultCode == RESULT_OK) {
-                    PhotoTraitLayout traitPhoto = traitLayouts.getPhotoTrait();
-                    traitPhoto.makeImage(traitBox.getCurrentTrait(),
-                            traitBox.getNewTraits());
-                }
+
+                PhotoTraitLayout traitPhoto = traitLayouts.getPhotoTrait();
+                TraitObject currentTrait = traitBox.getCurrentTrait();
+                Map<String, String> newTraits = traitBox.getNewTraits();
+                traitPhoto.makeImage(currentTrait, newTraits, resultCode == RESULT_OK);
+
                 break;
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.java
@@ -53,7 +53,7 @@ public class PhotoTraitLayout extends BaseTraitLayout {
     private ArrayList<Drawable> drawables;
     private Gallery photo;
     private GalleryImageAdapter photoAdapter;
-    private String mCurrentPhotoPath;
+    private Uri currentPhotoPath = null;
     // Creates a new thread to do importing
     private Runnable importRunnable = new Runnable() {
         public void run() {
@@ -233,26 +233,41 @@ public class PhotoTraitLayout extends BaseTraitLayout {
         }
     }
 
-    public void makeImage(TraitObject currentTrait, Map newTraits) {
+    public void makeImage(TraitObject currentTrait, Map<String, String> newTraits, Boolean success) {
 
         DocumentFile photosDir = DocumentTreeUtil.Companion.getFieldMediaDirectory(getContext(), "photos");
 
-        if (photosDir != null) {
+        if (photosDir != null && currentPhotoPath != null) {
 
-            DocumentFile file = photosDir.findFile(mCurrentPhotoPath);
+            DocumentFile file = DocumentFile.fromSingleUri(getContext(), currentPhotoPath);
 
             if (file != null) {
 
-                Utils.scanFile(getContext(), file.getUri().toString(), "image/*");
+                if (success) {
 
-                drawables.add(new BitmapDrawable(displayScaledSavedPhoto(file.getUri())));
+                    List<DocumentFile> p = DocumentTreeUtil.Companion.getPlotMedia(photosDir, getCRange().plot_id, ".jpg");
 
-                updateTraitAllowDuplicates(currentTrait.getTrait(), "photo", mCurrentPhotoPath, null, newTraits);
+                    Utils.scanFile(getContext(), file.getUri().toString(), "image/*");
 
-                photoAdapter = new GalleryImageAdapter((Activity) getContext(), drawables);
+                    drawables.add(new BitmapDrawable(displayScaledSavedPhoto(file.getUri())));
 
-                photo.setAdapter(photoAdapter);
-                photo.setSelection(photoAdapter.getCount() - 1);
+                    updateTraitAllowDuplicates(currentTrait.getTrait(), "photo", currentPhotoPath.toString(), null, newTraits);
+
+                    photoAdapter = new GalleryImageAdapter((Activity) getContext(), drawables);
+
+                    photo.setAdapter(photoAdapter);
+                    photo.setSelection(photoAdapter.getCount() - 1);
+                    photo.setOnItemClickListener((arg0, arg1, pos, arg3) -> {
+                        if (p.size() > pos) {
+                            displayPlotImage(p.get(pos).getUri());
+                        }
+                    });
+
+                } else {
+
+                    file.delete();
+
+                }
             }
         }
     }
@@ -382,13 +397,13 @@ public class PhotoTraitLayout extends BaseTraitLayout {
 
             String generatedName = getCRange().plot_id + "_" + getCurrentTrait().getTrait() + "_" + getRep() + "_" + timeStamp.format(Calendar.getInstance().getTime()) + ".jpg";
 
-            mCurrentPhotoPath = generatedName;
-
             Log.w("File", dir.getUri() + generatedName);
 
             DocumentFile file = dir.createFile("image/jpg", generatedName);
 
             if (file != null) {
+
+                currentPhotoPath = file.getUri();
 
                 Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
                 // Ensure that there's a camera activity to handle the intent
@@ -444,8 +459,11 @@ public class PhotoTraitLayout extends BaseTraitLayout {
                     photoAdapter = new GalleryImageAdapter((Activity) getContext(), drawables);
                     photo.setAdapter(photoAdapter);
                     photo.setSelection(photo.getCount() - 1);
-                    photo.setOnItemClickListener((arg0, arg1, pos, arg3) ->
-                            displayPlotImage(photos.get(pos).getUri()));
+                    photo.setOnItemClickListener((arg0, arg1, pos, arg3) -> {
+                        if (photos.size() > pos) {
+                            displayPlotImage(photos.get(pos).getUri());
+                        }
+                    });
                 } else {
                     photoAdapter = new GalleryImageAdapter((Activity) getContext(), drawables);
                     photo.setAdapter(photoAdapter);


### PR DESCRIPTION
# Description
Some devices were having trouble saving images. There was a NPE within the DocumentFile.findFile function (AOSP). I updated this trait to use the uri to the file directly instead of trying to find the file's name through that method.

Also fixed a crash when the user clicked a thumbnail immediately after taking a photo.

This was a reported issue, but I was not able to reproduce it.