### PR TITLE
setting_to_reset_all_settings

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
@@ -275,6 +275,9 @@ public class GeneralKeys {
     @NotNull
     public static final String EXPERIMENTAL_NEW_BRAPI_UI = "com.tracker.fieldbook.preferences.keys.enable_enhanced_brapi_import";
 
+    @NotNull
+    public static final String RESET_PREFERENCES = "RESET_PREFERENCES";
+
     private GeneralKeys() {
 
     }

--- a/app/src/main/java/com/fieldbook/tracker/preferences/SystemPreferencesFragment.kt
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/SystemPreferencesFragment.kt
@@ -41,6 +41,19 @@ class SystemPreferencesFragment : PreferenceFragmentCompat(),
             validateBrapiEnabledBeforeSetting(newValue.toString())
         }
 
+        val resetPref = findPreference<Preference>(GeneralKeys.RESET_PREFERENCES)
+        resetPref?.onPreferenceClickListener = Preference.OnPreferenceClickListener {
+            AlertDialog.Builder(context, R.style.AppAlertDialog)
+                .setTitle(R.string.reset_preferences_title)
+                .setMessage(R.string.reset_preferences_message)
+                .setPositiveButton(android.R.string.ok) { _, _ ->
+                    preferences.edit().clear().apply()
+                    activity?.finish()
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+            true
+        }
     }
 
     override fun onPreferenceChange(preference: Preference, newValue: Any): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1380,4 +1380,7 @@
     <string name="pref_geonav_distance_threshold_summary">GeoNav automatically stops when distance from all plots exceeds this value in kilometers.</string>
     <string name="pref_geonav_distance_threshold_title">Proximity Check</string>
     <string name="activity_collect_proximity_warning">GeoNav Stopping, outside proximity of coordinates</string>
+    <string name="preferences_system_defaults_reset">Reset Settings</string>
+    <string name="reset_preferences_title">Reset Settings to Default</string>
+    <string name="reset_preferences_message">Warning: this will reset all of Field Book\'s preferences.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -854,6 +854,12 @@
     <string name="database_reset_message">Database has been deleted</string>
     <string name="share_file_title">Sending file…</string>
 
+
+    <string name="preferences_storage_settings_title">Settings</string>
+    <string name="preferences_system_defaults_reset">Reset Settings</string>
+    <string name="reset_preferences_title">Reset Settings to Default</string>
+    <string name="reset_preferences_message">Warning: this will reset all of Field Book\'s preferences.</string>
+
     <!-- Experimental -->
     <string name="preferences_experimental_title">Experimental</string>
     <string name="preferences_experimental_stable_title">Stable</string>
@@ -1380,7 +1386,5 @@
     <string name="pref_geonav_distance_threshold_summary">GeoNav automatically stops when distance from all plots exceeds this value in kilometers.</string>
     <string name="pref_geonav_distance_threshold_title">Proximity Check</string>
     <string name="activity_collect_proximity_warning">GeoNav Stopping, outside proximity of coordinates</string>
-    <string name="preferences_system_defaults_reset">Reset Settings</string>
-    <string name="reset_preferences_title">Reset Settings to Default</string>
-    <string name="reset_preferences_message">Warning: this will reset all of Field Book\'s preferences.</string>
+
 </resources>

--- a/app/src/main/res/xml/preferences_system.xml
+++ b/app/src/main/res/xml/preferences_system.xml
@@ -35,11 +35,17 @@
             android:summary="@string/preferences_general_share_enable_description"
             android:title="@string/preferences_general_share_enable" />
 
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="settings_operations"
+        android:title="@string/preferences_storage_settings_title"
+        app:iconSpaceReserved="false">
+
         <Preference
             android:icon="@drawable/ic_refresh"
             android:key="RESET_PREFERENCES"
             android:title="@string/preferences_system_defaults_reset" />
-
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/app/src/main/res/xml/preferences_system.xml
+++ b/app/src/main/res/xml/preferences_system.xml
@@ -35,6 +35,11 @@
             android:summary="@string/preferences_general_share_enable_description"
             android:title="@string/preferences_general_share_enable" />
 
+        <Preference
+            android:icon="@drawable/ic_refresh"
+            android:key="RESET_PREFERENCES"
+            android:title="@string/preferences_system_defaults_reset" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [x] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Setting added to reset preferences to default
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)