### PR TITLE
Ux enhancements - explanatory info on lock and language changes

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -321,9 +321,6 @@ public class CollectActivity extends ThemedActivity
         checkForInitialBarcodeSearch();
 
         verifyPersonHelper.checkLastOpened();
-
-        View overlay = findViewById(R.id.lockOverlay);
-        overlay.setOnClickListener(v -> Toast.makeText(this, R.string.activity_collect_locked_state, Toast.LENGTH_SHORT).show());
     }
 
     public void triggerTts(String text) {
@@ -1670,7 +1667,7 @@ public class CollectActivity extends ThemedActivity
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_lock_clock);
             if (collectInputView.getText().isEmpty()) {
                 enableDataEntry();
-            } else disableDataEntry();
+            } else freezeDataEntry();
         }
 
         TraitObject trait = getCurrentTrait();
@@ -1690,24 +1687,32 @@ public class CollectActivity extends ThemedActivity
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_lock_clock);
             if (collectInputView.getText().isEmpty()) {
                 enableDataEntry();
-            } else disableDataEntry();
+            } else freezeDataEntry();
         }
     }
 
     private void enableDataEntry() {
-        missingValue.setEnabled(true);
-        deleteValue.setEnabled(true);
-        barcodeInput.setEnabled(true);
-        traitLayouts.enableViews();
+//        missingValue.setEnabled(true);
+//        deleteValue.setEnabled(true);
+//        barcodeInput.setEnabled(true);
+//        traitLayouts.enableViews();
         findViewById(R.id.lockOverlay).setVisibility(View.GONE);
     }
 
     private void disableDataEntry() {
-        missingValue.setEnabled(false);
-        deleteValue.setEnabled(false);
-        barcodeInput.setEnabled(false);
-        traitLayouts.disableViews();
-        findViewById(R.id.lockOverlay).setVisibility(View.VISIBLE);
+//        missingValue.setEnabled(false);
+//        deleteValue.setEnabled(false);
+//        barcodeInput.setEnabled(false);
+//        traitLayouts.disableViews();
+        View overlay = findViewById(R.id.lockOverlay);
+        overlay.setOnClickListener(v -> Toast.makeText(this, R.string.activity_collect_locked_state, Toast.LENGTH_SHORT).show());
+        overlay.setVisibility(View.VISIBLE);
+    }
+
+    private void freezeDataEntry() {
+        View overlay = findViewById(R.id.lockOverlay);
+        overlay.setOnClickListener(v -> Toast.makeText(this, R.string.activity_collect_frozen_state, Toast.LENGTH_SHORT).show());
+        overlay.setVisibility(View.VISIBLE);
     }
 
     private void moveToPlotID() {

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -29,7 +29,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.ListView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -409,7 +408,7 @@ public class CollectActivity extends ThemedActivity
 
                     } else {
 
-                        Toast.makeText(this, getString(R.string.act_collect_plot_with_code_not_found), Toast.LENGTH_LONG).show();
+                        Utils.makeToast(getApplicationContext(), getString(R.string.act_collect_plot_with_code_not_found));
 
                     }
                 }
@@ -836,7 +835,7 @@ public class CollectActivity extends ThemedActivity
         }
 
         if (!command.equals("quickgoto") && !command.equals("barcode"))
-            Utils.makeToast(getApplicationContext(), getString(R.string.main_toolbar_moveto_no_match));
+            Utils.makeToast(this, getString(R.string.main_toolbar_moveto_no_match));
 
         return false;
     }
@@ -1185,7 +1184,7 @@ public class CollectActivity extends ThemedActivity
     }
 
     private void brapiDelete(String parent, Boolean hint) {
-        Toast.makeText(getApplicationContext(), getString(R.string.brapi_delete_message), Toast.LENGTH_LONG).show();
+        Utils.makeToast(this, getString(R.string.brapi_delete_message));
         TraitObject trait = traitBox.getCurrentTrait();
         updateObservation(trait, getString(R.string.brapi_na), null);
         if (hint) {
@@ -1291,7 +1290,7 @@ public class CollectActivity extends ThemedActivity
                 e.printStackTrace();
             }
         } else {
-            Toast.makeText(this, "No file preference saved, select a file with a short press", Toast.LENGTH_SHORT).show();
+            Utils.makeToast(this, "No file preference saved, select a file with a short press");
         }
     }
 
@@ -1404,15 +1403,15 @@ public class CollectActivity extends ThemedActivity
         } else if (itemId == lockDataId) {
             if (dataLocked == UNLOCKED) {
                 dataLocked = LOCKED;
-                Toast.makeText(this, R.string.activity_collect_locked_state, Toast.LENGTH_SHORT).show();
+                Utils.makeToast(this, getString(R.string.activity_collect_locked_state));
             }
             else if (dataLocked == LOCKED) {
                 dataLocked = FROZEN;
-                Toast.makeText(this, R.string.activity_collect_frozen_state, Toast.LENGTH_SHORT).show();
+                Utils.makeToast(this, getString(R.string.activity_collect_frozen_state));
             }
             else {
                 dataLocked = UNLOCKED;
-                Toast.makeText(this, R.string.activity_collect_unlocked_state, Toast.LENGTH_SHORT).show();
+                Utils.makeToast(this, getString(R.string.activity_collect_unlocked_state));
             }
             preferences.edit().putInt(GeneralKeys.DATA_LOCK_STATE, dataLocked).apply();
             lockData();
@@ -1458,35 +1457,23 @@ public class CollectActivity extends ThemedActivity
 
             // if trait audio is recording, give a warning
             if (isTraitAudioRecording) {
-                Toast.makeText(
-                        this, R.string.trait_audio_recording_warning,
-                        Toast.LENGTH_SHORT
-                ).show();
+                Utils.makeToast(this, getString(R.string.trait_audio_recording_warning));
             }
             // if trait audio is playing, give a warning
             else if (isTraitAudioPlaying) {
-                Toast.makeText(
-                        this, R.string.trait_audio_playing_warning,
-                        Toast.LENGTH_SHORT
-                ).show();
+                Utils.makeToast(this, getString(R.string.trait_audio_playing_warning));
             }
             // if trait audio isn't recording or playing
             // record or stop the field audio depending on its state
             else if (!fieldAudioHelper.isRecording()) {
                 // TODO: add trait audio playback stopping logic
                 fieldAudioHelper.startRecording(true);
-                Toast.makeText(
-                        this, R.string.field_audio_recording_start,
-                        Toast.LENGTH_SHORT
-                ).show();
+                Utils.makeToast(this, getString(R.string.field_audio_recording_start));
                 micItem.setIcon(R.drawable.ic_tb_field_mic_on);
                 micItem.setTitle(R.string.menu_collect_stop_field_audio);
             } else {
                 fieldAudioHelper.stopRecording();
-                Toast.makeText(
-                        this, R.string.field_audio_recording_stop,
-                        Toast.LENGTH_SHORT
-                ).show();
+                Utils.makeToast(this, getString(R.string.field_audio_recording_stop));
                 micItem.setIcon(R.drawable.ic_tb_field_mic_off);
                 micItem.setTitle(R.string.menu_collect_start_field_audio);
             }
@@ -1588,7 +1575,7 @@ public class CollectActivity extends ThemedActivity
             }
         } else {
 
-            Toast.makeText(this, R.string.dialog_multi_measure_delete_no_observations, Toast.LENGTH_SHORT).show();
+            Utils.makeToast(this, getString(R.string.dialog_multi_measure_delete_no_observations));
 
         }
     }
@@ -1707,7 +1694,7 @@ public class CollectActivity extends ThemedActivity
         View overlay = findViewById(R.id.lockOverlay);
         overlay.setOnClickListener((v) -> {
             getSoundHelper().playError();
-            Toast.makeText(this, toastMessageId, Toast.LENGTH_SHORT).show();
+            Utils.makeToast(this, getString(toastMessageId));
         });
         overlay.setVisibility(View.VISIBLE);
     }
@@ -1863,7 +1850,7 @@ public class CollectActivity extends ThemedActivity
                     }
 
                 } else {
-                    Toast.makeText(this, R.string.act_file_explorer_no_file_error, Toast.LENGTH_SHORT).show();
+                    Utils.makeToast(this, getString(R.string.act_file_explorer_no_file_error));
                 }
                 break;
             case 2:

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -1659,7 +1659,7 @@ public class CollectActivity extends ThemedActivity
 
         if (state == LOCKED) {
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_tb_lock);
-            disableDataEntry();
+            disableDataEntry(R.string.activity_collect_locked_state);
         } else if (state == UNLOCKED) {
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_tb_unlock);
             enableDataEntry();
@@ -1667,7 +1667,7 @@ public class CollectActivity extends ThemedActivity
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_lock_clock);
             if (collectInputView.getText().isEmpty()) {
                 enableDataEntry();
-            } else freezeDataEntry();
+            } else disableDataEntry(R.string.activity_collect_frozen_state);
         }
 
         TraitObject trait = getCurrentTrait();
@@ -1679,7 +1679,7 @@ public class CollectActivity extends ThemedActivity
     public void traitLockData() {
         if (dataLocked == LOCKED) {
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_tb_lock);
-            disableDataEntry();
+            disableDataEntry(R.string.activity_collect_locked_state);
         } else if (dataLocked == UNLOCKED) {
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_tb_unlock);
             enableDataEntry();
@@ -1687,7 +1687,7 @@ public class CollectActivity extends ThemedActivity
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_lock_clock);
             if (collectInputView.getText().isEmpty()) {
                 enableDataEntry();
-            } else freezeDataEntry();
+            } else disableDataEntry(R.string.activity_collect_frozen_state);
         }
     }
 
@@ -1699,19 +1699,16 @@ public class CollectActivity extends ThemedActivity
         findViewById(R.id.lockOverlay).setVisibility(View.GONE);
     }
 
-    private void disableDataEntry() {
+    private void disableDataEntry(int toastMessageId) {
 //        missingValue.setEnabled(false);
 //        deleteValue.setEnabled(false);
 //        barcodeInput.setEnabled(false);
 //        traitLayouts.disableViews();
         View overlay = findViewById(R.id.lockOverlay);
-        overlay.setOnClickListener(v -> Toast.makeText(this, R.string.activity_collect_locked_state, Toast.LENGTH_SHORT).show());
-        overlay.setVisibility(View.VISIBLE);
-    }
-
-    private void freezeDataEntry() {
-        View overlay = findViewById(R.id.lockOverlay);
-        overlay.setOnClickListener(v -> Toast.makeText(this, R.string.activity_collect_frozen_state, Toast.LENGTH_SHORT).show());
+        overlay.setOnClickListener((v) -> {
+            getSoundHelper().playError();
+            Toast.makeText(this, toastMessageId, Toast.LENGTH_SHORT).show();
+        });
         overlay.setVisibility(View.VISIBLE);
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -321,6 +321,9 @@ public class CollectActivity extends ThemedActivity
         checkForInitialBarcodeSearch();
 
         verifyPersonHelper.checkLastOpened();
+
+        View overlay = findViewById(R.id.lockOverlay);
+        overlay.setOnClickListener(v -> Toast.makeText(this, R.string.activity_collect_locked_state, Toast.LENGTH_SHORT).show());
     }
 
     public void triggerTts(String text) {
@@ -1402,9 +1405,18 @@ public class CollectActivity extends ThemedActivity
             i.putExtra("trait", traitBox.getCurrentTrait().getRealPosition());
             startActivityForResult(i, 2);
         } else if (itemId == lockDataId) {
-            if (dataLocked == UNLOCKED) dataLocked = LOCKED;
-            else if (dataLocked == LOCKED) dataLocked = FROZEN;
-            else dataLocked = UNLOCKED;
+            if (dataLocked == UNLOCKED) {
+                dataLocked = LOCKED;
+                Toast.makeText(this, R.string.activity_collect_locked_state, Toast.LENGTH_SHORT).show();
+            }
+            else if (dataLocked == LOCKED) {
+                dataLocked = FROZEN;
+                Toast.makeText(this, R.string.activity_collect_frozen_state, Toast.LENGTH_SHORT).show();
+            }
+            else {
+                dataLocked = UNLOCKED;
+                Toast.makeText(this, R.string.activity_collect_unlocked_state, Toast.LENGTH_SHORT).show();
+            }
             preferences.edit().putInt(GeneralKeys.DATA_LOCK_STATE, dataLocked).apply();
             lockData();
         } else if (itemId == android.R.id.home) {
@@ -1687,6 +1699,7 @@ public class CollectActivity extends ThemedActivity
         deleteValue.setEnabled(true);
         barcodeInput.setEnabled(true);
         traitLayouts.enableViews();
+        findViewById(R.id.lockOverlay).setVisibility(View.GONE);
     }
 
     private void disableDataEntry() {
@@ -1694,6 +1707,7 @@ public class CollectActivity extends ThemedActivity
         deleteValue.setEnabled(false);
         barcodeInput.setEnabled(false);
         traitLayouts.disableViews();
+        findViewById(R.id.lockOverlay).setVisibility(View.VISIBLE);
     }
 
     private void moveToPlotID() {

--- a/app/src/main/java/com/fieldbook/tracker/preferences/LanguagePreferenceFragment.kt
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/LanguagePreferenceFragment.kt
@@ -1,7 +1,9 @@
 package com.fieldbook.tracker.preferences
 
+import android.app.AlertDialog
 import android.content.res.Resources
 import android.os.Bundle
+import android.util.Log
 import androidx.core.os.ConfigurationCompat
 import androidx.fragment.app.FragmentManager
 import androidx.preference.Preference
@@ -33,35 +35,34 @@ class LanguagePreferenceFragment : PreferenceFragmentCompat(), Preference.OnPref
      * Also update the app language using app compat.
      */
     override fun onPreferenceClick(preference: Preference): Boolean {
-
         try {
-
             context?.let { ctx ->
-
                 var id = preference.key
-
+                if (preference.key == "com.fieldbook.tracker.preference.language.default") {
+                    id = ConfigurationCompat.getLocales(Resources.getSystem().configuration)[0]?.language ?: "en-US"
+                }
+                Log.d("LanguagePrefFragment", "Switching language to: $id")
                 with (PreferenceManager.getDefaultSharedPreferences(ctx)) {
-
-                    if (preference.key == "com.fieldbook.tracker.preference.language.default") {
-
-                        id = ConfigurationCompat.getLocales(Resources.getSystem().configuration).get(0)?.language
-
-                    }
-
                     edit().putString(GeneralKeys.LANGUAGE_LOCALE_ID, id).apply()
                     edit().putString(GeneralKeys.LANGUAGE_LOCALE_SUMMARY, preference.title.toString()).apply()
+                }
 
-                    AppLanguageUtil.refreshAppText(context)
+                AlertDialog.Builder(ctx, R.style.AppAlertDialog).apply {
+                    setTitle(context.getString(R.string.dialog_warning))
+                    setMessage(context.getString(R.string.preference_language_warning))
+                    setPositiveButton(context.getString(android.R.string.ok)) { dialog, _ ->
+                        AppLanguageUtil.refreshAppText(ctx)
+                        dialog.dismiss()
+                        parentFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+                    }
+                    setCancelable(false)
+                    show()
                 }
             }
-
         } catch (e: Exception) {
-
             e.printStackTrace()
-
+            Log.e("LanguagePreference", "Error in onPreferenceClick: ${e.message}")
         }
-
-        parentFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
 
         return true
     }

--- a/app/src/main/java/com/fieldbook/tracker/traits/CategoricalTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/CategoricalTraitLayout.java
@@ -184,59 +184,56 @@ public class CategoricalTraitLayout extends BaseTraitLayout {
         layoutManager.setAlignItems(AlignItems.STRETCH);
         gridMultiCat.setLayoutManager(layoutManager);
 
-        if (!((CollectActivity) getContext()).isDataLocked()) {
+        gridMultiCat.setAdapter(new CategoryTraitAdapter(getContext()) {
 
-            gridMultiCat.setAdapter(new CategoryTraitAdapter(getContext()) {
+            @Override
+            public void onBindViewHolder(CategoryTraitViewHolder holder, int position) {
+                holder.bindTo();
 
-                @Override
-                public void onBindViewHolder(CategoryTraitViewHolder holder, int position) {
-                    holder.bindTo();
+                //get the label for this position
+                BrAPIScaleValidValuesCategories pair = cats.get(position);
 
-                    //get the label for this position
-                    BrAPIScaleValidValuesCategories pair = cats.get(position);
+                //update button with the preference based text
+                if (labelValPref.equals("value")) {
 
-                    //update button with the preference based text
-                    if (labelValPref.equals("value")) {
+                    holder.mButton.setText(pair.getValue());
 
-                        holder.mButton.setText(pair.getValue());
+                } else {
 
-                    } else {
+                    holder.mButton.setText(pair.getLabel());
 
-                        holder.mButton.setText(pair.getLabel());
-
-                    }
-
-                    //set the buttons tag to the json, when clicked this is updated in db
-                    holder.mButton.setTag(pair);
-                    holder.mButton.setOnClickListener(createClickListener(holder.mButton, position));
-
-                    //update the button's state if this category is selected
-                    String currentText = getCollectInputView().getText();
-
-                    if (labelValPref.equals("value")) {
-
-                        if (currentText.equals(pair.getValue())) {
-
-                            pressOnButton(holder.mButton);
-
-                        } else pressOffButton(holder.mButton);
-
-                    } else {
-
-                        if (currentText.equals(pair.getLabel())) {
-
-                            pressOnButton(holder.mButton);
-
-                        } else pressOffButton(holder.mButton);
-                    }
                 }
 
-                @Override
-                public int getItemCount() {
-                    return cats.size();
+                //set the buttons tag to the json, when clicked this is updated in db
+                holder.mButton.setTag(pair);
+                holder.mButton.setOnClickListener(createClickListener(holder.mButton, position));
+
+                //update the button's state if this category is selected
+                String currentText = getCollectInputView().getText();
+
+                if (labelValPref.equals("value")) {
+
+                    if (currentText.equals(pair.getValue())) {
+
+                        pressOnButton(holder.mButton);
+
+                    } else pressOffButton(holder.mButton);
+
+                } else {
+
+                    if (currentText.equals(pair.getLabel())) {
+
+                        pressOnButton(holder.mButton);
+
+                    } else pressOffButton(holder.mButton);
                 }
-            });
-        }
+            }
+
+            @Override
+            public int getItemCount() {
+                return cats.size();
+            }
+        });
 
         gridMultiCat.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override

--- a/app/src/main/java/com/fieldbook/tracker/traits/LayoutCollections.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/LayoutCollections.java
@@ -58,31 +58,33 @@ public class LayoutCollections {
         getTraitLayout(format).setNaTraitsText();
     }
 
-    public void enableViews() {
-        for (LinearLayout traitLayout : traitLayouts) {
-            enableViews(true, traitLayout);
-        }
-    }
-
-    public void disableViews() {
-        for (BaseTraitLayout traitLayout : traitLayouts) {
-            String type = traitLayout.type();
-            if (!type.equals("photo") && !type.equals("audio") && !type.equals("percent"))
-                enableViews(false, traitLayout);
-        }
-    }
-
-    public void enableViews(Boolean toggle, ViewGroup layout) {
-        layout.setEnabled(false);
-        for (int i = 0; i < layout.getChildCount(); i++) {
-            View child = layout.getChildAt(i);
-            if (child instanceof ViewGroup) {
-                enableViews(toggle, (ViewGroup) child);
-            } else {
-                child.setEnabled(toggle);
-            }
-        }
-    }
+//    Deprecated - simpler to disable/enable data collection using lockOverlay instead
+//
+//    public void enableViews() {
+//        for (LinearLayout traitLayout : traitLayouts) {
+//            enableViews(true, traitLayout);
+//        }
+//    }
+//
+//    public void disableViews() {
+//        for (BaseTraitLayout traitLayout : traitLayouts) {
+//            String type = traitLayout.type();
+//            if (!type.equals("photo") && !type.equals("audio") && !type.equals("percent"))
+//                enableViews(false, traitLayout);
+//        }
+//    }
+//
+//    public void enableViews(Boolean toggle, ViewGroup layout) {
+//        layout.setEnabled(false);
+//        for (int i = 0; i < layout.getChildCount(); i++) {
+//            View child = layout.getChildAt(i);
+//            if (child instanceof ViewGroup) {
+//                enableViews(toggle, (ViewGroup) child);
+//            } else {
+//                child.setEnabled(toggle);
+//            }
+//        }
+//    }
 
     public void registerAllReceivers() {
         for (BaseTraitLayout layout : this.traitLayouts) {

--- a/app/src/main/java/com/fieldbook/tracker/traits/MultiCatTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/MultiCatTraitLayout.java
@@ -112,11 +112,7 @@ public class MultiCatTraitLayout extends BaseTraitLayout {
 
         if (value != null && value.equals("NA")) controller.getInputView().setText("NA");
 
-        if (!((CollectActivity) getContext()).isDataLocked()) {
-
-            setAdapter();
-
-        }
+        setAdapter();
 
         refreshLock();
     }

--- a/app/src/main/java/com/fieldbook/tracker/utilities/Utils.java
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/Utils.java
@@ -12,6 +12,8 @@ import android.widget.Toast;
 
 public class Utils extends Application {
 
+    private static Toast currentToast;
+
     public static void scanFile(Context context, String path, String mimeType) {
         MediaScannerConnection.scanFile(context, new String[] { path }, new String[] { mimeType }, null);
     }
@@ -59,10 +61,12 @@ public class Utils extends Application {
         NetworkInfo networkInfo = connMgr.getActiveNetworkInfo();
         return networkInfo != null && networkInfo.isConnected();
     }
-
     public static void makeToast(Context context, String message) {
-        Toast toast = Toast.makeText(context, message, Toast.LENGTH_LONG);
-        toast.setGravity(Gravity.TOP,0,0);
-        toast.show();
+        if (currentToast != null) {
+            currentToast.cancel();
+        }
+        currentToast = Toast.makeText(context, message, Toast.LENGTH_LONG);
+        currentToast.setGravity(Gravity.TOP, 0, 0);
+        currentToast.show();
     }
 }

--- a/app/src/main/res/layout/activity_collect.xml
+++ b/app/src/main/res/layout/activity_collect.xml
@@ -143,4 +143,16 @@
 
     </ScrollView>
 
+    <View
+        android:id="@+id/lockOverlay"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@android:color/transparent"
+        android:visibility="gone"
+        android:clickable="true"
+        app:layout_constraintTop_toTopOf="@id/act_collect_input_view"
+        app:layout_constraintBottom_toBottomOf="@id/toolbarBottom"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -644,6 +644,7 @@
     <string name="preferences_appearance_language">Language</string>
     <string name="preferences_appearance_language_description">Language set by system</string>
     <string name="preference_language_default">System Language</string>
+    <string name="preference_language_warning">Translations are crowd-sourced and may not be entirely accurate or complete</string>
     <string name="language_en" translatable="false">English</string>
     <string name="language_am" translatable="false">አማርኛ</string>
     <string name="language_ar" translatable="false">اَلْعَرَبِيَّةُ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -347,6 +347,11 @@
     <string name="dialog_data_grid_repeated_measures_title">Choose Observation</string>
     <string name="menu_action_header_view_data_grid_title">Update Row Headers</string>
 
+    <!--- Lock -->
+    <string name="activity_collect_locked_state">Locked - data entry, modification and deletion are disabled</string>
+    <string name="activity_collect_frozen_state">Frozen - data entry is enabled but modification and deletion are disabled</string>
+    <string name="activity_collect_unlocked_state">Unlocked - data entry, modification and deletion are enabled</string>
+
     <!-- Trait Layout: Photo -->
     <string name="trait_error_hardware_missing">Your device does not have a camera that can be used to take a photo.</string>
     <string name="trait_delete_warning_photo">Are you sure you want to delete this photo?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -349,8 +349,8 @@
 
     <!--- Lock -->
     <string name="activity_collect_locked_state">Locked - data entry, modification and deletion are disabled</string>
-    <string name="activity_collect_frozen_state">Frozen - data entry is enabled but modification and deletion are disabled</string>
-    <string name="activity_collect_unlocked_state">Unlocked - data entry, modification and deletion are enabled</string>
+    <string name="activity_collect_frozen_state">Frozen - once data is saved it cannot be modified or deleted</string>
+    <string name="activity_collect_unlocked_state">Unlocked - no restrictions on data entry, modification, or deletion</string>
 
     <!-- Trait Layout: Photo -->
     <string name="trait_error_hardware_missing">Your device does not have a camera that can be used to take a photo.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -644,7 +644,7 @@
     <string name="preferences_appearance_language">Language</string>
     <string name="preferences_appearance_language_description">Language set by system</string>
     <string name="preference_language_default">System Language</string>
-    <string name="preference_language_warning">Translations are crowd-sourced and may not be entirely accurate or complete</string>
+    <string name="preference_language_warning" translatable="false">Translations are crowd-sourced and may not be entirely accurate or complete</string>
     <string name="language_en" translatable="false">English</string>
     <string name="language_am" translatable="false">አማርኛ</string>
     <string name="language_ar" translatable="false">اَلْعَرَبِيَّةُ</string>


### PR DESCRIPTION
## Description

_Provide a summary of your changes including motivation and context.
If these changes fix a bug or resolves a feature request, be sure to link to that issue._

Adds toasts when locked status is changed and toast plus error sound when locked interface is clicked.
Adds dialog when language is switched to warn that translations are crowd-sourced and may be incomplete  
Closes #915 and #890

## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note
Explanatory info added to lock and languages changes
```