### PR TITLE
collect_go_to_id_dialog_focus

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -1811,8 +1811,14 @@ public class CollectActivity extends ThemedActivity
         goToId = builder.create();
 
         goToId.setOnShowListener(dialog -> {
-            barcodeId.requestFocus();
-            SoftKeyboardUtil.Companion.showKeyboard(getContext(), barcodeId, 500L);
+            barcodeId.post(() -> {
+                barcodeId.requestFocus();
+                SoftKeyboardUtil.Companion.showKeyboard(getContext(), barcodeId, 250L);
+            });
+        });
+
+        goToId.setOnDismissListener(dialog -> {
+            barcodeId.post(() -> SoftKeyboardUtil.Companion.closeKeyboard(getContext(), barcodeId, 250L));
         });
 
         goToId.show();

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -108,6 +108,7 @@ import org.brapi.v2.model.pheno.BrAPIScaleValidValuesCategories;
 import org.phenoapps.interfaces.security.SecureBluetooth;
 import org.phenoapps.security.SecureBluetoothActivityImpl;
 import org.phenoapps.utils.BaseDocumentTreeUtil;
+import org.phenoapps.utils.SoftKeyboardUtil;
 import org.phenoapps.utils.TextToSpeechHelper;
 import org.threeten.bp.OffsetDateTime;
 
@@ -1808,6 +1809,12 @@ public class CollectActivity extends ThemedActivity
         });
 
         goToId = builder.create();
+
+        goToId.setOnShowListener(dialog -> {
+            barcodeId.requestFocus();
+            SoftKeyboardUtil.Companion.showKeyboard(getContext(), barcodeId, 500L);
+        });
+
         goToId.show();
 
         android.view.WindowManager.LayoutParams langParams = goToId.getWindow().getAttributes();


### PR DESCRIPTION
### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Go to ID dialog now has cursor focus when opened
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [x] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)