### PR TITLE
delete_storage_crashes

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
@@ -55,6 +55,7 @@ import com.michaelflisar.changelog.classes.ImportanceChangelogSorter;
 import com.michaelflisar.changelog.internal.ChangelogDialogFragment;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.phenoapps.utils.BaseDocumentTreeUtil;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -318,7 +319,13 @@ public class ConfigActivity extends ThemedActivity {
                     break;
                 case 3:
                     if (checkTraitsExist() < 0) return;
-                    exportUtil.exportActiveField();
+                    if (BaseDocumentTreeUtil.Companion.getRoot(this) != null
+                            && BaseDocumentTreeUtil.Companion.isEnabled(this)
+                            && BaseDocumentTreeUtil.Companion.getDirectory(this, R.string.dir_field_export) != null) {
+                        exportUtil.exportActiveField();
+                    } else {
+                        Toast.makeText(this, R.string.error_storage_directory, Toast.LENGTH_LONG).show();
+                    }
                     break;
                 case 4:
                     intent.setClassName(ConfigActivity.this,

--- a/app/src/main/java/com/fieldbook/tracker/activities/FieldEditorActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/FieldEditorActivity.java
@@ -395,10 +395,14 @@ public class FieldEditorActivity extends ThemedActivity
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 switch (position) {
                     case 0:
-                        loadLocalPermission();
+                        if (checkDirectory()) {
+                            loadLocalPermission();
+                        }
                         break;
                     case 1:
-                        loadCloud();
+                        if (checkDirectory()) {
+                            loadCloud();
+                        }
                         break;
                     case 2:
                         FieldCreatorDialogFragment dialog = new FieldCreatorDialogFragment((ThemedActivity) FieldEditorActivity.this);
@@ -453,6 +457,17 @@ public class FieldEditorActivity extends ThemedActivity
             }
         } else {
             Toast.makeText(this, R.string.opening_brapi_no_network_error, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private Boolean checkDirectory() {
+        if (BaseDocumentTreeUtil.Companion.getRoot(this) != null
+                && BaseDocumentTreeUtil.Companion.isEnabled(this)
+                && BaseDocumentTreeUtil.Companion.getDirectory(this, R.string.dir_field_import) != null) {
+            return true;
+        } else {
+            Toast.makeText(this, R.string.error_storage_directory, Toast.LENGTH_LONG).show();
+            return false;
         }
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/activities/TraitEditorActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/TraitEditorActivity.java
@@ -9,7 +9,6 @@ import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.app.DialogFragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -57,8 +56,6 @@ import com.fieldbook.tracker.objects.FieldObject;
 import com.fieldbook.tracker.objects.ImportFormat;
 import com.fieldbook.tracker.objects.TraitObject;
 import com.fieldbook.tracker.preferences.GeneralKeys;
-import com.fieldbook.tracker.traits.formats.Formats;
-import com.fieldbook.tracker.utilities.ArrayIndexComparator;
 import com.fieldbook.tracker.utilities.CSVWriter;
 import com.fieldbook.tracker.utilities.FileUtil;
 import com.fieldbook.tracker.utilities.SharedPreferenceUtils;
@@ -78,7 +75,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -380,7 +376,13 @@ public class TraitEditorActivity extends ThemedActivity implements TraitAdapterC
         } else if (itemId == R.id.sortTrait) {
             showTraitSortDialog();
         } else if (itemId == R.id.importexport) {
-            importExportDialog();
+            if (BaseDocumentTreeUtil.Companion.getRoot(this) != null
+                    && BaseDocumentTreeUtil.Companion.isEnabled(this)
+                    && BaseDocumentTreeUtil.Companion.getDirectory(this, R.string.dir_trait) != null) {
+                importExportDialog();
+            } else {
+                Toast.makeText(this, R.string.error_storage_directory, Toast.LENGTH_LONG).show();
+            }
         } else if (itemId == R.id.toggleTrait) {
             changeAllVisibility();
         } else if (itemId == android.R.id.home) {
@@ -606,7 +608,7 @@ public class TraitEditorActivity extends ThemedActivity implements TraitAdapterC
         try {
             startActivityForResult(Intent.createChooser(intent, "cloudFile"), REQUEST_CLOUD_FILE_CODE);
         } catch (android.content.ActivityNotFoundException ex) {
-            Toast.makeText(getApplicationContext(), "No suitable File Manager was found.", Toast.LENGTH_SHORT).show();
+            Toast.makeText(getApplicationContext(), R.string.no_suitable_file_manager_was_found, Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/preferences/StoragePreferencesFragment.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/StoragePreferencesFragment.java
@@ -19,7 +19,9 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.preference.ListPreference;
@@ -104,12 +106,16 @@ public class StoragePreferencesFragment extends PreferenceFragmentCompat impleme
         Preference databaseDelete = findPreference("pref_database_delete");
 
         databaseImport.setOnPreferenceClickListener(preference -> {
-            importDatabaseFilePermission();
+            if (checkDirectory()) {
+                importDatabaseFilePermission();
+            }
             return true;
         });
 
         databaseExport.setOnPreferenceClickListener(preference -> {
-            exportDatabaseFilePermission();
+            if (checkDirectory()) {
+                exportDatabaseFilePermission();
+            }
             return true;
         });
 
@@ -117,6 +123,18 @@ public class StoragePreferencesFragment extends PreferenceFragmentCompat impleme
             showDatabaseResetDialog1();
             return true;
         });
+    }
+
+    @NonNull
+    private Boolean checkDirectory() {
+        if (BaseDocumentTreeUtil.Companion.getRoot(context) != null
+                && BaseDocumentTreeUtil.Companion.isEnabled(context)
+                && BaseDocumentTreeUtil.Companion.getDirectory(context, R.string.dir_database) != null) {
+            return true;
+        } else {
+            Toast.makeText(context, R.string.error_storage_directory, Toast.LENGTH_LONG).show();
+            return false;
+        }
     }
 
     @Override

--- a/app/src/main/java/com/fieldbook/tracker/utilities/ExportUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/ExportUtil.kt
@@ -524,7 +524,9 @@ class ExportUtil @Inject constructor(@ActivityContext private val context: Conte
                     } else {
                         if (preferences.getBoolean(GeneralKeys.EXPORT_OVERWRITE, false)) {
 
-                            archivePreviousExport(filesToExport.first())
+                            if (filesToExport.isNotEmpty()) {
+                                archivePreviousExport(filesToExport.first())
+                            }
                         }
                         filesToExport.firstOrNull()
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -587,6 +587,7 @@
     <string name="export_content_traits_all">All traits</string>
     <string name="export_content_traits_active">Only active traits</string>
     <string name="export_error_general">Error during export</string>
+    <string name="error_storage_directory">Storage directory is missing or corrupted.</string>
     <string name="export_error_data_missing">No data exists to export</string>
     <string name="export_complete">Export complete</string>
     <string name="export_progress">Exporting…</string>
@@ -1386,5 +1387,6 @@
     <string name="pref_geonav_distance_threshold_summary">GeoNav automatically stops when distance from all plots exceeds this value in kilometers.</string>
     <string name="pref_geonav_distance_threshold_title">Proximity Check</string>
     <string name="activity_collect_proximity_warning">GeoNav Stopping, outside proximity of coordinates</string>
+    <string name="no_suitable_file_manager_was_found">No suitable File Manager was found.</string>
 
 </resources>


### PR DESCRIPTION
### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Improved warnings for missing or corrupted storage directory
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)