### PR TITLE
Adding in no observation warning message For Observation Syncing

### DIFF
--- a/app/src/main/res/layout/dialog_brapi_sync_observations.xml
+++ b/app/src/main/res/layout/dialog_brapi_sync_observations.xml
@@ -116,6 +116,22 @@
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:orientation="horizontal" >
+        <TextView
+            android:id="@+id/noObservationLbl"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingLeft="10dp"
+            android:paddingBottom="5dp"
+            android:text="@string/no_observations_warning"
+            android:textColor="#FF0000"
+            android:textSize="@dimen/text_size_xlarge"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
         android:orientation="horizontal">
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -507,6 +507,7 @@
     <string name="brapi_obs_header_name">Downloading Observations for Study:</string>
     <string name="number_traits_label">Number of Traits:</string>
     <string name="number_observation_label">Number of Observations:</string>
+    <string name="no_observations_warning">No Observations Found For Study.  Please Tap Cancel.</string>
     <string name="device_offline_warning">Device Offline: Please connect to a network and try again</string>
     <string name="next">Next</string>
     <string name="prev">Prev</string>


### PR DESCRIPTION

## Description

This addresses user not knowing when the brapi call is done as discussed in  issue #648.  The Syncing code will now throw up a warning message if something either happens during collecting the pages or if there are no observations found when downloading the observations.  This was internally tested with both a new field and a field which has observations within it and it works in both cases.



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
Added in a warning message and removed the loading spinner when Fieldbook is done pulling Observations when there are no observations currently associated with the field.
```