### PR TITLE
validate_categorical_barcode_data

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/interfaces/CollectController.kt
+++ b/app/src/main/java/com/fieldbook/tracker/interfaces/CollectController.kt
@@ -3,6 +3,7 @@ package com.fieldbook.tracker.interfaces
 import android.content.Context
 import android.location.Location
 import android.os.Handler
+import com.fieldbook.tracker.database.models.ObservationModel
 import com.fieldbook.tracker.devices.camera.UsbCameraApi
 import com.fieldbook.tracker.devices.camera.GoProApi
 import com.fieldbook.tracker.devices.camera.CanonApi
@@ -58,4 +59,5 @@ interface CollectController: FieldController {
     fun getFfmpegHelper(): FfmpegHelper
     fun getCanonApi(): CanonApi
     fun takePicture()
+    fun getCurrentObservation(): ObservationModel?
 }

--- a/app/src/main/java/com/fieldbook/tracker/interfaces/CollectRangeController.kt
+++ b/app/src/main/java/com/fieldbook/tracker/interfaces/CollectRangeController.kt
@@ -3,7 +3,7 @@ package com.fieldbook.tracker.interfaces
 import com.fieldbook.tracker.views.CollectInputView
 
 interface CollectRangeController: CollectController {
-    fun validateData(): Boolean
+    fun validateData(data: String?): Boolean
     fun initWidgets(rangeSuppress: Boolean)
     fun cancelAndFinish()
     fun callFinish()

--- a/app/src/main/java/com/fieldbook/tracker/interfaces/CollectTraitController.kt
+++ b/app/src/main/java/com/fieldbook/tracker/interfaces/CollectTraitController.kt
@@ -5,7 +5,7 @@ import com.fieldbook.tracker.traits.LayoutCollections
 import com.fieldbook.tracker.views.CollectInputView
 
 interface CollectTraitController: CollectController {
-    fun validateData(): Boolean
+    fun validateData(data: String?): Boolean
     fun getTraitLayouts(): LayoutCollections
     fun isCyclingTraitsAdvances(): Boolean
     fun refreshLock()

--- a/app/src/main/java/com/fieldbook/tracker/objects/TraitObject.java
+++ b/app/src/main/java/com/fieldbook/tracker/objects/TraitObject.java
@@ -1,9 +1,15 @@
 package com.fieldbook.tracker.objects;
 
+import android.graphics.Color;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.fieldbook.tracker.utilities.CategoryJsonUtil;
+
+import org.brapi.v2.model.pheno.BrAPIScaleValidValuesCategories;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -144,47 +150,38 @@ public class TraitObject {
         this.observationLevelNames = observationLevelNames;
     }
 
-    public boolean isValidValue(final String s) {
-        // this code is not perfect.
-        // I think that it is necessary to check
-        // the minimum and the maximum values
-        return !isUnder(s) && !isOver(s);
-    }
 
-    public boolean isUnder(final String s) {
-        if (!(format.equals("numeric")))
-            return false;
 
-        Log.d("FB",s);
-        if (minimum.length() > 0) {     // minimum exists
-            try {
-                final double v = Double.parseDouble(s);
-                final double lowerValue = Double.parseDouble(minimum);
-                return v < lowerValue;
-            } catch (NumberFormatException e) {
-                return true;
+    public boolean isValidCategoricalValue(final String inputCategory) {
+
+        //check if its the new json
+        try {
+
+            ArrayList<BrAPIScaleValidValuesCategories> c = CategoryJsonUtil.Companion.decode(inputCategory);
+
+            if (!c.isEmpty()) {
+
+                //get the value from the single-sized array
+                BrAPIScaleValidValuesCategories labelVal = c.get(0);
+
+                //check that this pair is a valid label/val pair in the category,
+                //if it is then set the text based on the preference
+                return CategoryJsonUtil.Companion.contains(c, labelVal);
             }
-        } else {
-            return false;
-        }
-    }
 
-    public boolean isOver(final String s) {
-        if (!(format.equals("numeric")))
-            return false;
+        } catch (Exception e) {
 
-        Log.d("FB",s);
-        if (maximum.length() > 0) {     // maximum exists
-            try {
-                final double v = Double.parseDouble(s);
-                final double upperValue = Double.parseDouble(maximum);
-                return v > upperValue;
-            } catch (NumberFormatException e) {
-                return true;
-            }
-        } else {
-            return false;
+            e.printStackTrace(); //if it fails to decode, assume its an old string
+
+//            if (CategoryJsonUtil.Companion.contains(cats, value)) {
+//
+//                getCollectInputView().setText(value);
+//
+//                getCollectInputView().setTextColor(Color.parseColor(getDisplayColor()));
+//            }
         }
+
+        return false;
     }
 
     @Override

--- a/app/src/main/java/com/fieldbook/tracker/traits/AudioTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/AudioTraitLayout.java
@@ -136,7 +136,7 @@ public class AudioTraitLayout extends BaseTraitLayout {
     @Override
     public void deleteTraitListener() {
         deleteRecording();
-        removeTrait(getCurrentTrait().getName());
+        removeTrait(getCurrentTrait());
         super.deleteTraitListener();
         recordingLocation = null;
         mediaPlayer = null;
@@ -263,7 +263,7 @@ public class AudioTraitLayout extends BaseTraitLayout {
 
         private void startRecording() {
             try {
-                removeTrait(getCurrentTrait().getName());
+                removeTrait(getCurrentTrait());
                 audioRecordingText.setText("");
                 fieldAudioHelper.startRecording(false);
             } catch (Exception e) {

--- a/app/src/main/java/com/fieldbook/tracker/traits/BaseTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/BaseTraitLayout.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.preference.PreferenceManager;
 
@@ -68,6 +69,15 @@ public abstract class BaseTraitLayout extends LinearLayout {
     }
 
     public abstract void init(Activity act);
+
+    /**
+     * validate is used in collect activity to check if the collected data is within the
+     * specification of the trait, such as min/max.
+     */
+    @NonNull
+    public Boolean validate(String data) {
+        return true;
+    }
 
     /**
      * Override to block multi-measure navigation with specific condition
@@ -303,8 +313,8 @@ public abstract class BaseTraitLayout extends LinearLayout {
         ((CollectActivity) getContext()).updateObservation(trait, value, null);
     }
 
-    public void removeTrait(String parent) {
-        ((CollectActivity) getContext()).removeTrait(parent);
+    public void removeTrait(TraitObject trait) {
+        ((CollectActivity) getContext()).removeTrait(trait);
     }
 
     public void triggerTts(String text) {

--- a/app/src/main/java/com/fieldbook/tracker/traits/BooleanTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/BooleanTraitLayout.java
@@ -7,10 +7,13 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.SeekBar;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.CollectActivity;
+
+import java.util.Locale;
 
 public class BooleanTraitLayout extends BaseTraitLayout implements SeekBar.OnSeekBarChangeListener {
 
@@ -91,6 +94,16 @@ public class BooleanTraitLayout extends BaseTraitLayout implements SeekBar.OnSee
         super.deleteTraitListener();
 
         //resetToDefault();
+    }
+
+    @NonNull
+    @Override
+    public Boolean validate(String data) {
+        try {
+            return data.toLowerCase(Locale.ROOT).equals("true") || data.toLowerCase(Locale.ROOT).equals("false");
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     private void resetToDefault() {

--- a/app/src/main/java/com/fieldbook/tracker/traits/CategoricalTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/CategoricalTraitLayout.java
@@ -8,6 +8,7 @@ import android.view.ViewTreeObserver;
 import android.widget.Button;
 import android.widget.LinearLayout;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -15,6 +16,7 @@ import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.CollectActivity;
 import com.fieldbook.tracker.preferences.GeneralKeys;
 import com.fieldbook.tracker.utilities.CategoryJsonUtil;
+import com.fieldbook.tracker.utilities.Utils;
 import com.google.android.flexbox.AlignItems;
 import com.google.android.flexbox.FlexDirection;
 import com.google.android.flexbox.FlexWrap;
@@ -316,5 +318,22 @@ public class CategoricalTraitLayout extends BaseTraitLayout {
                 return scale.get(0).getValue();
             } else return scale.get(0).getLabel();
         } else return "";
+    }
+
+    @NonNull
+    @Override
+    public Boolean validate(String data) {
+
+        //check if the data is in the list of categories
+        ArrayList<BrAPIScaleValidValuesCategories> cats = getCategories();
+        if (CategoryJsonUtil.Companion.contains(cats, data)) {
+            return true;
+        } else {
+            getCollectActivity().runOnUiThread(() -> {
+                //Utils.makeToast(controller.getContext(),
+                //        controller.getContext().getString(R.string.trait_error_invalid_value));
+            });
+            return false;
+        }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/traits/CategoricalTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/CategoricalTraitLayout.java
@@ -324,15 +324,15 @@ public class CategoricalTraitLayout extends BaseTraitLayout {
     @Override
     public Boolean validate(String data) {
 
-        //check if the data is in the list of categories
-        ArrayList<BrAPIScaleValidValuesCategories> cats = getCategories();
-        if (CategoryJsonUtil.Companion.contains(cats, data)) {
-            return true;
-        } else {
-            getCollectActivity().runOnUiThread(() -> {
-                //Utils.makeToast(controller.getContext(),
-                //        controller.getContext().getString(R.string.trait_error_invalid_value));
-            });
+        try {
+            ArrayList<BrAPIScaleValidValuesCategories> userChosenCats = CategoryJsonUtil.Companion.decode(data);
+            if (userChosenCats.isEmpty()) {
+                return true;
+            } else {
+                ArrayList<BrAPIScaleValidValuesCategories> cats = getCategories();
+                return CategoryJsonUtil.Companion.contains(cats, userChosenCats.get(0));
+            }
+        } catch (Exception e) {
             return false;
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/traits/CounterTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/CounterTraitLayout.java
@@ -103,7 +103,7 @@ public class CounterTraitLayout extends BaseTraitLayout {
 
     @Override
     public void deleteTraitListener() {
-        removeTrait(getCurrentTrait().getName());
+        removeTrait(getCurrentTrait());
         super.deleteTraitListener();
         ObservationModel model = getCurrentObservation();
         if (model != null) {

--- a/app/src/main/java/com/fieldbook/tracker/traits/CounterTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/CounterTraitLayout.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.util.AttributeSet;
 
+import androidx.annotation.NonNull;
+
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.CollectActivity;
 import com.fieldbook.tracker.database.models.ObservationModel;
@@ -110,6 +112,17 @@ public class CounterTraitLayout extends BaseTraitLayout {
             getCollectInputView().setText(model.getValue());
         } else {
             getCollectInputView().setText("0");
+        }
+    }
+
+    @NonNull
+    @Override
+    public Boolean validate(String data) {
+        try {
+            Integer.parseInt(data);
+            return true;
+        } catch (Exception e) {
+            return false;
         }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/traits/DateTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/DateTraitLayout.java
@@ -369,7 +369,7 @@ public class DateTraitLayout extends BaseTraitLayout {
 
     @Override
     public void deleteTraitListener() {
-        removeTrait(getCurrentTrait().getName());
+        removeTrait(getCurrentTrait());
 
         super.deleteTraitListener();
 

--- a/app/src/main/java/com/fieldbook/tracker/traits/DateTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/DateTraitLayout.java
@@ -7,6 +7,7 @@ import android.util.AttributeSet;
 import android.util.Log;
 import android.widget.ImageButton;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 
@@ -422,5 +423,16 @@ public class DateTraitLayout extends BaseTraitLayout {
             e.printStackTrace();
         }
         return getMonthForInt(c.get(Calendar.MONTH)) + " " + String.format(Locale.getDefault(), "%02d", c.get(Calendar.DAY_OF_MONTH));
+    }
+
+    @NonNull
+    @Override
+    public Boolean validate(String data) {
+        try {
+            Date d = dateFormat.parse(data);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/traits/DiseaseRatingTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/DiseaseRatingTraitLayout.java
@@ -148,7 +148,7 @@ public class DiseaseRatingTraitLayout extends BaseTraitLayout {
 
     @Override
     public void deleteTraitListener() {
-        removeTrait(getCurrentTrait().getName());
+        removeTrait(getCurrentTrait());
         super.deleteTraitListener();
 
         ObservationModel model = getCurrentObservation();

--- a/app/src/main/java/com/fieldbook/tracker/traits/GNSSTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/GNSSTraitLayout.kt
@@ -1025,4 +1025,26 @@ class GNSSTraitLayout : BaseTraitLayout, GPSTracker.GPSTrackerListener {
 
         update()
     }
+
+    override fun validate(data: String?): Boolean {
+
+        if (data == null) return true
+
+        try {
+            val gson = GeoJsonUtil.decode(data)
+            return true
+        } catch (e: Exception) {
+            if (";" in data) {
+                val parts = data.split(";")
+                if (parts.size >= 2) {
+                    val lat = parts[0].toDoubleOrNull()
+                    val lng = parts[1].toDoubleOrNull()
+                    if (lat != null && lng != null) {
+                        return true
+                    }
+                }
+            }
+            return false
+        }
+    }
 }

--- a/app/src/main/java/com/fieldbook/tracker/traits/MultiCatTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/MultiCatTraitLayout.java
@@ -8,6 +8,7 @@ import android.view.ViewTreeObserver;
 import android.widget.Button;
 import android.widget.LinearLayout;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -15,6 +16,7 @@ import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.CollectActivity;
 import com.fieldbook.tracker.preferences.GeneralKeys;
 import com.fieldbook.tracker.utilities.CategoryJsonUtil;
+import com.fieldbook.tracker.utilities.Utils;
 import com.google.android.flexbox.AlignItems;
 import com.google.android.flexbox.FlexDirection;
 import com.google.android.flexbox.FlexWrap;
@@ -23,6 +25,7 @@ import com.google.android.flexbox.FlexboxLayoutManager;
 import org.brapi.v2.model.pheno.BrAPIScaleValidValuesCategories;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.StringJoiner;
 
 public class MultiCatTraitLayout extends BaseTraitLayout {
@@ -354,5 +357,34 @@ public class MultiCatTraitLayout extends BaseTraitLayout {
             } else joiner.add(s.getValue());
         }
         return joiner.toString();
+    }
+
+    @NonNull
+    @Override
+    public Boolean validate(String data) {
+
+        String[] classTokens = data.split(":");
+
+        boolean valid = false;
+
+        ArrayList<BrAPIScaleValidValuesCategories> cats = new ArrayList<>(Arrays.asList(getCategories()));
+
+        for (String token : classTokens) {
+
+            BrAPIScaleValidValuesCategories validValue = new BrAPIScaleValidValuesCategories()
+                    .label(token)
+                    .value(token);
+
+            valid = hasCategory(validValue);
+        }
+
+        //check if the data is in the list of categories
+        if (!valid) {
+            getCollectActivity().runOnUiThread(() ->
+                    Utils.makeToast(controller.getContext(),
+                            controller.getContext().getString(R.string.trait_error_invalid_multicat_value)));
+        }
+
+        return valid;
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/traits/MultiCatTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/MultiCatTraitLayout.java
@@ -16,11 +16,13 @@ import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.CollectActivity;
 import com.fieldbook.tracker.preferences.GeneralKeys;
 import com.fieldbook.tracker.utilities.CategoryJsonUtil;
+import com.fieldbook.tracker.utilities.JsonUtil;
 import com.fieldbook.tracker.utilities.Utils;
 import com.google.android.flexbox.AlignItems;
 import com.google.android.flexbox.FlexDirection;
 import com.google.android.flexbox.FlexWrap;
 import com.google.android.flexbox.FlexboxLayoutManager;
+import com.google.gson.JsonParseException;
 
 import org.brapi.v2.model.pheno.BrAPIScaleValidValuesCategories;
 
@@ -363,19 +365,34 @@ public class MultiCatTraitLayout extends BaseTraitLayout {
     @Override
     public Boolean validate(String data) {
 
-        String[] classTokens = data.split(":");
-
-        boolean valid = false;
-
         ArrayList<BrAPIScaleValidValuesCategories> cats = new ArrayList<>(Arrays.asList(getCategories()));
 
-        for (String token : classTokens) {
+        ArrayList<BrAPIScaleValidValuesCategories> userChosenCats = new ArrayList<>();
 
-            BrAPIScaleValidValuesCategories validValue = new BrAPIScaleValidValuesCategories()
-                    .label(token)
-                    .value(token);
+        try {
 
-            valid = hasCategory(validValue);
+            if (JsonUtil.Companion.isJsonValid(data)) {
+
+                userChosenCats.addAll(CategoryJsonUtil.Companion.decode(data));
+
+            } else throw new RuntimeException();
+
+        } catch (Exception e) {
+
+            String[] classTokens = data.split(":");
+
+            for (String token : classTokens) {
+
+                userChosenCats.add(new BrAPIScaleValidValuesCategories()
+                        .label(token)
+                        .value(token));
+            }
+        }
+
+        boolean valid = true;
+        for (BrAPIScaleValidValuesCategories cat : userChosenCats) {
+            valid = CategoryJsonUtil.Companion.contains(cats, cat);
+            if (!valid) break;
         }
 
         //check if the data is in the list of categories

--- a/app/src/main/java/com/fieldbook/tracker/traits/NumericTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/NumericTraitLayout.java
@@ -3,11 +3,15 @@ package com.fieldbook.tracker.traits;
 import android.app.Activity;
 import android.content.Context;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 
+import androidx.annotation.NonNull;
+
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.CollectActivity;
+import com.fieldbook.tracker.utilities.Utils;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -71,7 +75,7 @@ public class NumericTraitLayout extends BaseTraitLayout {
             @Override
             public boolean onLongClick(View v) {
                 getCollectInputView().setText("");
-                removeTrait(getCurrentTrait().getName());
+                removeTrait(getCurrentTrait());
                 return false;
             }
         });
@@ -94,6 +98,65 @@ public class NumericTraitLayout extends BaseTraitLayout {
     public void deleteTraitListener() {
         ((CollectActivity) getContext()).removeTrait();
         super.deleteTraitListener();
+    }
+
+    @NonNull
+    @Override
+    public Boolean validate(String data) {
+
+        if (isUnder(data) || isOver(data)) {
+
+            getCollectActivity().runOnUiThread(() -> {
+
+                if (isOver(data)) {
+                    Utils.makeToast(controller.getContext(),
+                            controller.getContext().getString(R.string.trait_error_maximum_value)
+                                    + ": " + getCurrentTrait().getMaximum());
+                } else if (isUnder(data)) {
+                    Utils.makeToast(controller.getContext(),
+                            controller.getContext().getString(R.string.trait_error_minimum_value)
+                                    + ": " + getCurrentTrait().getMinimum());
+                }
+            });
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public boolean isUnder(final String s) {
+
+        String minimum = getCurrentTrait().getMinimum();
+
+        if (!minimum.isEmpty()) {
+            try {
+                final double v = Double.parseDouble(s);
+                final double lowerValue = Double.parseDouble(minimum);
+                return v < lowerValue;
+            } catch (NumberFormatException e) {
+                return true;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    public boolean isOver(final String s) {
+
+        String maximum = getCurrentTrait().getMaximum();
+
+        if (!maximum.isEmpty()) {
+            try {
+                final double v = Double.parseDouble(s);
+                final double upperValue = Double.parseDouble(maximum);
+                return v > upperValue;
+            } catch (NumberFormatException e) {
+                return true;
+            }
+        } else {
+            return false;
+        }
     }
 
     private class NumberButtonOnClickListener implements OnClickListener {

--- a/app/src/main/java/com/fieldbook/tracker/traits/NumericTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/NumericTraitLayout.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.CollectActivity;
+import com.fieldbook.tracker.objects.TraitObject;
 import com.fieldbook.tracker.utilities.Utils;
 
 import java.util.LinkedHashMap;
@@ -104,15 +105,17 @@ public class NumericTraitLayout extends BaseTraitLayout {
     @Override
     public Boolean validate(String data) {
 
-        if (isUnder(data) || isOver(data)) {
+        TraitObject trait = getCurrentTrait();
+
+        if (isUnder(trait, data) || isOver(trait, data)) {
 
             getCollectActivity().runOnUiThread(() -> {
 
-                if (isOver(data)) {
+                if (isOver(trait, data)) {
                     Utils.makeToast(controller.getContext(),
                             controller.getContext().getString(R.string.trait_error_maximum_value)
                                     + ": " + getCurrentTrait().getMaximum());
-                } else if (isUnder(data)) {
+                } else if (isUnder(trait, data)) {
                     Utils.makeToast(controller.getContext(),
                             controller.getContext().getString(R.string.trait_error_minimum_value)
                                     + ": " + getCurrentTrait().getMinimum());
@@ -125,9 +128,9 @@ public class NumericTraitLayout extends BaseTraitLayout {
         return true;
     }
 
-    public boolean isUnder(final String s) {
+    public static boolean isUnder(TraitObject trait, final String s) {
 
-        String minimum = getCurrentTrait().getMinimum();
+        String minimum = trait.getMinimum();
 
         if (!minimum.isEmpty()) {
             try {
@@ -142,9 +145,9 @@ public class NumericTraitLayout extends BaseTraitLayout {
         }
     }
 
-    public boolean isOver(final String s) {
+    public static boolean isOver(TraitObject trait, final String s) {
 
-        String maximum = getCurrentTrait().getMaximum();
+        String maximum = trait.getMaximum();
 
         if (!maximum.isEmpty()) {
             try {

--- a/app/src/main/java/com/fieldbook/tracker/traits/PercentTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PercentTraitLayout.java
@@ -1,5 +1,8 @@
 package com.fieldbook.tracker.traits;
 
+import static com.fieldbook.tracker.traits.NumericTraitLayout.isOver;
+import static com.fieldbook.tracker.traits.NumericTraitLayout.isUnder;
+
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
@@ -8,10 +11,15 @@ import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.CollectActivity;
 import com.fieldbook.tracker.database.models.ObservationModel;
 import com.fieldbook.tracker.objects.TraitObject;
+import com.fieldbook.tracker.traits.formats.Formats;
+import com.fieldbook.tracker.traits.formats.Scannable;
+import com.fieldbook.tracker.traits.formats.TraitFormat;
 
 public class PercentTraitLayout extends BaseTraitLayout {
     private SeekBar seekBar;
@@ -181,6 +189,17 @@ public class PercentTraitLayout extends BaseTraitLayout {
             loadLayout();
         } catch (Exception e) {
             e.printStackTrace();
+        }
+    }
+
+    @NonNull
+    @Override
+    public Boolean validate(String data) {
+        try {
+            TraitObject trait = getCurrentTrait();
+            return !(isUnder(trait, data) || isOver(trait, data));
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/traits/PercentTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PercentTraitLayout.java
@@ -222,7 +222,7 @@ public class PercentTraitLayout extends BaseTraitLayout {
 
     @Override
     public void deleteTraitListener() {
-        removeTrait(getCurrentTrait().getName());
+        removeTrait(getCurrentTrait());
         super.deleteTraitListener();
         ObservationModel model = getCurrentObservation();
         seekBar.setOnSeekBarChangeListener(null);

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/BooleanFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/BooleanFormat.kt
@@ -15,5 +15,5 @@ class BooleanFormat : TraitFormat(
     stringNameAux = null,
     NameParameter(),
     DefaultToggleValueParameter(),
-    DetailsParameter()
-)
+    DetailsParameter(),
+), Scannable

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/CategoricalFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/CategoricalFormat.kt
@@ -23,4 +23,7 @@ class CategoricalFormat : TraitFormat(
     NameParameter(),
     DetailsParameter(),
     CategoriesParameter()
-), StringCoder by CategoricalJsonCoder(), ValuePresenter by CategoricalValuePresenter()
+),
+    StringCoder by CategoricalJsonCoder(),
+    ValuePresenter by CategoricalValuePresenter(),
+    Scannable

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/CounterFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/CounterFormat.kt
@@ -14,4 +14,4 @@ class CounterFormat : TraitFormat(
     stringNameAux = null,
     NameParameter(),
     DetailsParameter()
-)
+), Scannable

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/DateFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/DateFormat.kt
@@ -14,4 +14,4 @@ class DateFormat : TraitFormat(
     stringNameAux = null,
     NameParameter(),
     DetailsParameter()
-)
+), Scannable

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/DiseaseRatingFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/DiseaseRatingFormat.kt
@@ -14,4 +14,4 @@ class DiseaseRatingFormat : TraitFormat(
     stringNameAux = null,
     NameParameter(),
     DetailsParameter()
-)
+), Scannable

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/GnssFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/GnssFormat.kt
@@ -14,4 +14,4 @@ class GnssFormat : TraitFormat(
     stringNameAux = null,
     NameParameter(),
     DetailsParameter()
-)
+), Scannable

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/LocationFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/LocationFormat.kt
@@ -14,4 +14,4 @@ class LocationFormat : TraitFormat(
     stringNameAux = null,
     NameParameter(),
     DetailsParameter()
-)
+), Scannable

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/MultiCategoricalFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/MultiCategoricalFormat.kt
@@ -20,4 +20,4 @@ class MultiCategoricalFormat : TraitFormat(
     NameParameter(),
     DetailsParameter(),
     CategoriesParameter()
-), StringCoder by CategoricalJsonCoder(), ValuePresenter by CategoricalValuePresenter()
+), StringCoder by CategoricalJsonCoder(), ValuePresenter by CategoricalValuePresenter(), Scannable

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/NumericFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/NumericFormat.kt
@@ -36,7 +36,7 @@ open class NumericFormat(
     iconDrawableResourceId = iconDrawableResourceId,
     stringNameAux = null,
     *parameters
-) {
+), Scannable {
 
     override fun validate(
         context: Context,

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/PercentFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/PercentFormat.kt
@@ -28,4 +28,4 @@ class PercentFormat : NumericFormat(
         isRequired = true
     ),
     DetailsParameter()
-)
+), Scannable by PercentageScannable()

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/Scannable.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/Scannable.kt
@@ -1,0 +1,17 @@
+package com.fieldbook.tracker.traits.formats
+
+/**
+ * Interface for defining traits that can be scanned in from a barcode.
+ */
+interface Scannable {
+
+    fun preprocess(barcodeValue: String): String {
+        return barcodeValue
+    }
+}
+
+class PercentageScannable : Scannable {
+    override fun preprocess(barcodeValue: String): String {
+        return barcodeValue.replace("%", "")
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/TextFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/TextFormat.kt
@@ -18,4 +18,4 @@ class TextFormat : TraitFormat(
     DefaultValueParameter(),
     DetailsParameter(),
     CloseKeyboardParameter(false)
-)
+), Scannable

--- a/app/src/main/java/com/fieldbook/tracker/views/RangeBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/RangeBoxView.kt
@@ -380,7 +380,7 @@ class RangeBoxView : ConstraintLayout {
     // Simulate range right key press
     fun repeatKeyPress(directionStr: String) {
         val left = directionStr.equals("left", ignoreCase = true)
-        if (!controller.validateData()) {
+        if (!controller.validateData(controller.getCurrentObservation()?.value)) {
             return
         }
         if (rangeID.isNotEmpty()) {
@@ -546,7 +546,7 @@ class RangeBoxView : ConstraintLayout {
 
     ///// paging /////
     fun moveEntryLeft() {
-        if (!controller.validateData()) {
+        if (!controller.validateData(controller.getCurrentObservation()?.value)) {
             return
         }
         if (controller.getPreferences().getBoolean(GeneralKeys.ENTRY_NAVIGATION_SOUND, false)
@@ -570,7 +570,7 @@ class RangeBoxView : ConstraintLayout {
 
     fun moveEntryRight() {
         val traitBox = controller.getTraitBox()
-        if (!controller.validateData()) {
+        if (!controller.validateData(controller.getCurrentObservation()?.value)) {
             return
         }
         if (controller.getPreferences().getBoolean(GeneralKeys.ENTRY_NAVIGATION_SOUND, false)

--- a/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
@@ -400,16 +400,11 @@ class TraitBoxView : ConstraintLayout {
      * @param traitName the observation variable name
      * @param plotID the unique plot identifier to remove the observations from
      */
-    fun remove(traitName: String, plotID: String, rep: String) {
-        if (newTraits.containsKey(traitName)) newTraits.remove(traitName)
+    fun remove(trait: TraitObject, plotID: String, rep: String) {
+        if (newTraits.containsKey(trait.name)) newTraits.remove(trait.name)
         val studyId =
             controller.getPreferences().getInt(GeneralKeys.SELECTED_FIELD_ID, 0).toString()
-        val traitDbId = controller.getDatabase().getTraitByName(traitName).id
-        controller.getDatabase().deleteTrait(studyId, plotID, traitDbId, rep)
-    }
-
-    fun remove(trait: TraitObject, plotID: String, rep: String) {
-        remove(trait.name, plotID, rep)
+        controller.getDatabase().deleteTrait(studyId, plotID, trait.id, rep)
     }
 
     private fun createTraitOnTouchListener(

--- a/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
@@ -431,7 +431,7 @@ class TraitBoxView : ConstraintLayout {
         if (visibleTraitsList == null) return
 
         var pos = 0
-        if (!controller.validateData()) {
+        if (!controller.validateData(controller.getCurrentObservation()?.value)) {
             return
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1380,4 +1380,5 @@
     <string name="pref_geonav_distance_threshold_summary">GeoNav automatically stops when distance from all plots exceeds this value in kilometers.</string>
     <string name="pref_geonav_distance_threshold_title">Proximity Check</string>
     <string name="activity_collect_proximity_warning">GeoNav Stopping, outside proximity of coordinates</string>
+    <string name="trait_error_invalid_multicat_value">Invalid categorical data was entered.</string>
 </resources>


### PR DESCRIPTION
### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Barcodes scanned for data entry are now correctly checked for valid values
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)