### PR TITLE
close_keyboard_text_trait_option

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -2103,12 +2103,13 @@ public class DataHelper {
      * V2 - Edit existing trait
      */
     public long editTraits(String traitDbId, String trait, String format, String defaultValue,
-                           String minimum, String maximum, String details, String categories) {
+                           String minimum, String maximum, String details, String categories,
+                           Boolean closeKeyboardOnOpen) {
 
         open();
 
         return ObservationVariableDao.Companion.editTraits(traitDbId, trait, format, defaultValue,
-                minimum, maximum, details, categories);
+                minimum, maximum, details, categories, closeKeyboardOnOpen);
 //        try {
 //            ContentValues c = new ContentValues();
 //            c.put("trait", trait);
@@ -2146,7 +2147,7 @@ public class DataHelper {
 
         return ObservationVariableDao.Companion.editTraits(trait.getId(), trait.getName(),
                 trait.getFormat(), trait.getDefaultValue(), trait.getMinimum(), trait.getMaximum(),
-                trait.getDetails(), trait.getCategories());
+                trait.getDetails(), trait.getCategories(), trait.getCloseKeyboardOnOpen());
     }
 
     public boolean checkUnique(HashMap<String, String> values) {

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationVariableAttributeDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationVariableAttributeDao.kt
@@ -1,5 +1,6 @@
 package com.fieldbook.tracker.database.dao
 
+import androidx.core.content.contentValuesOf
 import com.fieldbook.tracker.database.*
 import com.fieldbook.tracker.database.Migrator.ObservationVariableAttribute
 
@@ -17,9 +18,40 @@ class ObservationVariableAttributeDao {
 
         fun getAttributeIdByName(name: String): Int = withDatabase { db ->
 
-            db.query(ObservationVariableAttribute.tableName,
+            db.beginTransaction()
+
+            var id = -1
+
+            try {
+
+                id = db.query(ObservationVariableAttribute.tableName,
                     where = "observation_variable_attribute_name LIKE ?",
-                    whereArgs = arrayOf(name)).toFirst()[ObservationVariableAttribute.PK] as Int
+                    whereArgs = arrayOf(name)).toFirst().getOrDefault(ObservationVariableAttribute.PK, -1) as Int
+
+                if (id == -1) {
+
+                    db.insert(ObservationVariableAttribute.tableName, null, contentValuesOf(
+                        "observation_variable_attribute_name" to name
+                    ))
+
+                    id = db.query(ObservationVariableAttribute.tableName,
+                        where = "observation_variable_attribute_name LIKE ?",
+                        whereArgs = arrayOf(name)).toFirst().getOrDefault(ObservationVariableAttribute.PK, -1) as Int
+                }
+
+                db.setTransactionSuccessful()
+
+            } catch (e: Exception) {
+
+                e.printStackTrace()
+
+            } finally {
+
+                db.endTransaction()
+
+            }
+
+            id
 
         } ?: -1
 

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationVariableValueDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationVariableValueDao.kt
@@ -27,17 +27,28 @@ class ObservationVariableValueDao {
 
         }
 
-        fun insert(min: String, max: String, categories: String, id: String) = withDatabase { db ->
+        fun insertCloseKeyboard(closeKeyboardOnOpen: String, id: String) = withDatabase { db ->
 
-            //iterate trhough mapping of the old columns that are now attr/vals
+            val attrId = ObservationVariableAttributeDao.getAttributeIdByName("closeKeyboardOnOpen")
+
+            db.insert(ObservationVariableValue.tableName, null, contentValuesOf(
+
+                ObservationVariable.FK to id,
+                Migrator.ObservationVariableAttribute.FK to attrId,
+                "observation_variable_attribute_value" to closeKeyboardOnOpen
+
+            ))
+        }
+
+        fun insert(min: String, max: String, categories: String, closeKeyboardOnOpen: String, id: String) = withDatabase { db ->
+
+            //iterate through mapping of the old columns that are now attr/vals
             mapOf(
                     "validValuesMin" to min,
                     "validValuesMax" to max,
                     "category" to categories,
+                    "closeKeyboardOnOpen" to closeKeyboardOnOpen
             ).asSequence().forEach { attrValue ->
-
-                //TODO: commenting this out would create a sparse table from the unused attribute values
-//                    if (attrValue.value.isNotEmpty()) {
 
                 val attrId = ObservationVariableAttributeDao.getAttributeIdByName(attrValue.key)
 
@@ -48,10 +59,7 @@ class ObservationVariableValueDao {
                         "observation_variable_attribute_value" to attrValue.value
 
                 ))
-//                    }
             }
         }
-
-//        fun getAll() = withDatabase { it.query(ObservationVariableValue.tableName).toTable() }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/VisibleObservationVariableDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/VisibleObservationVariableDao.kt
@@ -71,6 +71,7 @@ class VisibleObservationVariableDao {
                         val attrName =
                             ObservationVariableAttributeDao.getAttributeNameById(it[ObservationVariableAttribute.FK] as Int)
 
+
                         when (attrName) {
                             "validValuesMin" -> minimum =
                                 it["observation_variable_attribute_value"] as? String ?: ""
@@ -80,6 +81,9 @@ class VisibleObservationVariableDao {
 
                             "category" -> categories =
                                 it["observation_variable_attribute_value"] as? String ?: ""
+
+                            "closeKeyboardOnOpen" -> closeKeyboardOnOpen =
+                                (it["observation_variable_attribute_value"] as? String ?: "false").toBoolean()
                         }
 
                     }

--- a/app/src/main/java/com/fieldbook/tracker/dialogs/NewTraitDialog.kt
+++ b/app/src/main/java/com/fieldbook/tracker/dialogs/NewTraitDialog.kt
@@ -492,7 +492,8 @@ class NewTraitDialog(
             traitObject.minimum,
             traitObject.maximum,
             traitObject.details,
-            traitObject.categories
+            traitObject.categories,
+            traitObject.closeKeyboardOnOpen
         )
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/objects/TraitObject.java
+++ b/app/src/main/java/com/fieldbook/tracker/objects/TraitObject.java
@@ -24,6 +24,7 @@ public class TraitObject {
     private String externalDbId;
     private String traitDataSource;
     private String additionalInfo;
+    private Boolean closeKeyboardOnOpen = false;
 
     /**
      * This is a BMS specific field. This will be populated when traits are imported from
@@ -191,12 +192,12 @@ public class TraitObject {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TraitObject that = (TraitObject) o;
-        return realPosition == that.realPosition && Objects.equals(name, that.name) && Objects.equals(format, that.format) && Objects.equals(defaultValue, that.defaultValue) && Objects.equals(minimum, that.minimum) && Objects.equals(maximum, that.maximum) && Objects.equals(details, that.details) && Objects.equals(categories, that.categories) && Objects.equals(id, that.id) && Objects.equals(visible, that.visible) && Objects.equals(externalDbId, that.externalDbId) && Objects.equals(traitDataSource, that.traitDataSource) && Objects.equals(additionalInfo, that.additionalInfo) && Objects.equals(observationLevelNames, that.observationLevelNames);
+        return realPosition == that.realPosition && Objects.equals(name, that.name) && Objects.equals(format, that.format) && Objects.equals(defaultValue, that.defaultValue) && Objects.equals(minimum, that.minimum) && Objects.equals(maximum, that.maximum) && Objects.equals(details, that.details) && Objects.equals(categories, that.categories) && Objects.equals(id, that.id) && Objects.equals(visible, that.visible) && Objects.equals(externalDbId, that.externalDbId) && Objects.equals(traitDataSource, that.traitDataSource) && Objects.equals(additionalInfo, that.additionalInfo) && Objects.equals(observationLevelNames, that.observationLevelNames) && Objects.equals(closeKeyboardOnOpen, that.closeKeyboardOnOpen);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, format, defaultValue, minimum, maximum, details, categories, realPosition, id, visible, externalDbId, traitDataSource, additionalInfo, observationLevelNames);
+        return Objects.hash(name, format, defaultValue, minimum, maximum, details, categories, realPosition, id, visible, externalDbId, traitDataSource, additionalInfo, observationLevelNames, closeKeyboardOnOpen);
     }
 
     public TraitObject clone() {
@@ -216,7 +217,16 @@ public class TraitObject {
         t.setTraitDataSource(this.traitDataSource);
         t.setAdditionalInfo(this.additionalInfo);
         t.setObservationLevelNames(this.observationLevelNames);
+        t.setCloseKeyboardOnOpen(this.closeKeyboardOnOpen);
 
         return t;
+    }
+
+    public Boolean getCloseKeyboardOnOpen() {
+        return closeKeyboardOnOpen;
+    }
+
+    public void setCloseKeyboardOnOpen(Boolean closeKeyboardOnOpen) {
+        this.closeKeyboardOnOpen = closeKeyboardOnOpen;
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/traits/TextTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/TextTraitLayout.kt
@@ -12,6 +12,7 @@ import android.widget.EditText
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.activities.CollectActivity
 import com.fieldbook.tracker.preferences.GeneralKeys
+import org.phenoapps.utils.SoftKeyboardUtil.Companion.closeKeyboard
 import org.phenoapps.utils.SoftKeyboardUtil.Companion.showKeyboard
 
 class TextTraitLayout : BaseTraitLayout {
@@ -225,7 +226,11 @@ class TextTraitLayout : BaseTraitLayout {
 
     private fun selectEditText() {
         inputEditText?.let { input ->
-            showKeyboard(context, input, 300L)
+            if (currentTrait.closeKeyboardOnOpen) {
+                closeKeyboard(context, input, 300L)
+            } else {
+                showKeyboard(context, input, 300L)
+            }
             input.removeTextChangedListener(textWatcher)
             input.addTextChangedListener(textWatcher)
             input.requestFocus()

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/TextFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/TextFormat.kt
@@ -1,6 +1,7 @@
 package com.fieldbook.tracker.traits.formats
 
 import com.fieldbook.tracker.R
+import com.fieldbook.tracker.traits.formats.parameters.CloseKeyboardParameter
 import com.fieldbook.tracker.traits.formats.parameters.DefaultValueParameter
 import com.fieldbook.tracker.traits.formats.parameters.DetailsParameter
 import com.fieldbook.tracker.traits.formats.parameters.NameParameter
@@ -15,5 +16,6 @@ class TextFormat : TraitFormat(
     stringNameAux = null,
     NameParameter(),
     DefaultValueParameter(),
-    DetailsParameter()
+    DetailsParameter(),
+    CloseKeyboardParameter(false)
 )

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/parameters/CloseKeyboardParameter.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/parameters/CloseKeyboardParameter.kt
@@ -1,0 +1,55 @@
+package com.fieldbook.tracker.traits.formats.parameters
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ToggleButton
+import com.fieldbook.tracker.R
+import com.fieldbook.tracker.database.DataHelper
+import com.fieldbook.tracker.objects.TraitObject
+import com.fieldbook.tracker.traits.formats.ValidationResult
+
+class CloseKeyboardParameter(private val initialDefaultValue: Boolean? = null) :
+    BaseFormatParameter(
+        nameStringResourceId = R.string.traits_create_close_keyboard,
+        defaultLayoutId = R.layout.list_item_trait_parameter_default_toggle_value,
+        parameter = Parameters.CLOSE_KEYBOARD
+    ) {
+
+    override fun createViewHolder(
+        parent: ViewGroup,
+    ): BaseFormatParameter.ViewHolder {
+        val v = LayoutInflater.from(parent.context)
+            .inflate(R.layout.list_item_trait_parameter_default_toggle_value, parent, false)
+        return ViewHolder(v)
+    }
+
+    inner class ViewHolder(itemView: View) : BaseFormatParameter.ViewHolder(itemView) {
+
+        val defaultValueToggle =
+            itemView.findViewById<ToggleButton>(R.id.dialog_new_trait_default_toggle_btn).also {
+                initialDefaultValue?.let { value ->
+                    it.isChecked = value
+                }
+            }
+
+        override fun merge(traitObject: TraitObject) = traitObject.apply {
+            closeKeyboardOnOpen = defaultValueToggle.isChecked
+        }
+
+        override fun load(traitObject: TraitObject?): Boolean {
+            try {
+                defaultValueToggle.isChecked = traitObject?.closeKeyboardOnOpen == true
+            } catch (e: Exception) {
+                e.printStackTrace()
+                return false
+            }
+            return true
+        }
+
+        override fun validate(
+            database: DataHelper,
+            initialTraitObject: TraitObject?
+        ) = ValidationResult()
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/parameters/Parameters.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/parameters/Parameters.kt
@@ -2,6 +2,15 @@ package com.fieldbook.tracker.traits.formats.parameters
 
 enum class Parameters {
 
-    FORMAT, NAME, DEFAULT_VALUE, DETAILS, MAXIMUM, MINIMUM, CATEGORIES, CAMERA;
+    FORMAT, NAME, DEFAULT_VALUE, DETAILS, MAXIMUM, MINIMUM, CATEGORIES, CAMERA, CLOSE_KEYBOARD;
 
+    companion object {
+
+        val System = listOf(
+            "validValuesMin",
+            "validValuesMax",
+            "category",
+            "closeKeyboardOnOpen"
+        )
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -294,6 +294,7 @@
     <string name="traits_create_false">False</string>
     <string name="traits_create_categories_text">Use / to separate categories</string>
     <string name="traits_create_camera">Camera</string>
+    <string name="traits_create_close_keyboard">Close Keyboard</string>
 
     <string name="traits_create_warning_name_blank">Trait name cannot be blank</string>
     <string name="traits_create_warning_duplicate">Trait already exists</string>


### PR DESCRIPTION
### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [x] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note

```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)