### PR TITLE
Fixing Observation Syncing to use internal DB ids instead of trait names

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -19,6 +19,9 @@ import com.fieldbook.tracker.brapi.model.BrapiTrial;
 import com.fieldbook.tracker.brapi.model.FieldBookImage;
 import com.fieldbook.tracker.brapi.model.Observation;
 import com.fieldbook.tracker.database.DataHelper;
+import com.fieldbook.tracker.database.dao.ObservationUnitDao;
+import com.fieldbook.tracker.database.dao.ObservationVariableDao;
+import com.fieldbook.tracker.database.models.ObservationUnitModel;
 import com.fieldbook.tracker.objects.FieldObject;
 import com.fieldbook.tracker.objects.TraitObject;
 import com.fieldbook.tracker.preferences.GeneralKeys;
@@ -662,8 +665,12 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
                 public void onSuccess(ObservationsResponse response, int i, Map<String, List<String>> map) {
 
                     paginationManager.updateTotalPages(response.getMetadata().getPagination().getTotalPages());
+
+                    Map<String,String> extVariableDbIdMap = getExtVariableDbIdMapping();
+                    Map<String,String> extUnitDbIdMap = getExtUnitDbIdMapping();
+
                     List<io.swagger.client.model.Observation> brapiObservationList = response.getResult().getData();
-                    final List<Observation> observationList = mapObservations(brapiObservationList);
+                    final List<Observation> observationList = mapObservations(brapiObservationList, extVariableDbIdMap, extUnitDbIdMap);
 
                     function.apply(observationList);
 
@@ -697,6 +704,25 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
         }
     }
 
+    private Map<String,String> getExtVariableDbIdMapping() {
+        String[] traitNames = ObservationVariableDao.Companion.getAllTraits();
+        Map<String,String> externalIdToInternalMap = new HashMap<>();
+        for(String trait : traitNames) {
+            TraitObject traitObject = ObservationVariableDao.Companion.getTraitByName(trait);
+            externalIdToInternalMap.put(traitObject.getExternalDbId(), traitObject.getId());
+        }
+        return externalIdToInternalMap;
+    }
+
+    private Map<String,String> getExtUnitDbIdMapping(){
+        ObservationUnitModel[] observationUnits = ObservationUnitDao.Companion.getAll();
+        Map<String, String> externalIdToInternalMap = new HashMap<>();
+        for(ObservationUnitModel model : observationUnits) {
+            externalIdToInternalMap.put(model.getObservation_unit_db_id(),String.valueOf(model.getInternal_id_observation_unit()));
+        }
+        return externalIdToInternalMap;
+    }
+
     private Observation mapToObservation(NewObservationDbIdsObservations obs){
         Observation newObservation = new Observation();
         newObservation.setDbId(obs.getObservationDbId());
@@ -710,22 +736,31 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
      * @param brapiObservationList
      * @return list of Fieldbook Observation objects
      */
-    private List<Observation> mapObservations(List<io.swagger.client.model.Observation> brapiObservationList) {
+    private List<Observation> mapObservations(List<io.swagger.client.model.Observation> brapiObservationList, Map<String,String> extVariableDbIdMap, Map<String,String> extUnitDbIdMap) {
         List<Observation> outputList = new ArrayList<>();
         for(io.swagger.client.model.Observation brapiObservation : brapiObservationList) {
             Observation newObservation = new Observation();
 
+            newObservation.setStudyId(brapiObservation.getStudyDbId());
+
             newObservation.setVariableName(brapiObservation.getObservationVariableName());
             newObservation.setDbId(brapiObservation.getObservationDbId());
+            String internalUnitId = extUnitDbIdMap.get(brapiObservation.getObservationUnitDbId());
+
             newObservation.setUnitDbId(brapiObservation.getObservationUnitDbId());
-            newObservation.setVariableDbId(brapiObservation.getObservationVariableDbId());
+            //need to get out the internal observation variable DB ID or else we will store the wrong thing in the table
+            String internalVarId = extVariableDbIdMap.get(brapiObservation.getObservationVariableDbId());
+            newObservation.setVariableDbId(internalVarId);
             newObservation.setValue(brapiObservation.getValue());
 
             //TODO Uncomment once the time stamp is working correctly.
 //            newObservation.setTimestamp(brapiObservation.getObservationTimeStamp());
 
-            outputList.add(newObservation);
-
+            //Make sure we are on the right experiment level.
+            // This will cause bugs if there have been plot and plant level traits found as the observations retrieves all of them
+            if(internalUnitId != null) {
+                outputList.add(newObservation);
+            }
         }
         return outputList;
     }
@@ -888,6 +923,7 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
     private Pair<List<TraitObject>, Integer> mapTraits(List<ObservationVariable> variables) throws JSONException {
         List<TraitObject> traits = new ArrayList<>();
         int variablesMissingTrait = 0;
+        int positionCount = 1;
         for (ObservationVariable var : variables) {
 
             TraitObject trait = new TraitObject();
@@ -955,8 +991,8 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
 
             // Set some config variables in fieldbook
             trait.setVisible(true);
-            trait.setRealPosition(0);
-
+            trait.setRealPosition(positionCount);
+            positionCount++;
             traits.add(trait);
         }
 

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV1.java
@@ -705,11 +705,11 @@ public class BrAPIServiceV1 extends AbstractBrAPIService implements BrAPIService
     }
 
     private Map<String,String> getExtVariableDbIdMapping() {
-        String[] traitNames = ObservationVariableDao.Companion.getAllTraits();
+        List<TraitObject> traits = ObservationVariableDao.Companion.getAllTraitObjects();
         Map<String,String> externalIdToInternalMap = new HashMap<>();
-        for(String trait : traitNames) {
-            TraitObject traitObject = ObservationVariableDao.Companion.getTraitByName(trait);
-            externalIdToInternalMap.put(traitObject.getExternalDbId(), traitObject.getId());
+        for(TraitObject trait : traits) {
+            String dbId = trait.getId();
+            externalIdToInternalMap.put(trait.getExternalDbId(),dbId);
         }
         return externalIdToInternalMap;
     }

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -18,6 +18,10 @@ import com.fieldbook.tracker.brapi.model.BrapiTrial;
 import com.fieldbook.tracker.brapi.model.FieldBookImage;
 import com.fieldbook.tracker.brapi.model.Observation;
 import com.fieldbook.tracker.database.DataHelper;
+import com.fieldbook.tracker.database.dao.ObservationUnitDao;
+import com.fieldbook.tracker.database.dao.ObservationVariableDao;
+import com.fieldbook.tracker.database.models.ObservationUnitModel;
+import com.fieldbook.tracker.database.models.ObservationVariableModel;
 import com.fieldbook.tracker.objects.FieldObject;
 import com.fieldbook.tracker.objects.TraitObject;
 import com.fieldbook.tracker.preferences.GeneralKeys;
@@ -664,9 +668,11 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
 
                     if (response.getResult() != null) {
 
+                        Map<String,String> extVariableDbIdMap = getExtVariableDbIdMapping();
+                        Map<String,String> extUnitDbIdMap = getExtUnitDbIdMapping();
                         // Result contains a list of observation variables
                         List<BrAPIObservation> brapiObservationList = response.getResult().getData();
-                        final List<Observation> observationList = mapObservations(brapiObservationList);
+                        final List<Observation> observationList = mapObservations(brapiObservationList, extVariableDbIdMap, extUnitDbIdMap);
 
                         function.apply(observationList);
 
@@ -722,6 +728,25 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
         }
     }
 
+    private Map<String,String> getExtVariableDbIdMapping() {
+        String[] traitNames = ObservationVariableDao.Companion.getAllTraits();
+        Map<String,String> externalIdToInternalMap = new HashMap<>();
+        for(String trait : traitNames) {
+            TraitObject traitObject = ObservationVariableDao.Companion.getTraitByName(trait);
+            externalIdToInternalMap.put(traitObject.getExternalDbId(), traitObject.getId());
+        }
+        return externalIdToInternalMap;
+    }
+
+    private Map<String,String> getExtUnitDbIdMapping(){
+        ObservationUnitModel[] observationUnits = ObservationUnitDao.Companion.getAll();
+        Map<String, String> externalIdToInternalMap = new HashMap<>();
+        for(ObservationUnitModel model : observationUnits) {
+            externalIdToInternalMap.put(model.getObservation_unit_db_id(),String.valueOf(model.getInternal_id_observation_unit()));
+        }
+        return externalIdToInternalMap;
+    }
+
     private Observation mapToObservation(BrAPIObservation obs){
         Observation newObservation = new Observation();
         newObservation.setDbId(obs.getObservationDbId());
@@ -751,18 +776,28 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
      * @param brapiObservationList
      * @return list of Fieldbook Observation objects
      */
-    private List<Observation> mapObservations(List<BrAPIObservation> brapiObservationList) {
+    private List<Observation> mapObservations(List<BrAPIObservation> brapiObservationList,Map<String,String> extVariableDbIdMap, Map<String,String> extUnitDbIdMap) {
         List<Observation> outputList = new ArrayList<>();
         for(BrAPIObservation brapiObservation : brapiObservationList) {
             Observation newObservation = new Observation();
 
+            newObservation.setStudyId(brapiObservation.getStudyDbId());
+
             newObservation.setVariableName(brapiObservation.getObservationVariableName());
             newObservation.setDbId(brapiObservation.getObservationDbId());
+            String internalUnitId = extUnitDbIdMap.get(brapiObservation.getObservationUnitDbId());
+
             newObservation.setUnitDbId(brapiObservation.getObservationUnitDbId());
-            newObservation.setVariableDbId(brapiObservation.getObservationVariableDbId());
+            //need to get out the internal observation variable DB ID or else we will store the wrong thing in the table
+            String internalVarId = extVariableDbIdMap.get(brapiObservation.getObservationVariableDbId());
+            newObservation.setVariableDbId(internalVarId);
             newObservation.setValue(brapiObservation.getValue());
 
-            outputList.add(newObservation);
+            //Make sure we are on the right experiment level.
+            // This will cause bugs if there have been plot and plant level traits found as the observations retrieves all of them
+            if(internalUnitId != null) {
+                outputList.add(newObservation);
+            }
 
         }
         return outputList;
@@ -955,6 +990,7 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
     private Pair<List<TraitObject>, Integer> mapTraits(List<BrAPIObservationVariable> variables) throws JSONException {
         List<TraitObject> traits = new ArrayList<>();
         int variablesMissingTrait = 0;
+        int positionCount = 1;
         for (BrAPIObservationVariable var : variables) {
 
             TraitObject trait = new TraitObject();
@@ -1035,7 +1071,8 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
 
             // Set some config variables in fieldbook
             trait.setVisible(true);
-            trait.setRealPosition(0);
+            trait.setRealPosition(positionCount);
+            positionCount++;
 
             traits.add(trait);
         }

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -729,11 +729,11 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
     }
 
     private Map<String,String> getExtVariableDbIdMapping() {
-        String[] traitNames = ObservationVariableDao.Companion.getAllTraits();
+        List<TraitObject> traits = ObservationVariableDao.Companion.getAllTraitObjects();
         Map<String,String> externalIdToInternalMap = new HashMap<>();
-        for(String trait : traitNames) {
-            TraitObject traitObject = ObservationVariableDao.Companion.getTraitByName(trait);
-            externalIdToInternalMap.put(traitObject.getExternalDbId(), traitObject.getId());
+        for(TraitObject trait : traits) {
+            String dbId = trait.getId();
+            externalIdToInternalMap.put(trait.getExternalDbId(),dbId);
         }
         return externalIdToInternalMap;
     }

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -56,6 +56,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -422,8 +423,8 @@ public class DataHelper {
 //        return synced;
     }
 
-    public void setTraitObservations(Integer studyId, Observation observation) {
-        ObservationDao.Companion.insertObservation(studyId, observation);
+    public void setTraitObservations(Integer studyId, Observation observation, Map<String,String> traitIdToTypeMap) {
+        ObservationDao.Companion.insertObservation(studyId, observation, traitIdToTypeMap);
     }
 
     /**

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
@@ -12,6 +12,7 @@ import com.fieldbook.tracker.database.Migrator.*
 import com.fieldbook.tracker.database.Migrator.Companion.sLocalImageObservationsViewName
 import com.fieldbook.tracker.database.Migrator.Companion.sNonImageObservationsViewName
 import com.fieldbook.tracker.database.Migrator.Companion.sRemoteImageObservationsViewName
+import com.fieldbook.tracker.database.dao.ObservationVariableDao.Companion.getTraitByName
 import com.fieldbook.tracker.database.models.ObservationModel
 import com.fieldbook.tracker.utilities.CategoryJsonUtil
 import org.threeten.bp.OffsetDateTime
@@ -376,31 +377,9 @@ class ObservationDao {
 
         } ?: -1
 
-        fun insertObservation(studyId: Int, model: BrapiObservation): Int = withDatabase { db ->
-            //         * @param exp_id the field identifier
-            //         * @param plotId the unique name of the currently selected field
-            //         * @param parent the variable name of the observation
-//            val obs = getObservation("$expId", model.unitDbId,model.variableName)
-//            println("**************************")
-//            println("FAIL Season: ${obs?.season}")
-//            println("FAIL studyId: ${obs?.studyId}")
-//            println("FAIL Value: ${obs?.value}")
-//            println("FAIL unitId: ${obs?.unitDbId}")
-//            println("FAIL VariableDbId: ${obs?.variableDbId}")
-//            println("FAIL DbId: ${obs?.dbId}")
-//            println("FAIL FieldbookDbId: ${obs?.fieldbookDbId}")
-//            println("FAIL VariableName: ${obs?.variableName}")
-//            println("**************************")
+        fun insertObservation(studyId: Int, model: BrapiObservation, traitIdToTypeMap:Map<String,String>): Int = withDatabase { db ->
 
             if (getObservation("$studyId", model.unitDbId, model.variableDbId, "1")?.dbId != null) {
-
-//                println("**************************")
-//                println("FAIL Value: ${obs?.value}")
-//                println("FAIL VariableDbId: ${obs?.variableDbId}")
-//                println("FAIL VariableName: ${obs?.variableName}")
-//                println("FAIL UnitDbId: ${obs?.unitDbId}")
-//                println("**************************")
-
                 println(
                     "DbId: ${
                         getObservation(
@@ -414,10 +393,11 @@ class ObservationDao {
                 -1
             }
             else {
+                //get observationVariableFieldbookformat based on the variableName
+                val variableFormat = traitIdToTypeMap[model.variableDbId]?:ObservationVariableDao.Companion.getTraitByName(model.variableName)!!.format
                 val varRowId =  db.insert(Observation.tableName, null, contentValuesOf(
                     "observation_variable_name" to model.variableName,
-//                "observation_variable_field_book_format" to model.observation_variable_field_book_format,
-                    "observation_variable_field_book_format" to null,
+                    "observation_variable_field_book_format" to variableFormat,
                     "value" to model.value,
                     "observation_time_stamp" to model.timestamp,
                     "collector" to model.collector,
@@ -426,8 +406,8 @@ class ObservationDao {
                     "last_synced_time" to model.lastSyncedTime,
 //                "additional_info" to model.additional_info,
                     "additional_info" to null,
-//                Study.FK to model.studyId,
                     "observation_db_id" to model.dbId,
+                    "rep" to "1",
                     Study.FK to studyId,
                     ObservationUnit.FK to model.unitDbId,
                     ObservationVariable.FK to model.variableDbId

--- a/app/src/test/java/BrapiServiceTest.java
+++ b/app/src/test/java/BrapiServiceTest.java
@@ -649,7 +649,7 @@ public class BrapiServiceTest {
         final FieldBookImage[] postImageMetaDataResponse = {null};
         final CountDownLatch signal = new CountDownLatch(1);
 
-        FieldBookImage image = new FieldBookImage(context, "/path/test.jpg", Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888));
+        FieldBookImage image = new FieldBookImage(context, "/path/test.jpg","" ,Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888));
         image.setUnitDbId(ouDbId);
         image.setTimestamp(OffsetDateTime.now());
 


### PR DESCRIPTION
## Description

_Provide a summary of your changes including motivation and context.
If these changes fix a bug or resolves a feature request, be sure to link to that issue._

Fixing Observation Syncing to properly link the observations with the traits and plots based on internal ids instead of by names.

## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
Fixed a bug causing the Observation Syncing to do nothing.
```