### PR TITLE
adds preference to return to first trait

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -1988,6 +1988,10 @@ public class CollectActivity extends ThemedActivity
         return ep.getBoolean(GeneralKeys.CYCLING_TRAITS_ADVANCES, false);
     }
 
+    public boolean isReturnFirstTrait() {
+        return ep.getBoolean(GeneralKeys.RETURN_FIRST_TRAIT, false);
+    }
+
     /**
      * Inserts a user observation whenever a label is printed.
      * See ResultReceiver onReceiveResult in LabelPrintLayout

--- a/app/src/main/java/com/fieldbook/tracker/interfaces/CollectRangeController.kt
+++ b/app/src/main/java/com/fieldbook/tracker/interfaces/CollectRangeController.kt
@@ -8,6 +8,7 @@ interface CollectRangeController: CollectController {
     fun cancelAndFinish()
     fun callFinish()
     fun refreshMain()
+    fun isReturnFirstTrait(): Boolean
     fun getNonExistingTraits(plotIndex: Int): List<Int>
     fun existsAllTraits(traitIndex: Int, plotIndex: Int): Int
     fun existsTrait(plotIndex: Int): Boolean

--- a/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
@@ -31,6 +31,7 @@ public class GeneralKeys {
     public static final String RETURN_CHARACTER                     = "RETURN_CHARACTER";
     public static final String VOLUME_NAVIGATION                    = "VOLUME_NAVIGATION";
     public static final String CYCLING_TRAITS_ADVANCES              = "CycleTraits";
+    public static final String RETURN_FIRST_TRAIT              = "ReturnFirst";
     public static final String DISABLE_ENTRY_ARROW_NO_DATA          = "DISABLE_ENTRY_ARROW_NO_DATA";
 
     // General

--- a/app/src/main/java/com/fieldbook/tracker/views/RangeBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/RangeBoxView.kt
@@ -567,6 +567,7 @@ class RangeBoxView : ConstraintLayout {
         } else {
             if (rangeID.isNotEmpty()) {
                 //index.setEnabled(true);
+                // In addtion to advancing the entry, return to the first trait in the trait order if the preference is enabled
                 if (controller.isReturnFirstTrait()) {
                     traitBox.returnFirst()
                 }

--- a/app/src/main/java/com/fieldbook/tracker/views/RangeBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/RangeBoxView.kt
@@ -552,6 +552,7 @@ class RangeBoxView : ConstraintLayout {
     }
 
     fun moveEntryRight() {
+        val traitBox = controller.getTraitBox()
         if (!controller.validateData()) {
             return
         }
@@ -561,11 +562,14 @@ class RangeBoxView : ConstraintLayout {
         }
         val entryArrow =
             controller.getPreferences().getString(GeneralKeys.DISABLE_ENTRY_ARROW_NO_DATA, "0")
-        if ((entryArrow == "2" || entryArrow == "3") && !controller.getTraitBox().existsTrait()) {
+        if ((entryArrow == "2" || entryArrow == "3") && !traitBox.existsTrait()) {
             controller.getSoundHelper().playError()
         } else {
             if (rangeID.isNotEmpty()) {
                 //index.setEnabled(true);
+                if (controller.isReturnFirstTrait()) {
+                    traitBox.returnFirst()
+                }
                 paging = incrementPaging(paging)
                 controller.refreshMain()
             }

--- a/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
@@ -346,6 +346,18 @@ class TraitBoxView : ConstraintLayout {
         controller.getCollectInputView().resetInitialIndex()
     }
 
+    fun returnFirst() {
+        if (!controller.validateData()) {
+            return
+        }
+        if (controller.getPreferences().getBoolean(GeneralKeys.CYCLE_TRAITS_SOUND, false)) {
+            controller.getSoundHelper().playCycle()
+        }
+        traitType.setSelection(0)
+        controller.refreshLock()
+        controller.getCollectInputView().resetInitialIndex()
+    }
+
     fun update(parent: String?, value: String) {
         if (newTraits.containsKey(parent!!)) {
             newTraits.remove(parent)

--- a/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
@@ -347,14 +347,10 @@ class TraitBoxView : ConstraintLayout {
     }
 
     fun returnFirst() {
-        if (!controller.validateData()) {
-            return
-        }
         if (controller.getPreferences().getBoolean(GeneralKeys.CYCLE_TRAITS_SOUND, false)) {
             controller.getSoundHelper().playCycle()
         }
         traitType.setSelection(0)
-        controller.refreshLock()
         controller.getCollectInputView().resetInitialIndex()
     }
 

--- a/app/src/main/res/drawable/ic_adv_return_first_trait.xml
+++ b/app/src/main/res/drawable/ic_adv_return_first_trait.xml
@@ -1,0 +1,1 @@
+<!-- drawable/ray_start_arrow.xml --><vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:width="24dp" android:viewportWidth="24" android:viewportHeight="24"><path android:fillColor="#000000" android:pathData="M23,12L19,16V13H6.83C6.42,14.17 5.31,15 4,15A3,3 0 0,1 1,12A3,3 0 0,1 4,9C5.31,9 6.42,9.83 6.83,11H19V8L23,12Z" /></vector>

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -9,6 +9,7 @@
         <new>Search selections persist</new>
         <new>Updates available from About</new>
         <new>Added Vietnamese and Swedish translations</new>
+        <new>Added option to return to first trait on entry navigation</new>
         <info>Merged barcode and text unique ID search setting</info>
         <info>Numerous GeoNav improvements</info>
         <info>Merged duplicate settings</info>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -587,6 +587,9 @@
     <string name="preferences_behavior_cycle_traits">Cycling traits advances entry</string>
     <string name="preferences_behavior_cycle_traits_description">After going through all traits, Field Book goes to the next entry</string>
 
+    <string name="preferences_behavior_return_to_first_trait">Advancing entry returns to first trait</string>
+    <string name="preferences_behavior_return_to_first_trait_description">When moving to the next entry, Field Book also returns to the first trait</string>
+
     <string name="preferences_behavior_volume_buttons_navigate">Map volume keys to entry navigation</string>
     <string name="preferences_behavior_volume_buttons_navigate_description">Volume keys go to next or previous entry</string>
 

--- a/app/src/main/res/xml/preferences_behavior.xml
+++ b/app/src/main/res/xml/preferences_behavior.xml
@@ -11,6 +11,13 @@
 
     <CheckBoxPreference
         android:defaultValue="false"
+        android:icon="@drawable/ic_adv_return_first_trait"
+        android:key="ReturnFirst"
+        android:summary="@string/preferences_behavior_return_to_first_trait_description"
+        android:title="@string/preferences_behavior_return_to_first_trait" />
+
+    <CheckBoxPreference
+        android:defaultValue="false"
         android:icon="@drawable/ic_remap_volume_buttons"
         android:key="VOLUME_NAVIGATION"
         android:summary="@string/preferences_behavior_volume_buttons_navigate_description"


### PR DESCRIPTION
## Description

_Provide a summary of your changes including motivation and context.
If these changes fix a bug or resolves a feature request, be sure to link to that issue._



## Type of change

Adds preference that returns traitbox to first trait when entry is advanced
closes #722

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
Added a behavior option to return to first trait when entry is advanced.
```