### PR TITLE
save last used res file to open on longpress

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -203,6 +203,7 @@ public class CollectActivity extends ThemedActivity
      * Main screen elements
      */
     private Menu systemMenu;
+    private Toolbar toolbar;
     private InfoBarAdapter infoBarAdapter;
     private TraitBoxView traitBox;
     private RangeBoxView rangeBox;
@@ -632,7 +633,7 @@ public class CollectActivity extends ThemedActivity
     }
 
     private void initToolbars() {
-        Toolbar toolbar = findViewById(R.id.toolbar);
+        toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
         Toolbar toolbarBottom = findViewById(R.id.toolbarBottom);
@@ -1247,6 +1248,44 @@ public class CollectActivity extends ThemedActivity
     }
 
     @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus) { // Ensure the menu item view is already created before setting longpress listener
+            toolbar.post(() -> setupLongPressListener());
+        }
+    }
+
+    private void setupLongPressListener() {
+        final View menuItemView = toolbar.findViewById(R.id.resources);
+        if (menuItemView != null) {
+            menuItemView.setOnLongClickListener(v -> {
+                openSavedResourceFile();
+                return true;
+            });
+        }
+    }
+
+    private void openSavedResourceFile() {
+        String fileString = preferences.getString(GeneralKeys.LAST_USED_RESOURCE_FILE, "");
+        if (!fileString.isEmpty()) {
+            try {
+                Uri resultUri = Uri.parse(fileString);
+                String suffix = fileString.substring(fileString.lastIndexOf('.') + 1).toLowerCase();
+                String mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(suffix);
+
+                Intent open = new Intent(Intent.ACTION_VIEW);
+                open.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                open.setDataAndType(resultUri, mime);
+                startActivity(open);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        } else {
+            Toast.makeText(this, "No file preference saved, select a file with a short press", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    @Override
     protected void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
     }
@@ -1781,17 +1820,17 @@ public class CollectActivity extends ThemedActivity
             case REQUEST_FILE_EXPLORER_CODE:
                 if (resultCode == RESULT_OK) {
                     try {
-
                         String resultString = data.getStringExtra(FileExploreActivity.EXTRA_RESULT_KEY);
+                        //save most recently used resource file
+                        preferences.edit().putString(GeneralKeys.LAST_USED_RESOURCE_FILE, resultString).apply();
+
                         Uri resultUri = Uri.parse(resultString);
-
                         String suffix = resultString.substring(resultString.lastIndexOf('.') + 1).toLowerCase();
-
                         String mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(suffix);
+
                         Intent open = new Intent(Intent.ACTION_VIEW);
                         open.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                         open.setDataAndType(resultUri, mime);
-
                         startActivity(open);
                     } catch (Exception e) {
                         e.printStackTrace();

--- a/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
@@ -129,6 +129,7 @@ public class GeneralKeys {
     public static final String TRAITS_EXPORTED = "TraitsExported";
     public static final String ALL_TRAITS_VISIBLE = "allTraitsVisible";
     public static final String LAST_USED_TRAIT = "com.fieldbook.tracker.LAST_USED_TRAIT";
+    public static final String LAST_USED_RESOURCE_FILE = "com.fieldbook.tracker.LAST_USED_RESOURCE_FILE";
 
     //themes
     public static final String SAVED_DATA_COLOR = "SAVED_DATA_COLOR";


### PR DESCRIPTION
## Description

_Provide a summary of your changes including motivation and context.
If these changes fix a bug or resolves a feature request, be sure to link to that issue._

Adds handler to skip the filepicker and directly open the last used resource file when the resource file icon is longpressed
closes #921

## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
longpress on resource file icon directly opens last used file
```