### PR TITLE
barcode readers send zero-byte unicode string 

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/traits/TextTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/TextTraitLayout.kt
@@ -41,12 +41,15 @@ class TextTraitLayout : BaseTraitLayout {
 
             val value = en.toString()
 
-            triggerTts(value)
+            //check that the string is not all zero-byte which usb barcode readers send at end
+            if (!value.toByteArray().all { it.toInt() == 0 }) {
 
-            collectInputView.text = value
+                triggerTts(value)
 
-            updateObservation(currentTrait, value)
+                collectInputView.text = value
 
+                updateObservation(currentTrait, value)
+            }
         }
 
         override fun beforeTextChanged(
@@ -101,7 +104,7 @@ class TextTraitLayout : BaseTraitLayout {
                         controller.getTraitBox().moveTrait("right")
                     }
 
-                    ""
+                    scan
 
                 }
             } else if (event.action == KeyEvent.ACTION_UP


### PR DESCRIPTION
some barcode readers send zero-byte unicode string at end of scan which was causing the observation value to be updated to empty fixes #813

## Description

_Provide a summary of your changes including motivation and context.
If these changes fix a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
Fix for barcode readers not scanning barcode correctly.
```