### PR TITLE
BrAPI Observation Syncing

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/BrapiActivity.java
@@ -237,6 +237,7 @@ public class BrapiActivity extends AppCompatActivity {
         if(this.selectedStudy != null) {
             brapiLoadDialog.setSelectedStudy(this.selectedStudy);
             brapiLoadDialog.setObservationLevel(this.selectedObservationLevel);
+            brapiLoadDialog.setPaginationManager(this.paginationManager);
             brapiLoadDialog.show();
         } else{
             Toast toast = Toast.makeText(getApplicationContext(), R.string.brapi_warning_select_study, Toast.LENGTH_LONG);

--- a/app/src/main/java/com/fieldbook/tracker/adapters/FieldAdapter.java
+++ b/app/src/main/java/com/fieldbook/tracker/adapters/FieldAdapter.java
@@ -29,6 +29,7 @@ import com.fieldbook.tracker.brapi.BrapiInfoDialog;
 import com.fieldbook.tracker.activities.FieldEditorActivity;
 import com.fieldbook.tracker.database.dao.ObservationUnitAttributeDao;
 import com.fieldbook.tracker.database.dao.StudyDao;
+import com.fieldbook.tracker.dialogs.BrapiSyncObsDialog;
 import com.fieldbook.tracker.objects.FieldObject;
 import com.fieldbook.tracker.preferences.GeneralKeys;
 import com.fieldbook.tracker.utilities.DialogUtils;
@@ -57,6 +58,9 @@ public class FieldAdapter extends BaseAdapter {
     private String selectedPrimary;
     private String selectedSecondary;
     private String selectedTertiary;
+
+    AlertDialog.Builder builder;
+    AlertDialog progressDialog;
 
     public FieldAdapter(Context context, ArrayList<FieldObject> list) {
         this.context = context;
@@ -195,6 +199,11 @@ public class FieldAdapter extends BaseAdapter {
                 } else if (item.getItemId() == R.id.sort) {
                     AlertDialog alert = showSortDialog(position);
                     DialogUtils.styleDialogs(alert);
+                }
+                else if (item.getItemId() == R.id.syncObs) {
+                    BrapiSyncObsDialog alert = new BrapiSyncObsDialog(context);
+                    alert.setFieldObject(getItem(position));
+                    alert.show();
                 }
 
                 return false;

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -251,7 +251,7 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
     private void loadObservations() {
         System.out.println("Study DBId: "+study.getStudyDbId());
 
-        List<String> observationIds = new ArrayList<String>();
+        List<String> observationVariableDbIds = new ArrayList<String>();
 
         //Trying to get the traits as well:
         brAPIService.getTraits(study.getStudyDbId(), new Function<BrapiStudyDetails, Void>() {
@@ -260,7 +260,7 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
                 for(TraitObject obj : input.getTraits()) {
                     System.out.println("Trait:"+obj.getTrait());
                     System.out.println("ObsIds: "+obj.getExternalDbId());
-                    observationIds.add(obj.getExternalDbId());
+                    observationVariableDbIds.add(obj.getExternalDbId());
                 }
 
                 return null;
@@ -272,8 +272,8 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
             }
         });
 
-        System.out.println("obsIds Size:"+observationIds.size());
-        brAPIService.getObservations(study.getStudyDbId(), observationIds, paginationManager, new Function<List<Observation>, Void>() {
+        System.out.println("obsIds Size:"+observationVariableDbIds.size());
+        brAPIService.getObservations(study.getStudyDbId(), observationVariableDbIds, paginationManager, new Function<List<Observation>, Void>() {
             @Override
             public Void apply(List<Observation> input) {
                 study.setObservations(input);

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -24,12 +24,16 @@ import androidx.arch.core.util.Function;
 
 import com.fieldbook.tracker.brapi.model.BrapiObservationLevel;
 import com.fieldbook.tracker.brapi.model.BrapiStudyDetails;
+import com.fieldbook.tracker.brapi.model.Observation;
 import com.fieldbook.tracker.brapi.service.BrAPIService;
 import com.fieldbook.tracker.brapi.service.BrAPIServiceFactory;
 import com.fieldbook.tracker.R;
+import com.fieldbook.tracker.brapi.service.BrapiPaginationManager;
+import com.fieldbook.tracker.objects.TraitObject;
 import com.fieldbook.tracker.utilities.DialogUtils;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 public class BrapiLoadDialog extends Dialog implements android.view.View.OnClickListener {
@@ -42,6 +46,8 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
     private Boolean studyLoadStatus = false;
     private Boolean plotLoadStatus = false;
     private Boolean traitLoadStatus = false;
+    private BrapiPaginationManager paginationManager;
+
     // Creates a new thread to do importing
     private Runnable importRunnable = new Runnable() {
         public void run() {
@@ -59,6 +65,10 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
 
     public void setSelectedStudy(BrapiStudyDetails selectedStudy) {
         this.study = selectedStudy;
+    }
+
+    public void setPaginationManager(BrapiPaginationManager paginationManager) {
+        this.paginationManager = paginationManager;
     }
 
     @Override
@@ -82,6 +92,7 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
         studyDetails = new BrapiStudyDetails();
         updateNumPlotsLabel();
         buildStudyDetails();
+        //        loadObservations(); //Uncomment this if you want the app to sync the observations when field is loaded.
         loadStudy();
     }
 
@@ -227,6 +238,65 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
                         }
                     }
                 });
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Function to load the observations.
+     *
+     * TODO: Decide if we want to delete.  It is likely a better approach to use the BrapiSyncObsDialog as it gives the user more control
+     */
+    private void loadObservations() {
+        System.out.println("Study DBId: "+study.getStudyDbId());
+
+        List<String> observationIds = new ArrayList<String>();
+
+        //Trying to get the traits as well:
+        brAPIService.getTraits(study.getStudyDbId(), new Function<BrapiStudyDetails, Void>() {
+            @Override
+            public Void apply(BrapiStudyDetails input) {
+                for(TraitObject obj : input.getTraits()) {
+                    System.out.println("Trait:"+obj.getTrait());
+                    System.out.println("ObsIds: "+obj.getExternalDbId());
+                    observationIds.add(obj.getExternalDbId());
+                }
+
+                return null;
+            }
+        }, new Function<Integer, Void>() {
+            @Override
+            public Void apply(Integer input) {
+                return null;
+            }
+        });
+
+        System.out.println("obsIds Size:"+observationIds.size());
+        brAPIService.getObservations(study.getStudyDbId(), observationIds, paginationManager, new Function<List<Observation>, Void>() {
+            @Override
+            public Void apply(List<Observation> input) {
+                study.setObservations(input);
+                BrapiStudyDetails.merge(studyDetails, study);
+                System.out.println("StudyId: " + study.getStudyDbId());
+                System.out.println("StudyName: " + study.getStudyName());
+                for(Observation obs : input) {
+
+                    System.out.println("***************************");
+                    System.out.println("StudyId: "+obs.getStudyId());
+                    System.out.println("ObsId: "+obs.getDbId());
+                    System.out.println("UnitDbId: "+obs.getUnitDbId());
+
+                    System.out.println("VariableDbId: "+obs.getVariableDbId());
+                    System.out.println("VariableName: "+obs.getVariableName());
+                    System.out.println("Value: "+obs.getValue());
+                }
+                return null;
+            }
+        }, new Function<Integer, Void>() {
+            @Override
+            public Void apply(Integer input) {
+                System.out.println("Stopped:");
                 return null;
             }
         });

--- a/app/src/main/java/com/fieldbook/tracker/brapi/model/BrapiStudyDetails.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/model/BrapiStudyDetails.java
@@ -14,6 +14,7 @@ public class BrapiStudyDetails {
   private List<String> attributes;
   private List<List<String>> values;
   private List<TraitObject> traits;
+  private List<Observation> observations;
 
   public static void merge(BrapiStudyDetails sd1, BrapiStudyDetails sd2) {
     if (sd2.getStudyDbId() != null)
@@ -34,6 +35,8 @@ public class BrapiStudyDetails {
       sd1.setValues(sd2.getValues());
     if (sd2.getTraits() != null)
       sd1.setTraits(sd2.getTraits());
+    if (sd2.getObservations() != null)
+      sd1.setObservations(sd2.getObservations());
   }
 
   public String getCommonCropName() {
@@ -107,4 +110,9 @@ public class BrapiStudyDetails {
   public void setValues(List<List<String>> values) {
     this.values = values;
   }
+
+  public List<Observation> getObservations() { return observations; }
+
+  public void setObservations(List<Observation> observations) { this.observations = observations; }
+
 }

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
@@ -166,6 +166,8 @@ public interface BrAPIService {
 
     public void getPlotDetails(final String studyDbId, BrapiObservationLevel observationLevel, final Function<BrapiStudyDetails, Void> function, final Function<Integer, Void> failFunction);
 
+    public void getObservations(final String studyDbId, final List<String> observationVariableDbIds, BrapiPaginationManager paginationManager, final Function<List<Observation>, Void> function, final Function<Integer, Void> failFunction );
+
     public void getOntology(BrapiPaginationManager paginationManager, final BiFunction<List<TraitObject>, Integer, Void> function, final Function<Integer, Void> failFunction);
 
     public void createObservations(List<Observation> observations,

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -1110,15 +1110,6 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
 
                 System.out.println("Size of study details: "+studyDetails.getValues().size());
 
-                //Need to make sure the plot values are sorted before we try to save observations.
-                List<List<String>> sortedPlotValues = studyDetails.getValues()
-                        .stream()
-                        .distinct()
-                        .sorted((plot1, plot2) -> Integer.parseInt(plot1.get(plotId)) - Integer.parseInt(plot2.get(plotId)))
-                        .collect(Collectors.toList());
-
-                System.out.println("Size of study details after sort: "+sortedPlotValues.size());
-
                 for (List<String> dataRow : studyDetails.getValues()) {
                     dataHelper.createFieldData(expId, studyDetails.getAttributes(), dataRow);
                 }

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -18,6 +18,7 @@ import com.fieldbook.tracker.brapi.model.BrapiTrial;
 import com.fieldbook.tracker.brapi.model.FieldBookImage;
 import com.fieldbook.tracker.brapi.model.Observation;
 import com.fieldbook.tracker.database.DataHelper;
+import com.fieldbook.tracker.database.dao.ObservationVariableDao;
 import com.fieldbook.tracker.objects.FieldObject;
 import com.fieldbook.tracker.objects.TraitObject;
 import com.fieldbook.tracker.preferences.GeneralKeys;
@@ -39,6 +40,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import io.swagger.client.ApiClient;
 import io.swagger.client.ApiException;
@@ -61,6 +63,7 @@ import io.swagger.client.model.ObservationUnit;
 import io.swagger.client.model.ObservationUnitsResponse1;
 import io.swagger.client.model.ObservationVariable;
 import io.swagger.client.model.ObservationVariablesResponse;
+import io.swagger.client.model.ObservationsResponse;
 import io.swagger.client.model.Program;
 import io.swagger.client.model.ProgramsResponse;
 import io.swagger.client.model.StudiesResponse;
@@ -623,12 +626,84 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
         }
     }
 
+    /**
+     * Function to pull out the observations for a given study.
+     * This method will do an async call to the BrAPI validated server and will get the Observations
+     * @param studyDbId
+     * @param observationVariableDbIds
+     * @param paginationManager
+     * @param function
+     * @param failFunction
+     */
+    public void getObservations(final String studyDbId, final List<String> observationVariableDbIds,
+                                BrapiPaginationManager paginationManager, final Function<List<Observation>, Void> function,
+                                final Function<Integer, Void> failFunction ) {
+        Integer initPage = paginationManager.getPage();
+
+        try {
+            BrapiV1ApiCallBack<ObservationsResponse> callback = new BrapiV1ApiCallBack<ObservationsResponse>() {
+                @Override
+                public void onSuccess(ObservationsResponse response, int i, Map<String, List<String>> map) {
+                    // Cancel processing if the page that was processed is not the page
+                    // that we are currently on. For Example: User taps "Next Page" before brapi call returns data
+                    if (initPage.equals(paginationManager.getPage())) {
+                        updatePageInfo(paginationManager, response.getMetadata());
+                        // Result contains a list of observation variables
+                        List<io.swagger.client.model.Observation> brapiObservationList = response.getResult().getData();
+                        final List<Observation> observationList = mapObservations(brapiObservationList);
+
+                        function.apply(observationList);
+                    }
+                }
+
+                @Override
+                public void onFailure(ApiException error, int i, Map<String, List<String>> map) {
+                    failFunction.apply(error.getCode());
+                }
+
+            };
+
+            //This call is what kicks off the async thread
+            observationsApi.studiesStudyDbIdObservationsGetAsync(studyDbId,observationVariableDbIds, paginationManager.getPage(), paginationManager.getPageSize(),
+                    getBrapiToken(), callback);
+
+        } catch (ApiException e) {
+            Log.e("error-go", e.toString());
+            failFunction.apply(e.getCode());
+        }
+    }
+
     private Observation mapToObservation(NewObservationDbIdsObservations obs){
         Observation newObservation = new Observation();
         newObservation.setDbId(obs.getObservationDbId());
         newObservation.setUnitDbId(obs.getObservationUnitDbId());
         newObservation.setVariableDbId(obs.getObservationVariableDbId());
         return newObservation;
+    }
+
+    /**
+     * Function to map the observations from Brapi to the Fieldbook Observation variable.
+     * @param brapiObservationList
+     * @return list of Fieldbook Observation objects
+     */
+    private List<Observation> mapObservations(List<io.swagger.client.model.Observation> brapiObservationList) {
+        List<Observation> outputList = new ArrayList<>();
+        for(io.swagger.client.model.Observation brapiObservation : brapiObservationList) {
+            Observation newObservation = new Observation();
+
+            newObservation.setVariableName(brapiObservation.getObservationVariableName());
+            newObservation.setDbId(brapiObservation.getObservationDbId());
+            newObservation.setUnitDbId(brapiObservation.getObservationUnitDbId());
+            newObservation.setVariableDbId(brapiObservation.getObservationVariableDbId());
+            newObservation.setValue(brapiObservation.getValue());
+
+            //TODO Uncomment once the time stamp is working correctly.
+//            newObservation.setTimestamp(brapiObservation.getObservationTimeStamp());
+
+            outputList.add(newObservation);
+
+        }
+        return outputList;
     }
 
     public void createObservations(List<Observation> observations,
@@ -796,7 +871,7 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
 
             // Get the synonyms for easier reading. Set it as the trait name.
             String synonym = var.getSynonyms().size() > 0 ? var.getSynonyms().get(0) : null;
-            trait.setTrait(getPrioritizedValue(synonym, var.getName()));
+            trait.setTrait(getPrioritizedValue(synonym, var.getObservationVariableName() ,var.getName())); //This will default to the Observation Variable Name if available.
 
             //v5.1.0 bugfix branch update, getPrioritizedValue can return null, trait name should never be null
             // Skip the trait if there brapi trait field isn't present
@@ -1023,6 +1098,19 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
             // We want the saving of plots and traits wrap together in a transaction
             // so if they fail, the field can be deleted.
             try {
+                int plotId = studyDetails.getAttributes().indexOf("Plot");
+
+                System.out.println("Size of study details: "+studyDetails.getValues().size());
+
+                //Need to make sure the plot values are sorted before we try to save observations.
+                List<List<String>> sortedPlotValues = studyDetails.getValues()
+                        .stream()
+                        .distinct()
+                        .sorted((plot1, plot2) -> Integer.parseInt(plot1.get(plotId)) - Integer.parseInt(plot2.get(plotId)))
+                        .collect(Collectors.toList());
+
+                System.out.println("Size of study details after sort: "+sortedPlotValues.size());
+
                 for (List<String> dataRow : studyDetails.getValues()) {
                     dataHelper.createFieldData(expId, studyDetails.getAttributes(), dataRow);
                 }
@@ -1031,6 +1119,20 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
                 for (TraitObject t : studyDetails.getTraits()) {
                     dataHelper.insertTraits(t);
                 }
+                //Leaving this in for debugging purposes
+//                for(Observation obs : studyDetails.getObservations()) {
+//                    System.out.println("****************************");
+//                    System.out.println("Saving: varName: "+obs.getVariableName());
+//                    System.out.println("Saving: value: "+obs.getValue());
+//                    System.out.println("Saving: studyId: "+obs.getStudyId());
+//                    System.out.println("Saving: unitDBId: "+obs.getUnitDbId());
+//                    System.out.println("Saving: varDbId: "+obs.getVariableDbId());
+//                    System.out.println("Saving: StudyId: "+studyDetails.getStudyDbId());
+//                    System.out.println("Saving: expId: "+expId);
+//                    TraitObject trait = ObservationVariableDao.Companion.getTraitByName(obs.getVariableName());
+////                    System.out.println("SavingL TraitId: "+trait.getId());
+//                    dataHelper.setTraitObservations(expId, obs);
+//                }
 
                 // If we haven't thrown an error by now, we are good.
                 DataHelper.db.setTransactionSuccessful();

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -1120,15 +1120,6 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
 
                 System.out.println("Size of study details: "+studyDetails.getValues().size());
 
-                //Make sure the plot values are sorted.
-                List<List<String>> sortedPlotValues = studyDetails.getValues()
-                        .stream()
-                        .distinct()
-                        .sorted((plot1, plot2) -> Integer.parseInt(plot1.get(plotId)) - Integer.parseInt(plot2.get(plotId)))
-                        .collect(Collectors.toList());
-
-                System.out.println("Size of study details after sort: "+sortedPlotValues.size());
-
                 for (List<String> dataRow : studyDetails.getValues()) {
                     dataHelper.createFieldData(expId, studyDetails.getAttributes(), dataRow);
                 }

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrapiPaginationManager.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrapiPaginationManager.java
@@ -80,8 +80,25 @@ public class BrapiPaginationManager {
         return pageSize;
     }
 
-    public void updatePageInfo(Integer totalPages) {
+    public Integer getTotalPages() { return totalPages; }
+
+    /**
+     * Function to move the paginationManager to the next page
+     */
+    public void moveToNextPage() {
+        currentPage++;
+    }
+
+    /**
+     * Function to update the total number of pages
+     * @param totalPages
+     */
+    public void updateTotalPages(Integer totalPages) {
         this.totalPages = totalPages;
+    }
+
+    public void updatePageInfo(Integer totalPages) {
+        updateTotalPages(totalPages);
         refreshPageIndicator();
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -321,6 +321,10 @@ public class DataHelper {
 //        return synced;
     }
 
+    public void setTraitObservations(Integer expId, Observation observation) {
+        ObservationDao.Companion.insertObservation(expId, observation);
+    }
+
     /**
      * Get user created trait observations for currently selected study
      */

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
@@ -272,6 +272,58 @@ class ObservationDao {
 
         } ?: -1
 
+        fun insertObservation(expId:Int, model: BrapiObservation): Int = withDatabase { db ->
+            //         * @param exp_id the field identifier
+            //         * @param plotId the unique name of the currently selected field
+            //         * @param parent the variable name of the observation
+//            val obs = getObservation("$expId", model.unitDbId,model.variableName)
+//            println("**************************")
+//            println("FAIL Season: ${obs?.season}")
+//            println("FAIL studyId: ${obs?.studyId}")
+//            println("FAIL Value: ${obs?.value}")
+//            println("FAIL unitId: ${obs?.unitDbId}")
+//            println("FAIL VariableDbId: ${obs?.variableDbId}")
+//            println("FAIL DbId: ${obs?.dbId}")
+//            println("FAIL FieldbookDbId: ${obs?.fieldbookDbId}")
+//            println("FAIL VariableName: ${obs?.variableName}")
+//            println("**************************")
+
+            if(getObservation("$expId", model.unitDbId,model.variableName)?.dbId != null)  {
+
+//                println("**************************")
+//                println("FAIL Value: ${obs?.value}")
+//                println("FAIL VariableDbId: ${obs?.variableDbId}")
+//                println("FAIL VariableName: ${obs?.variableName}")
+//                println("FAIL UnitDbId: ${obs?.unitDbId}")
+//                println("**************************")
+
+                println("DbId: ${getObservation("$expId", model.unitDbId,model.variableName)?.dbId}")
+                -1
+            }
+            else {
+                val varRowId =  db.insert(Observation.tableName, null, contentValuesOf(
+                    "observation_variable_name" to model.variableName,
+//                "observation_variable_field_book_format" to model.observation_variable_field_book_format,
+                    "observation_variable_field_book_format" to null,
+                    "value" to model.value,
+                    "observation_time_stamp" to model.timestamp,
+                    "collector" to model.collector,
+//                "geoCoordinates" to model.geo_coordinates,
+                    "geoCoordinates" to null,
+                    "last_synced_time" to model.lastSyncedTime,
+//                "additional_info" to model.additional_info,
+                    "additional_info" to null,
+//                Study.FK to model.studyId,
+                    "observation_db_id" to model.dbId,
+                    Study.FK to expId,
+                    ObservationUnit.FK to model.unitDbId,
+                    ObservationVariable.FK to model.variableDbId
+                )).toInt()
+                varRowId
+            }
+
+        } ?: -1
+
         /**
          * Should trait be observation_field_book_format?
          */

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/StudyDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/StudyDao.kt
@@ -140,6 +140,7 @@ class StudyDao {
 
             it.exp_id = this[Study.PK] as Int
             it.exp_name = this["study_name"].toString()
+            it.exp_alias = this["study_alias"].toString()
             it.unique_id = this["study_unique_id_name"].toString()
             it.primary_id = this["study_primary_id_name"].toString()
             it.secondary_id = this["study_secondary_id_name"].toString()

--- a/app/src/main/java/com/fieldbook/tracker/dialogs/BrapiSyncObsDialog.kt
+++ b/app/src/main/java/com/fieldbook/tracker/dialogs/BrapiSyncObsDialog.kt
@@ -113,34 +113,40 @@ class BrapiSyncObsDialog(context: Context) : Dialog(context) ,android.view.View.
                     StudyObservations(fieldBookStudyDbId, input.traits, mutableListOf())
                 studyObservations.merge(traitStudy)
 
-                brAPIService!!.getObservations(brapiStudyDbId, observationIds, paginationManager,
+                brAPIService!!.getObservations(brapiStudyDbId,
+                    observationIds,
+                    paginationManager,
                     { obsInput ->
                         ((context as ContextWrapper).baseContext as Activity).runOnUiThread {
                             val currentStudy =
                                 StudyObservations(fieldBookStudyDbId, mutableListOf(), obsInput)
                             studyObservations.merge(currentStudy)
 
-                            //Print out the values for debug
-                            for (obs in studyObservations.observationList) {
-                                println("***************************")
-                                println("StudyId: " + obs.studyId)
-                                println("ObsId: " + obs.dbId)
-                                println("UnitDbId: " + obs.unitDbId)
-                                println("VariableDbId: " + obs.variableDbId)
-                                println("VariableName: " + obs.variableName)
-                                println("Value: " + obs.value)
-                            }
-                            println("Done pulling observations.")
 
-                            //Once we have loaded in the observations, we can make the save button visible
-                            makeSaveBtnVisible()
+                            //Print out the values for debug
+//                                for (obs in currentStudy.observationList) {
+//                                    println("***************************")
+//                                    println("StudyId: " + obs.studyId)
+//                                    println("ObsId: " + obs.dbId)
+//                                    println("UnitDbId: " + obs.unitDbId)
+//                                    println("VariableDbId: " + obs.variableDbId)
+//                                    println("VariableName: " + obs.variableName)
+//                                    println("Value: " + obs.value)
+//                                }
+                            println("Size of ObsList: ${studyObservations.observationList.size}")
+                            println("Done pulling observations. Page: ${paginationManager.page}/${paginationManager.totalPages}")
+
+                            //Once we have loaded in all the observations, we can make the save button visible
+                            if (paginationManager.page == paginationManager.totalPages) {
+                                makeSaveBtnVisible()
+                            }
                         }
 
                         null
                     }) {
-                    println("Stopped:")
-                    null
-                }
+                        println("Stopped:")
+                        null
+                    }
 
                 null
             }) { null }

--- a/app/src/main/java/com/fieldbook/tracker/dialogs/BrapiSyncObsDialog.kt
+++ b/app/src/main/java/com/fieldbook/tracker/dialogs/BrapiSyncObsDialog.kt
@@ -102,19 +102,19 @@ class BrapiSyncObsDialog(context: Context) : Dialog(context) ,android.view.View.
         //Get the trait information first as we need to know that to associate an observation with a plot:
         brAPIService!!.getTraits(brapiStudyDbId,
             { input ->
-                val observationIds: MutableList<String> = ArrayList()
+                val observationVariableDbIds: MutableList<String> = ArrayList()
 
                 for (obj in input.traits) {
                     println("Trait:" + obj.trait)
                     println("ObsIds: " + obj.externalDbId)
-                    observationIds.add(obj.externalDbId)
+                    observationVariableDbIds.add(obj.externalDbId)
                 }
                 val traitStudy =
                     StudyObservations(fieldBookStudyDbId, input.traits, mutableListOf())
                 studyObservations.merge(traitStudy)
 
                 brAPIService!!.getObservations(brapiStudyDbId,
-                    observationIds,
+                    observationVariableDbIds,
                     paginationManager,
                     { obsInput ->
                         ((context as ContextWrapper).baseContext as Activity).runOnUiThread {
@@ -181,7 +181,6 @@ class BrapiSyncObsDialog(context: Context) : Dialog(context) ,android.view.View.
 internal class ImportRunnableTask(val context: Context, val studyObservations: StudyObservations) : AsyncTask<Int, Int, Int>() {
 
     var dialog: ProgressDialog? = null
-    var brapiControllerResponse: BrapiControllerResponse? = null
     var fail = false
     var failMessage = ""
 

--- a/app/src/main/java/com/fieldbook/tracker/dialogs/BrapiSyncObsDialog.kt
+++ b/app/src/main/java/com/fieldbook/tracker/dialogs/BrapiSyncObsDialog.kt
@@ -1,0 +1,251 @@
+package com.fieldbook.tracker.dialogs
+
+import android.app.Activity
+import android.app.Dialog
+import android.app.ProgressDialog
+import android.content.Context
+import android.content.ContextWrapper
+import android.os.AsyncTask
+import android.os.Bundle
+import android.os.Handler
+import android.text.Html
+import android.view.View
+import android.view.Window
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import com.fieldbook.tracker.R
+import com.fieldbook.tracker.brapi.BrapiControllerResponse
+import com.fieldbook.tracker.brapi.model.Observation
+import com.fieldbook.tracker.brapi.service.BrAPIService
+import com.fieldbook.tracker.brapi.service.BrAPIServiceFactory
+import com.fieldbook.tracker.brapi.service.BrapiPaginationManager
+import com.fieldbook.tracker.database.DataHelper
+import com.fieldbook.tracker.objects.FieldObject
+import com.fieldbook.tracker.objects.TraitObject
+import com.fieldbook.tracker.preferences.GeneralKeys
+import com.fieldbook.tracker.utilities.DialogUtils
+
+data class StudyObservations(var fieldBookStudyDbId:Int=0, val traitList: MutableList<TraitObject> = mutableListOf(), val observationList: MutableList<Observation> = mutableListOf()) {
+    fun merge(newStudy: StudyObservations) {
+        fieldBookStudyDbId = newStudy.fieldBookStudyDbId
+        traitList.addAll(newStudy.traitList)
+        observationList.addAll(newStudy.observationList)
+    }
+}
+
+class BrapiSyncObsDialog(context: Context) : Dialog(context) ,android.view.View.OnClickListener {
+    private var saveBtn: Button? = null
+    private var brAPIService: BrAPIService? = null
+
+    private var studyObservations = StudyObservations()
+
+    lateinit var paginationManager: BrapiPaginationManager
+
+    lateinit var selectedField: FieldObject
+    lateinit var fieldNameLbl: TextView
+
+    // Creates a new thread to do importing
+    private val importRunnable =
+        Runnable { ImportRunnableTask(context,studyObservations).execute(0) }
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setCanceledOnTouchOutside(false)
+        requestWindowFeature(Window.FEATURE_NO_TITLE)
+        setContentView(R.layout.dialog_brapi_sync_observations)
+        brAPIService = BrAPIServiceFactory.getBrAPIService(this.context)
+        val pageSize = context.getSharedPreferences("Settings", 0)
+            .getString(GeneralKeys.BRAPI_PAGE_SIZE, "1000")!!.toInt()
+        paginationManager = BrapiPaginationManager(0, pageSize)
+        saveBtn = findViewById(R.id.brapi_save_btn)
+        saveBtn!!.setOnClickListener(this)
+        fieldNameLbl = findViewById(R.id.studyNameValue)
+        val cancelBtn = findViewById<Button>(R.id.brapi_cancel_btn)
+        cancelBtn.setOnClickListener(this)
+    }
+
+    fun setFieldObject(fieldObject: FieldObject) {
+        this.selectedField = fieldObject
+    }
+
+    override fun onStart() {
+        // Set our OK button to be disabled until we are finished loading
+        saveBtn!!.visibility = View.GONE
+
+        fieldNameLbl.text = selectedField.exp_name
+
+        //need to call the load code
+        loadObservations(selectedField)
+    }
+
+    override fun onClick(v: View) {
+        println("Clicked: ${v.id}")
+        when (v.id) {
+            R.id.brapi_save_btn -> saveObservations()
+            R.id.brapi_cancel_btn -> dismiss()
+            else -> {}
+        }
+        dismiss()
+    }
+
+    /**
+     * Function to load the observations from a specific study
+     */
+    private fun loadObservations(study: FieldObject) {
+        val brapiStudyDbId = study.exp_alias
+        val fieldBookStudyDbId = study.exp_id
+        val brAPIService = BrAPIServiceFactory.getBrAPIService(this.context)
+
+
+        //Get the trait information first as we need to know that to associate an observation with a plot:
+        brAPIService!!.getTraits(brapiStudyDbId,
+            { input ->
+                val observationIds: MutableList<String> = ArrayList()
+
+                for (obj in input.traits) {
+                    println("Trait:" + obj.trait)
+                    println("ObsIds: " + obj.externalDbId)
+                    observationIds.add(obj.externalDbId)
+                }
+                val traitStudy =
+                    StudyObservations(fieldBookStudyDbId, input.traits, mutableListOf())
+                studyObservations.merge(traitStudy)
+
+                brAPIService!!.getObservations(brapiStudyDbId, observationIds, paginationManager,
+                    { obsInput ->
+                        ((context as ContextWrapper).baseContext as Activity).runOnUiThread {
+                            val currentStudy =
+                                StudyObservations(fieldBookStudyDbId, mutableListOf(), obsInput)
+                            studyObservations.merge(currentStudy)
+
+                            //Print out the values for debug
+                            for (obs in studyObservations.observationList) {
+                                println("***************************")
+                                println("StudyId: " + obs.studyId)
+                                println("ObsId: " + obs.dbId)
+                                println("UnitDbId: " + obs.unitDbId)
+                                println("VariableDbId: " + obs.variableDbId)
+                                println("VariableName: " + obs.variableName)
+                                println("Value: " + obs.value)
+                            }
+                            println("Done pulling observations.")
+
+                            //Once we have loaded in the observations, we can make the save button visible
+                            makeSaveBtnVisible()
+                        }
+
+                        null
+                    }) {
+                    println("Stopped:")
+                    null
+                }
+
+                null
+            }) { null }
+
+    }
+
+    /**
+     * Function to unhide the save button
+     */
+    fun makeSaveBtnVisible() {
+        //populate the description fields
+        (findViewById<View>(R.id.numberTraitsValue) as TextView).text =
+            "${studyObservations.traitList.size}"
+        (findViewById<View>(R.id.numberObsValue) as TextView).text =
+            "${studyObservations.observationList.size}"
+
+        findViewById<View>(R.id.loadingPanel).visibility = View.GONE
+        saveBtn!!.visibility = View.VISIBLE
+    }
+
+    fun saveObservations() {
+        // Dismiss this dialog
+        dismiss()
+
+        // Run saving task in the background so we can showing progress dialog
+        val mHandler = Handler()
+        mHandler.post(importRunnable)
+    }
+}
+// Mimics the class used in the csv field importer to run the saving
+// task in a different thread from the UI thread so the app doesn't freeze up.
+internal class ImportRunnableTask(val context: Context, val studyObservations: StudyObservations) : AsyncTask<Int, Int, Int>() {
+
+    var dialog: ProgressDialog? = null
+    var brapiControllerResponse: BrapiControllerResponse? = null
+    var fail = false
+    var failMessage = ""
+
+    override fun onPreExecute() {
+        super.onPreExecute()
+        dialog = ProgressDialog(context)
+        dialog!!.isIndeterminate = true
+        dialog!!.setCancelable(false)
+        dialog!!.setMessage(Html.fromHtml(context.resources.getString(R.string.import_dialog_importing)))
+        dialog!!.show()
+    }
+
+    override fun doInBackground(vararg params: Int?): Int? {
+
+        println("numObs: ${studyObservations.observationList.size}")
+        println("dbId: ${studyObservations.fieldBookStudyDbId}")
+        val dataHelper = DataHelper(context)
+
+        try {
+            //Sync the traits first
+            for (trait in studyObservations.traitList) {
+                dataHelper.insertTraits(trait)
+            }
+        }
+        catch (exc: Exception) {
+            fail = true
+            failMessage = exc?.message?:"ERROR"
+            return null
+        }
+
+        try {
+            //Sorting here to only save the most recently taken observation if it is not already in the DB
+            val observationList =
+                studyObservations.observationList.sortedByDescending { it.timestamp }
+
+            //Then sync the observations
+            for (obs in observationList) {
+                //Leaving this here for debugging purposes
+//            println("****************************")
+//            println("Saving: varName: " + obs.variableName)
+//            println("Saving: value: " + obs.value)
+//            println("Saving: studyId: " + obs.studyId)
+//            println("Saving: unitDBId: " + obs.unitDbId)
+//            println("Saving: varDbId: " + obs.variableDbId)
+                dataHelper.setTraitObservations(studyObservations.fieldBookStudyDbId, obs)
+            }
+            return 0
+        }
+        catch (exc: Exception) {
+            fail = true
+            failMessage = exc?.message?:"ERROR"
+            return null
+        }
+
+    }
+
+
+    override fun onPostExecute(result: Int) {
+        if (dialog!!.isShowing) dialog!!.dismiss()
+        if(fail) {
+            val alertDialogBuilder = AlertDialog.Builder(context)
+            alertDialogBuilder.setTitle(R.string.dialog_save_error_title)
+                .setPositiveButton(R.string.dialog_ok) { dialogInterface, i ->
+                    // Finish our BrAPI import activity
+                    (context as Activity).finish()
+                }
+            alertDialogBuilder.setMessage(failMessage)
+            val alertDialog = alertDialogBuilder.create()
+            alertDialog.show()
+            DialogUtils.styleDialogs(alertDialog)
+        }
+    }
+}

--- a/app/src/main/res/layout/dialog_brapi_sync_observations.xml
+++ b/app/src/main/res/layout/dialog_brapi_sync_observations.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="#FFFFFF"
+    android:orientation="vertical"
+    android:paddingLeft="20dp"
+    android:paddingTop="5dp"
+    android:paddingRight="20dp"
+    android:paddingBottom="5dp">
+
+
+
+
+    <TextView
+        android:id="@+id/studyNameLbl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingLeft="10dp"
+        android:paddingTop="5dp"
+        android:paddingBottom="10dp"
+        android:text="@string/brapi_obs_header_name"
+        android:textColor="#000000"
+        android:textSize="@dimen/text_size_medium"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/studyNameValue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="15dip"
+        android:paddingLeft="10dp"
+        android:paddingBottom="10dp"
+        android:textColor="#000000"
+        android:textSize="@dimen/text_size_medium"
+        android:textStyle="bold" />
+
+    <RelativeLayout
+        android:id="@+id/loadingPanel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="0"
+        android:gravity="center">
+
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true" />
+    </RelativeLayout>
+
+    <TextView
+        android:id="@+id/studyDescriptionLbl"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingLeft="10dp"
+        android:paddingBottom="5dp"
+        android:text="@string/brapi_study_description"
+        android:textColor="#000000"
+        android:textSize="@dimen/text_size_large"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal" >
+        <TextView
+            android:id="@+id/numberTraitsLbl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="10dp"
+            android:paddingBottom="5dp"
+            android:text="@string/number_traits_label"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_medium"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/numberTraitsValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="15dip"
+            android:paddingLeft="10dp"
+            android:paddingBottom="10dp"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_medium"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal" >
+        <TextView
+            android:id="@+id/numberObsLbl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="10dp"
+            android:paddingBottom="5dp"
+            android:text="@string/number_observation_label"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_medium"
+            android:textStyle="bold" />
+        <TextView
+            android:id="@+id/numberObsValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="15dip"
+            android:paddingLeft="10dp"
+            android:paddingBottom="10dp"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_medium"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/brapi_save_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:minWidth="@dimen/button_default_width"
+            android:onClick="dialogButtonClicked"
+            android:text="@string/dialog_save"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_large"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/brapi_cancel_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:minWidth="@dimen/button_default_width"
+            android:onClick="dialogButtonClicked"
+            android:text="@string/dialog_cancel"
+            android:textColor="#000000"
+            android:textSize="@dimen/text_size_large"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/menu/menu_field_listitem.xml
+++ b/app/src/main/res/menu/menu_field_listitem.xml
@@ -5,6 +5,9 @@
         android:id="@+id/sort"
         android:title="@string/fields_sort_update" />
     <item
+        android:id="@+id/syncObs"
+        android:title="@string/brapi_obs_sync_menu_name" />
+    <item
         android:id="@+id/delete"
         android:title="@string/fields_delete" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -562,6 +562,10 @@
     <string name="brapi_error_saving_all_traits">Error saving traits. No traits were saved.</string>
     <string name="brapi_error_saving_some_traits">Error saving some traits. Some traits were not saved</string>
     <string name="brapi_traits_saved_success">Selected traits saved successfully.</string>
+    <string name="brapi_obs_sync_menu_name">Sync Observations</string>
+    <string name="brapi_obs_header_name">Downloading Observations for Study:</string>
+    <string name="number_traits_label">Number of Traits:</string>
+    <string name="number_observation_label">Number of Observations:</string>
     <string name="device_offline_warning">Device Offline: Please connect to a network and try again</string>
     <string name="next">Next</string>
     <string name="prev">Prev</string>


### PR DESCRIPTION
# Description

This Pull Request will allow the user to pull down existing Observations for a BrAPI study.  This is not done automatically, but rather through a Dialog that is completely optional.  This allows for users to update fields on devices depending on what was scored on different devices

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

I have tested this for test fields stored in Breedbase pulling down ~150 observations for both BrAPI v1 and v2.  I have also tested the pagination by setting pageSize to 10 and pulling down the same study.


**Test Configuration**:
* Motorola G series phones from 2020-2022
* SDK: Recent versions of Android, unknown exactly.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
