### PR TITLE
Bms integration fix

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -206,7 +206,7 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
 
                         // This is BMS specific. Remove the traits that are not part of the selected Observation Level.
                         // To ensure that only relevant traits are included in the imported study/field.
-                        studyDetails.getTraits().removeIf(t -> !t.getObservationLevelNames().contains(selectedObservationLevel.getObservationLevelName()));
+                        studyDetails.getTraits().removeIf(t -> t.getObservationLevelNames() != null && !t.getObservationLevelNames().contains(selectedObservationLevel.getObservationLevelName()));
 
                         loadStudy();
                         // Check if user should save yet

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -203,6 +203,11 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
                     @Override
                     public void run() {
                         BrapiStudyDetails.merge(studyDetails, study);
+
+                        // This is BMS specific. Remove the traits that are not part of the selected Observation Level.
+                        // To ensure that only relevant traits are included in the imported study/field.
+                        studyDetails.getTraits().removeIf(t -> !t.getObservationLevelNames().contains(selectedObservationLevel.getObservationLevelName()));
+
                         loadStudy();
                         // Check if user should save yet
                         traitLoadStatus = true;

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiLoadDialog.java
@@ -206,7 +206,8 @@ public class BrapiLoadDialog extends Dialog implements android.view.View.OnClick
 
                         // This is BMS specific. Remove the traits that are not part of the selected Observation Level.
                         // To ensure that only relevant traits are included in the imported study/field.
-                        studyDetails.getTraits().removeIf(t -> t.getObservationLevelNames() != null && !t.getObservationLevelNames().contains(selectedObservationLevel.getObservationLevelName()));
+                        studyDetails.getTraits().removeIf(t -> t.getObservationLevelNames() != null &&
+                                t.getObservationLevelNames().stream().noneMatch(s -> s.equalsIgnoreCase(selectedObservationLevel.getObservationLevelName())));
 
                         loadStudy();
                         // Check if user should save yet

--- a/app/src/main/java/com/fieldbook/tracker/objects/TraitObject.java
+++ b/app/src/main/java/com/fieldbook/tracker/objects/TraitObject.java
@@ -4,6 +4,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import java.util.List;
+
 /**
  * Simple wrapper class for trait data
  */
@@ -21,6 +23,12 @@ public class TraitObject {
     private String externalDbId;
     private String traitDataSource;
     private String additionalInfo;
+
+    /**
+     * This is a BMS specific field. This will be populated when traits are imported from
+     * the BMS implementation of Brapi 2.0 GET /variables.
+     */
+    private List<String> observationLevelNames;
 
     public String getTrait() {
         return trait;
@@ -124,6 +132,14 @@ public class TraitObject {
 
     public void setAdditionalInfo(String additionalInfo) {
         this.additionalInfo = additionalInfo;
+    }
+
+    public List<String> getObservationLevelNames() {
+        return observationLevelNames;
+    }
+
+    public void setObservationLevelNames(List<String> observationLevelNames) {
+        this.observationLevelNames = observationLevelNames;
     }
 
     public boolean isValidValue(final String s) {


### PR DESCRIPTION
## Description

This is a short-term solution for [684](https://github.com/PhenoApps/Field-Book/discussions/684).

This code change will handle observationLevelNames metadata in additionalInfo (e.g., {"observationLevelNames": ["plot", "plant"]}) for BrAPI GET 2.x variables (BMS specific). This metadata helps identify the level(s) at which a variable is utilized within a study/field. The information will be utilized to filter the variables based on the selected Observation Level during BrAPI Field Import, ensuring that only relevant variables will be added.

## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
Fix BRAPI 2.0 integration with BMS. Only variables (traits) relevant to the selected observation level during BrAPI Field Import will be added automatically.
```