### PR TITLE
bugfix for text traits not entering digits correctly

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/traits/TextTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/TextTraitLayout.kt
@@ -84,6 +84,10 @@ class TextTraitLayout : BaseTraitLayout {
 
         inputEditText?.setOnKeyListener { _, code, event ->
 
+            if (inputEditText?.text?.toString() != scan) {
+                scan = inputEditText?.text?.toString() ?: ""
+            }
+
             if (event.keyCode == KeyEvent.KEYCODE_BACK) {
 
                 (context as CollectActivity).onBackPressed()
@@ -95,10 +99,24 @@ class TextTraitLayout : BaseTraitLayout {
 
                 scan = if (code != KeyEvent.KEYCODE_ENTER && event.unicodeChar != 10) {
 
-                    val newScan = "$scan${event.unicodeChar.toChar()}"
+                    val newScan = if (code == KeyEvent.KEYCODE_DEL) {
+
+                        scan.dropLast(1)
+
+                    } else {
+
+                        "$scan${event.unicodeChar.toChar()}"
+
+                    }
 
                     //set text for current trait/plot
                     inputEditText?.setText(newScan)
+
+                    inputEditText?.text?.toString()?.let { x ->
+
+                        inputEditText?.setSelection(x.length)
+
+                    }
 
                     newScan
 
@@ -144,6 +162,7 @@ class TextTraitLayout : BaseTraitLayout {
             input.setText(value ?: "")
             input.setSelection(value?.length ?: 0)
             input.setTextColor(Color.parseColor(displayColor))
+            scan = input.text.toString()
         }
 
         selectEditText()
@@ -156,6 +175,7 @@ class TextTraitLayout : BaseTraitLayout {
             input.setText("")
             input.setSelection(0)
             input.setTextColor(Color.BLACK)
+            scan = ""
         }
 
         selectEditText()


### PR DESCRIPTION
## Description

Fixed issue, tested on Boox and Pixel 6. Also tested USB barcode scanner to make sure it was still functional.



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
Bugfix for entering digits in a text trait on some keyboards
```