### PR TITLE
Fix Set System Default Language in appearances

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/preferences/LanguagePreferenceFragment.kt
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/LanguagePreferenceFragment.kt
@@ -47,7 +47,10 @@ class LanguagePreferenceFragment : PreferenceFragmentCompat(), Preference.OnPref
                 var id = preference.key
                 var languageSummary = preference.title.toString()
                 if (preference.key == "com.fieldbook.tracker.preference.language.default") {
-                    //set id to the default language
+
+                    //LocaleListCompat keeps an array of user's preferred languages (including the one set in this app), instead of assuming the system
+                    //default language is the first one in the list, check it explicitly. Technically, users can have
+                    //multiple languages defined, this will pick their first one as the default.
                     val defaultLocales = LocaleListCompat.getAdjustedDefault()
                     val defaultLocale = defaultLocales[0]
                     id = if (defaultLocales.size() > 1 && defaultLocale?.toLanguageTag() == currentPrefTag) {


### PR DESCRIPTION
## Description

Previously this was not working, now it correctly sets the app language to the default system language.


## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note

```