### PR TITLE
brapi_hide_previously_imported

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/filter/BrapiListFilterActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/filter/BrapiListFilterActivity.kt
@@ -80,6 +80,8 @@ abstract class BrapiListFilterActivity<T> : ListFilterActivity() {
 
     abstract fun BrapiCacheModel.mapToUiModel(): List<CheckboxListAdapter.Model>
 
+    abstract fun List<CheckboxListAdapter.Model>.filterExists(): List<CheckboxListAdapter.Model>
+
     /**
      * By default pass the same list.
      * Only affects data in the study list activity, uses shared preferences saved from other activities
@@ -375,6 +377,7 @@ abstract class BrapiListFilterActivity<T> : ListFilterActivity() {
             .mapToUiModel()
             .distinct()
             .filterBySearchTextPreferences()
+            .filterExists()
             .persistCheckBoxes()
             .sortedBy { it.label }
 

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/filter/BrapiSubFilterListActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/filter/BrapiSubFilterListActivity.kt
@@ -38,6 +38,8 @@ abstract class BrapiSubFilterListActivity<T> : BrapiListFilterActivity<T>() {
 
     protected var numFilterBadge: BadgeDrawable? = null
 
+    override fun List<CheckboxListAdapter.Model>.filterExists(): List<CheckboxListAdapter.Model> = this
+
     override fun setupSearch(models: List<CheckboxListAdapter.Model>) {
 
         val searchEditText = searchBar.editText

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/filter/filterer/BrapiStudyFilterActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/filter/filterer/BrapiStudyFilterActivity.kt
@@ -21,9 +21,13 @@ import com.fieldbook.tracker.activities.brapi.io.filter.BrapiSubFilterListActivi
 import com.fieldbook.tracker.activities.brapi.io.filter.BrapiTrialsFilterActivity
 import com.fieldbook.tracker.activities.brapi.io.filter.BrapiTrialsFilterActivity.Companion.filterByProgram
 import com.fieldbook.tracker.adapters.CheckboxListAdapter
+import com.fieldbook.tracker.database.DataHelper
 import com.fieldbook.tracker.preferences.GeneralKeys
+import dagger.hilt.android.AndroidEntryPoint
 import org.brapi.v2.model.core.BrAPIStudy
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class BrapiStudyFilterActivity(
     override val defaultRootFilterKey: String = FILTERER_KEY,
     override val filterName: String = "studies",
@@ -45,6 +49,9 @@ class BrapiStudyFilterActivity(
         TRIAL,
         CROP
     }
+
+    @Inject
+    lateinit var database: DataHelper
 
     override fun BrapiCacheModel.filterByPreferences(): BrapiCacheModel {
 
@@ -73,6 +80,11 @@ class BrapiStudyFilterActivity(
                 tokens in model.label.lowercase() || tokens in model.subLabel.lowercase() || tokens in model.id.lowercase()
             }
         }
+    }
+
+    override fun List<CheckboxListAdapter.Model>.filterExists(): List<CheckboxListAdapter.Model> {
+        val brapiIds = database.allFieldObjects.map { it.study_db_id }
+        return filter { it.id !in brapiIds }
     }
 
     override fun onSearchTextComplete(searchText: String) {

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/filter/filterer/BrapiTraitFilterActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/filter/filterer/BrapiTraitFilterActivity.kt
@@ -15,21 +15,13 @@ import com.fieldbook.tracker.activities.brapi.io.BrapiFilterTypeAdapter
 import com.fieldbook.tracker.activities.brapi.io.filter.BrapiSubFilterListActivity
 import com.fieldbook.tracker.activities.brapi.io.BrapiTraitImporterActivity
 import com.fieldbook.tracker.activities.brapi.io.filter.BrapiTrialsFilterActivity
-import com.fieldbook.tracker.activities.brapi.io.TrialStudyModel
-import com.fieldbook.tracker.activities.brapi.io.filter.BrapiProgramFilterActivity
-import com.fieldbook.tracker.activities.brapi.io.filter.BrapiSeasonsFilterActivity
-import com.fieldbook.tracker.activities.brapi.io.filter.BrapiSeasonsFilterActivity.Companion.filterByProgramAndTrial
-import com.fieldbook.tracker.activities.brapi.io.filter.BrapiTrialsFilterActivity.Companion.filterByProgram
-import com.fieldbook.tracker.activities.brapi.io.filter.filterer.BrapiStudyFilterActivity.FilterChoice
 import com.fieldbook.tracker.activities.brapi.io.mapper.DataTypes
 import com.fieldbook.tracker.adapters.CheckboxListAdapter
 import com.fieldbook.tracker.brapi.service.BrAPIServiceV2
+import com.fieldbook.tracker.database.DataHelper
 import com.fieldbook.tracker.preferences.GeneralKeys
 import com.fieldbook.tracker.traits.formats.Formats
-import com.google.android.material.appbar.MaterialToolbar
-import com.google.android.material.badge.BadgeDrawable
-import com.google.android.material.badge.BadgeUtils
-import com.google.android.material.badge.ExperimentalBadgeUtils
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -39,7 +31,9 @@ import kotlinx.coroutines.withContext
 import org.brapi.client.v2.model.queryParams.phenotype.VariableQueryParams
 import org.brapi.v2.model.core.BrAPIStudy
 import org.brapi.v2.model.pheno.BrAPIObservationVariable
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class BrapiTraitFilterActivity(
     override val defaultRootFilterKey: String = FILTERER_KEY,
     override val filterName: String = "traits",
@@ -57,6 +51,9 @@ class BrapiTraitFilterActivity(
         STUDY,
         CROP
     }
+
+    @Inject
+    lateinit var database: DataHelper
 
     private var queryVariablesJob: Job? = null
 
@@ -93,6 +90,11 @@ class BrapiTraitFilterActivity(
                 tokens in model.label.lowercase() || tokens in model.subLabel.lowercase() || tokens in model.id.lowercase()
             }
         }
+    }
+
+    override fun List<CheckboxListAdapter.Model>.filterExists(): List<CheckboxListAdapter.Model> {
+        val brapiIds = database.allTraitObjects.map { it.externalDbId }
+        return filter { it.id !in brapiIds }
     }
 
     override fun onSearchTextComplete(searchText: String) {


### PR DESCRIPTION
### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [x] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Fields and traits that have already been imported are now hidden on the BrAPI import screen
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [x] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)