### PR TITLE
v5 repeated measures export warning

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/utilities/ExportUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/ExportUtil.kt
@@ -251,10 +251,7 @@ class ExportUtil @Inject constructor(@ActivityContext private val context: Conte
         params?.width = WindowManager.LayoutParams.MATCH_PARENT
         saveDialog.window?.attributes = params
 
-        // Override positive button so it doesn't automatically dismiss dialog
-        val positiveButton: Button = saveDialog.getButton(AlertDialog.BUTTON_POSITIVE)
-        positiveButton.setOnClickListener {
-
+        fun onOkExportClicked() {
             val isOnlyUniqueChecked = onlyUnique?.isChecked == true
             val isAllColumnsChecked = allColumns?.isChecked == true
             val isActiveTraitsChecked = activeTraits?.isChecked == true
@@ -262,17 +259,17 @@ class ExportUtil @Inject constructor(@ActivityContext private val context: Conte
 
             if (!checkDB.isChecked && !checkTable.isChecked) {
                 Toast.makeText(context, context.getString(R.string.export_error_missing_format), Toast.LENGTH_SHORT).show()
-                return@setOnClickListener
+                return
             }
 
             if (!isOnlyUniqueChecked && !isAllColumnsChecked) {
                 Toast.makeText(context, context.getString(R.string.export_error_missing_column), Toast.LENGTH_SHORT).show()
-                return@setOnClickListener
+                return
             }
 
             if (!isActiveTraitsChecked && !isAllTraitsChecked) {
                 Toast.makeText(context, context.getString(R.string.export_error_missing_trait), Toast.LENGTH_SHORT).show()
-                return@setOnClickListener
+                return
             }
 
             with(preferences.edit()) {
@@ -309,7 +306,26 @@ class ExportUtil @Inject constructor(@ActivityContext private val context: Conte
 
             startExportTasks()
             saveDialog.dismiss()
+        }
 
+        // Override positive button so it doesn't automatically dismiss dialog
+        val positiveButton: Button = saveDialog.getButton(AlertDialog.BUTTON_POSITIVE)
+        positiveButton.setOnClickListener {
+
+            val repeatedMeasuresEnabled = preferences.getBoolean(GeneralKeys.REPEATED_VALUES_PREFERENCE_KEY, false)
+
+            //show a warning if table is selected and repeated measures is enabled
+            if (checkTable.isChecked && repeatedMeasuresEnabled) {
+
+                AlertDialog.Builder(context)
+                    .setTitle(R.string.export_util_repeated_measures_table_warning_title)
+                    .setMessage(R.string.export_util_repeated_measures_table_warning_message)
+                    .setPositiveButton(android.R.string.ok) { _, _ ->
+                        onOkExportClicked()
+                    }
+                    .show()
+
+            } else onOkExportClicked()
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1116,5 +1116,7 @@
     <string name="tutorial_main_geonav_title">GeoNav</string>
     <string name="tutorial_main_geonav_description">This will open a configuration dialog to help with field navigation.</string>
     <string name="oauth_configured_incorrectly">Authorization request failed, please check your BrAPI settings.</string>
+    <string name="export_util_repeated_measures_table_warning_title">Repeated Measures Table</string>
+    <string name="export_util_repeated_measures_table_warning_message">Only the latest repeated measures value will be exported in table format.</string>
 
 </resources>


### PR DESCRIPTION
fix #576
warning when exporting table with repeated measures enabled, table format only shows the latest repeated measure

## Description

_Provide a summary of your changes including motivation and context.
If these changes fix a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note

```