### PR TITLE
Don't select all data for Text traits

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/traits/TextTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/TextTraitLayout.kt
@@ -128,7 +128,6 @@ class TextTraitLayout : BaseTraitLayout {
         inputEditText?.removeTextChangedListener(textWatcher)
         super.loadLayout()
         inputEditText?.isEnabled = !isLocked
-        inputEditText?.selectAll()
     }
 
     override fun afterLoadExists(act: CollectActivity, value: String?) {
@@ -181,7 +180,6 @@ class TextTraitLayout : BaseTraitLayout {
         if (currentObservation != null) {
             inputEditText?.setText(currentObservation.value)
             inputEditText?.setSelection(currentObservation.value.length)
-            inputEditText?.selectAll()
         }
         selectEditText()
     }


### PR DESCRIPTION
feat: don't select all text for text traits, before it was selecting/highlighting the existing data

## Description

_Provide a summary of your changes including motivation and context.
If these changes fix a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
Text trait data is not automatically selected anymore.
```