### PR TITLE
Bug 512 added ability to import obs. vars. that already have FB formats defined

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -942,18 +942,52 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
         return sb.toString();
     }
 
+    /**
+     * @param dataType
+     * @return
+     */
     private String convertBrAPIDataType(String dataType) {
         //TODO: Check these out and make sure they match with fieldbook data types.
         switch (dataType) {
             case "Nominal":
-            case "Ordinal": // All Field Book categories are ordered, so this works
+            case "Ordinal":
+            case "categorical":
+            case "qualitative":
+                // All Field Book categories are ordered, so this works
                 return "categorical";
+            case "date":
             case "Date":
                 return "date";
             case "Numerical":
             case "Duration":
+            case "numeric":
                 return "numeric";
-            case "Code": // Not the ideal solution for this conversion
+            case "rust rating":
+            case "disease rating":
+                return "disease rating";
+            case "percent":
+                return "percent";
+            case "boolean":
+                return "boolean";
+            case "photo":
+                return "photo";
+            case "audio":
+                return "audio";
+            case "counter":
+                return "counter";
+            case "multicat":
+                return "multicat";
+            case "location":
+                return "location";
+            case "barcode":
+                return "barcode";
+            case "gnss":
+                return "gnss";
+            case "zebra label print":
+                return "zebra label print";
+            case "usb camera":
+                return "usb camera";
+            case "Code":
             case "Text":
             default:
                 return "text";

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -936,18 +936,51 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
         return sb.toString();
     }
 
+    /**
+     * @param dataType
+     * @return
+     */
     private String convertBrAPIDataType(String dataType) {
         //TODO: Check these out and make sure they match with fieldbook data types.
         switch (dataType) {
             case "Nominal":
             case "Ordinal":
+            case "categorical":
+            case "qualitative":
                 // All Field Book categories are ordered, so this works
                 return "categorical";
+            case "date":
             case "Date":
                 return "date";
             case "Numerical":
             case "Duration":
+            case "numeric":
                 return "numeric";
+            case "rust rating":
+            case "disease rating":
+                return "disease rating";
+            case "percent":
+                return "percent";
+            case "boolean":
+                return "boolean";
+            case "photo":
+                return "photo";
+            case "audio":
+                return "audio";
+            case "counter":
+                return "counter";
+            case "multicat":
+                return "multicat";
+            case "location":
+                return "location";
+            case "barcode":
+                return "barcode";
+            case "gnss":
+                return "gnss";
+            case "zebra label print":
+                return "zebra label print";
+            case "usb camera":
+                return "usb camera";
             case "Code":
             case "Text":
             default:


### PR DESCRIPTION
Added more trait format options when importing obs. vars. from brapi now the user can have obs. vars. with field book trait formats, instead of having to edit them after import.

# Description

Updated convert brapi data type function in v1 and v2 to allow for fieldbook trait formats to be used.

Fixes #512 
