### PR TITLE
autosave final trait category during new trait creation

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/dialogs/NewTraitDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/dialogs/NewTraitDialog.java
@@ -152,23 +152,26 @@ public class NewTraitDialog extends DialogFragment implements CategoryAdapter.Ca
 
         addCategoryButton.setOnClickListener((v) -> {
             String value = categoryValueEt.getText().toString();
-            if (!value.isEmpty()) {
-
-                ArrayList<String> values = new ArrayList<>();
-                for (BrAPIScaleValidValuesCategories s : catList) {
-                    values.add(s.getValue());
-                }
-
-                if (!values.contains(value)) {
-                    BrAPIScaleValidValuesCategories scale = new BrAPIScaleValidValuesCategories();
-                    scale.setLabel(value);
-                    scale.setValue(value);
-                    catList.add(scale);
-                    categoryValueEt.setText("");
-                    updateCatAdapter();
-                }
-            }
+            addCategory(value);
+            categoryValueEt.setText("");
         });
+    }
+
+    private void addCategory(String value) {
+        if (!value.isEmpty()) {
+            ArrayList<String> values = new ArrayList<>();
+            for (BrAPIScaleValidValuesCategories s : catList) {
+                values.add(s.getValue());
+            }
+
+            if (!values.contains(value)) {
+                BrAPIScaleValidValuesCategories scale = new BrAPIScaleValidValuesCategories();
+                scale.setLabel(value);
+                scale.setValue(value);
+                catList.add(scale);
+                updateCatAdapter();
+            }
+        }
     }
 
     private void updateCatAdapter() {
@@ -368,7 +371,11 @@ public class NewTraitDialog extends DialogFragment implements CategoryAdapter.Ca
         t.setMinimum(minimum.getText().toString());
         t.setMaximum(maximum.getText().toString());
         t.setDetails(details.getText().toString());
-        //t.setCategories(categoryLabelEt.getText().toString());
+        String finalCat = categoryValueEt.getText().toString();
+        if (!finalCat.isEmpty()) {
+            addCategory(finalCat);
+            categoryValueEt.setText("");
+        }
 
         try {
 


### PR DESCRIPTION
## Description

_Provide a summary of your changes including motivation and context.
If these changes fix a bug or resolves a feature request, be sure to link to that issue._

Refactors new trait category addition, so addition method can be run a final time on trait save even if add button is not clicked.

Closes #572

## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
autosave final trait category during new trait creation
```