### PR TITLE
v5 geonav ui bugfixes

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/traits/GNSSTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/GNSSTraitLayout.kt
@@ -625,19 +625,27 @@ class GNSSTraitLayout : BaseTraitLayout, GPSTracker.GPSTrackerListener {
                 val latitude = latTextView.text.toString()
                 val longitude = lngTextView.text.toString()
                 val elevation = altTextView.text.toString()
-                val precision = accTextView.text.toString()
+                val uiPrecision = accTextView.text.toString()
 
                 val isFloat = try {
-                    precision.toDouble()
+                    uiPrecision.toDouble()
                     true
                 } catch (e: NumberFormatException) {
                     false
                 }
 
-                submitGnss(latitude, longitude, elevation, if (isFloat) "GPS" else precision)
+                val precisionName = if (isFloat) "GPS" else uiPrecision
 
-                triggerTts(context.getString(R.string.trait_location_saved_tts))
+                if (NmeaParser().compareFix(precisionName, precision ?: "Any")) {
 
+                    submitGnss(latitude, longitude, elevation, precisionName)
+
+                    triggerTts(context.getString(R.string.trait_location_saved_tts))
+
+                } else {
+
+                    soundWarning()
+                }
             }
         }
 

--- a/app/src/main/java/com/fieldbook/tracker/views/RepeatedValuesView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/RepeatedValuesView.kt
@@ -8,7 +8,6 @@ import android.util.TypedValue
 import android.view.View
 import android.widget.Button
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.constraintlayout.widget.Group
 import androidx.viewpager.widget.ViewPager
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.activities.CollectActivity
@@ -68,7 +67,7 @@ class RepeatedValuesView(context: Context, attributeSet: AttributeSet) :
     private val rightButton: Button
     private val addButton: FloatingActionButton
     private val pager: ViewPager
-    private val nonEmptyGroup: Group
+    //private val nonEmptyGroup: Group
 
     //initialize all the global view variables
     init {
@@ -79,7 +78,7 @@ class RepeatedValuesView(context: Context, attributeSet: AttributeSet) :
         rightButton = findViewById(R.id.repeated_values_view_right_btn)
         addButton = findViewById(R.id.repeated_values_view_add_btn)
         pager = findViewById(R.id.repeated_values_view_pager)
-        nonEmptyGroup = findViewById(R.id.view_repeated_values_group)
+        //nonEmptyGroup = findViewById(R.id.view_repeated_values_group)
 
         pager.pageMargin = 8f.dipToPixels(context).toInt()
 
@@ -181,13 +180,13 @@ class RepeatedValuesView(context: Context, attributeSet: AttributeSet) :
     //inserts a dummy row which later is deleted if the value is blank
     private fun addFirstItem() {
 
-        prepareModeNonEmpty()
+        //prepareModeNonEmpty()
 
         mValues.add(ObservationModelViewHolder(insertNewRep("1"), Color.BLACK))
 
         submitList()
 
-        updateButtonVisibility()
+        //updateButtonVisibility()
 
         (context as CollectActivity).traitLayoutRefresh()
 
@@ -239,11 +238,11 @@ class RepeatedValuesView(context: Context, attributeSet: AttributeSet) :
     //called when values do exist
     fun prepareModeNonEmpty() {
 
-        nonEmptyGroup.visibility = View.VISIBLE
-        addButton.visibility = View.VISIBLE
-        pager.visibility = View.VISIBLE
-        leftButton.visibility = View.VISIBLE
-        rightButton.visibility = View.VISIBLE
+        //nonEmptyGroup.visibility = View.VISIBLE
+        //addButton.visibility = View.VISIBLE
+        //pager.visibility = View.VISIBLE
+        //leftButton.visibility = View.VISIBLE
+        //rightButton.visibility = View.VISIBLE
 
         updateButtonVisibility()
     }
@@ -373,6 +372,5 @@ class RepeatedValuesView(context: Context, attributeSet: AttributeSet) :
         }
 
         leftButton.visibility = if (pager.currentItem == 0) View.INVISIBLE else View.VISIBLE
-
     }
 }

--- a/app/src/main/res/layout/view_repeated_values.xml
+++ b/app/src/main/res/layout/view_repeated_values.xml
@@ -5,18 +5,13 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <androidx.constraintlayout.widget.Group
-        android:id="@+id/view_repeated_values_group"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:constraint_referenced_ids="repeated_values_view_add_btn, repeated_values_view_left_btn,
-            repeated_values_view_pager, repeated_values_view_right_btn" />
-
     <Button
+        android:visibility="invisible"
         android:id="@+id/repeated_values_view_left_btn"
         android:layout_width="64dp"
         android:layout_height="64dp"
         android:background="@drawable/ic_chevron_left"
+        android:contentDescription="@string/repeated_values_left_button_content_description"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -31,6 +26,7 @@
         android:paddingStart="16dp"
         android:paddingEnd="16dp"
         android:textSize="@dimen/text_size_xlarge"
+        android:contentDescription="@string/repeated_values_pager_content_description"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/repeated_values_view_add_btn"
         app:layout_constraintStart_toEndOf="@id/repeated_values_view_left_btn"
@@ -63,6 +59,7 @@
         android:layout_height="64dp"
         android:background="@drawable/ic_chevron_right"
         android:visibility="invisible"
+        android:contentDescription="@string/repeated_values_right_button_content_description"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -913,7 +913,7 @@
 
     <string name="brapi_oidc_scope">OIDC Scope</string>
     <string name="brapi_oidc_scope_desc">The Scope to be used in the authentication provider</string>
-    <string name="brapi_oidc_scope_default" translatable="false"></string>
+    <string name="brapi_oidc_scope_default" translatable="false" />
 
     <string name="preferences_brapi_traits_title">BrAPI Variables</string>
     <string name="preferences_appearance_collect_labelval_customize">Value vs Label Display</string>
@@ -1116,5 +1116,8 @@
     <string name="tutorial_main_geonav_title">GeoNav</string>
     <string name="tutorial_main_geonav_description">This will open a configuration dialog to help with field navigation.</string>
     <string name="oauth_configured_incorrectly">Authorization request failed, please check your BrAPI settings.</string>
+    <string name="repeated_values_pager_content_description">repeated values</string>
+    <string name="repeated_values_right_button_content_description">right</string>
+    <string name="repeated_values_left_button_content_description">left</string>
 
 </resources>


### PR DESCRIPTION
## Description

fixes #854 

After field testing this, user chosen precision acts as a minimum not by match in geonav and gnss.

I found two ui related bugs that this PR fixes including:
1. switching from float rtk to rtk in gnss, user could quickly press collect to save an observations and bypass the precision requirement (when precision is GPS)
2. minor repeated measures visual bug

## Type of change

_What type of changes does your code introduce? Put an `x` in boxes that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated relevant documentation

## Changelog entry

_Please add a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the behavior trait drag and drop behavior.
-->

```release-note

```