### PR TITLE
bugfix loading old categorical observation values

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/utilities/CategoryJsonUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/CategoryJsonUtil.kt
@@ -20,13 +20,17 @@ class CategoryJsonUtil {
         }
 
         fun decode(json: String): ArrayList<BrAPIScaleValidValuesCategories> {
-            return if (json == "NA") arrayListOf(BrAPIScaleValidValuesCategories().apply {
-                label = json
-                value = json
-            }) else Gson().fromJson(
-                json,
-                object : TypeToken<List<BrAPIScaleValidValuesCategories?>>() {}.type
-            )
+            return try {
+                Gson().fromJson(
+                    json,
+                    object : TypeToken<List<BrAPIScaleValidValuesCategories?>>() {}.type
+                )
+            } catch (e: Exception) {
+                arrayListOf(BrAPIScaleValidValuesCategories().apply {
+                    label = json
+                    value = json
+                })
+            }
         }
 
         /**


### PR DESCRIPTION
## Description

Bugfix for old string values for categorical traits not being parsed correctly.


## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
Bugfix loading old categorical observation values
```