### PR TITLE
Eliminate possibility of incorrect plot/trait assignment during label printing

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -2304,20 +2304,18 @@ public class CollectActivity extends ThemedActivity
 
     /**
      * Inserts a user observation whenever a label is printed.
-     * See ResultReceiver onReceiveResult in LabelPrintLayout
+     * @param plotID: The plot ID at the time of printing.
+     * @param traitID: The trait ID at the time of printing.
+     * @param traitFormat: The format of the trait.
      * @param labelNumber: The number of labels printed.
      */
-    public void insertPrintObservation(String labelNumber) {
-
-        TraitObject trait = getCurrentTrait();
-
+    public void insertPrintObservation(String plotID, String traitID, String traitFormat, String labelNumber) {
         String studyId = Integer.toString(preferences.getInt(GeneralKeys.SELECTED_FIELD_ID, 0));
 
-        database.insertObservation(rangeBox.getPlotID(), trait.getId(), trait.getFormat(), labelNumber,
+        database.insertObservation(plotID, traitID, traitFormat, labelNumber,
                 getPerson(),
                 getLocationByPreferences(), "", studyId, "",
                 null, null);
-
     }
 
     @Override

--- a/app/src/main/java/com/fieldbook/tracker/traits/LabelPrintTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/LabelPrintTraitLayout.java
@@ -23,6 +23,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.CollectActivity;
+import com.fieldbook.tracker.objects.TraitObject;
 import com.fieldbook.tracker.preferences.GeneralKeys;
 import com.fieldbook.tracker.utilities.BluetoothChooseCallback;
 import com.fieldbook.tracker.utilities.BluetoothUtil;
@@ -156,7 +157,9 @@ public class LabelPrintTraitLayout extends BaseTraitLayout {
 
                 String message = intent.getExtras().getString("message");
                 int numLabels = intent.getExtras().getInt("numLabels", 0);
-
+                String plotId = intent.getExtras().getString("plotId");
+                String traitId = intent.getExtras().getString("traitId");
+                String traitFormat = intent.getExtras().getString("traitFormat");
 
                 if (message != null) {
 
@@ -164,13 +167,21 @@ public class LabelPrintTraitLayout extends BaseTraitLayout {
 
                 }
 
-                if (numLabels > 0) {
+                if (numLabels > 0 && plotId != null && traitId != null) {
                     String labelNumber = String.valueOf(numLabels);
-                    // Use the number of labels printed to record each print event
-                    ((CollectActivity) getContext()).insertPrintObservation(labelNumber);
 
+                    // Call the activity's method with the contextual information
+                    ((CollectActivity) getContext()).insertPrintObservation(plotId, traitId, traitFormat, labelNumber);
                     ((CollectActivity) getContext()).refreshRepeatedValuesToolbarIndicator();
                 }
+
+//                if (numLabels > 0) {
+//                    String labelNumber = String.valueOf(numLabels);
+//                    // Use the number of labels printed to record each print event
+//                    ((CollectActivity) getContext()).insertPrintObservation(labelNumber);
+//
+//                    ((CollectActivity) getContext()).refreshRepeatedValuesToolbarIndicator();
+//                }
             }
         }
     };
@@ -449,17 +460,23 @@ public class LabelPrintTraitLayout extends BaseTraitLayout {
                          */
                         String printerName = getPrefs().getString(GeneralKeys.LABEL_PRINT_DEVICE_NAME, null);
                         Log.d(TAG, "retrieved printerName is " + printerName);
+
+                        // Retrieve plotId and trait for use in the print command
+                        CollectActivity activity = (CollectActivity) getContext();
+                        String plotId = activity.getRangeBox().getPlotID();
+                        TraitObject trait = activity.getCurrentTrait();
+
                         if (printerName == null) {
                             mBluetoothUtil.choose(getContext(), new BluetoothChooseCallback() {
                                 @Override
                                 public void onDeviceChosen(String newDeviceName) {
                                     Log.d(TAG, "Chosen printerName is " + newDeviceName);
                                     saveDeviceNamePreference(newDeviceName);
-                                    mBluetoothUtil.print(getContext(), newDeviceName, size, labels);
+                                    mBluetoothUtil.print(getContext(), newDeviceName, labels, plotId, trait);
                                 }
                             });
                         } else {
-                            mBluetoothUtil.print(getContext(), printerName, size, labels);
+                            mBluetoothUtil.print(getContext(), printerName, labels, plotId, trait);
                         }
                     }
                 }

--- a/app/src/main/java/com/fieldbook/tracker/traits/LabelPrintTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/LabelPrintTraitLayout.java
@@ -175,13 +175,6 @@ public class LabelPrintTraitLayout extends BaseTraitLayout {
                     ((CollectActivity) getContext()).refreshRepeatedValuesToolbarIndicator();
                 }
 
-//                if (numLabels > 0) {
-//                    String labelNumber = String.valueOf(numLabels);
-//                    // Use the number of labels printed to record each print event
-//                    ((CollectActivity) getContext()).insertPrintObservation(labelNumber);
-//
-//                    ((CollectActivity) getContext()).refreshRepeatedValuesToolbarIndicator();
-//                }
             }
         }
     };

--- a/app/src/main/java/com/fieldbook/tracker/traits/LabelPrintTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/LabelPrintTraitLayout.java
@@ -169,10 +169,9 @@ public class LabelPrintTraitLayout extends BaseTraitLayout {
 
                 if (numLabels > 0 && plotId != null && traitId != null) {
                     String labelNumber = String.valueOf(numLabels);
-
-                    // Call the activity's method with the contextual information
-                    ((CollectActivity) getContext()).insertPrintObservation(plotId, traitId, traitFormat, labelNumber);
-                    ((CollectActivity) getContext()).refreshRepeatedValuesToolbarIndicator();
+                    CollectActivity activity = (CollectActivity) getContext();
+                    activity.insertPrintObservation(plotId, traitId, traitFormat, labelNumber);
+                    activity.refreshRepeatedValuesToolbarIndicator();
                 }
 
             }

--- a/app/src/main/java/com/fieldbook/tracker/utilities/BluetoothUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/BluetoothUtil.kt
@@ -10,8 +10,6 @@ import android.widget.RadioGroup
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.objects.TraitObject
 
-
-
 interface BluetoothChooseCallback {
     fun onDeviceChosen(deviceName: String)
 }

--- a/app/src/main/java/com/fieldbook/tracker/utilities/BluetoothUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/BluetoothUtil.kt
@@ -8,6 +8,9 @@ import android.util.Log
 import android.widget.RadioButton
 import android.widget.RadioGroup
 import com.fieldbook.tracker.R
+import com.fieldbook.tracker.objects.TraitObject
+
+
 
 interface BluetoothChooseCallback {
     fun onDeviceChosen(deviceName: String)
@@ -73,11 +76,17 @@ class BluetoothUtil {
      * This function will send a list of label commands to the printer, and only updates the printer message when the
      * button is pressed.
      */
-    fun print(ctx: Context, printerName: String, size: String, labelCommand: List<String>) {
+    fun print(
+        ctx: Context,
+        printerName: String,
+        labelCommand: List<String>,
+        plotId: String,
+        trait: TraitObject
+    ) {
         Log.d(TAG, "Label zpl is: $labelCommand")
         if (labelCommand.isNotEmpty()) {
             Log.d(TAG, "Sending label zpl to $printerName")
-            PrintThread(ctx, printerName).print(size, labelCommand)
+            PrintThread(ctx, printerName).print(labelCommand, plotId, trait)
         }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/utilities/PrintThread.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/PrintThread.kt
@@ -7,11 +7,13 @@ import android.os.Looper
 import android.widget.Toast
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.fieldbook.tracker.R
+import com.fieldbook.tracker.objects.TraitObject
 import com.zebra.sdk.comm.BluetoothConnection
 import com.zebra.sdk.comm.ConnectionException
 import com.zebra.sdk.printer.SGD
 import com.zebra.sdk.printer.ZebraPrinterFactory
 import com.zebra.sdk.printer.ZebraPrinterLanguageUnknownException
+
 
 /**
  * A thread implementation for communicating with Zebra printers using the ZSDK_ANDROID_API.jar
@@ -24,13 +26,15 @@ class PrintThread(private val ctx: Context, private val btName: String) : Thread
     //the broadcaster to send messages back to the trait layout
     private var mLocalBroadcast: LocalBroadcastManager? = null
 
-    //the size to be sent back to record in the database
-    private var mSize: String = String()
+    //the trait and plot to attach the print count to in the database
+    private var plotId: String = ""
+    private lateinit var trait: TraitObject
 
     //the command the bluetooth util class uses
-    fun print(size: String, labels: List<String>) {
-        mSize = size
+    fun print(labels: List<String>, plotId: String, trait: TraitObject) {
         mLabelCommands = labels
+        this.plotId = plotId
+        this.trait = trait
         start()
     }
 
@@ -96,6 +100,9 @@ class PrintThread(private val ctx: Context, private val btName: String) : Thread
 
                             intent.putExtra("message", success)
                             intent.putExtra("numLabels", mLabelCommands.size)
+                            intent.putExtra("plotId", plotId)
+                            intent.putExtra("traitId", trait.id)
+                            intent.putExtra("traitFormat", trait.format)
 
                         } else if (printerStatus.isHeadOpen) {
 


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

Updates LabelPrintTraitLayout, BluetoothUtil.print() and PrintThread to include the current plot and trait in the broadcast intent as additional info, then uses them on receipt of a successful print message to store the  print observation to the correct plot and trait, even if the user has since moved on.

Closes #1106

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Label print observations are now assigned to the correct entry when navigating before the print is complete
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)