### PR TITLE
Include changelog.xml update in release action

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -180,9 +180,7 @@ jobs:
         if: ${{ success() }}
         uses: EndBug/add-and-commit@v7
         with:
-          add: |
-            version.properties
-            CHANGELOG.md
+          add: "version.properties CHANGELOG.md app/src/main/res/raw/changelog.xml"
           message: "Bump ${{ env.BUMP_TYPE }} and update changelog for v${{ env.VERSION }}"
           token: ${{ secrets.ACTIONS_PAT }}
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -80,9 +80,40 @@ jobs:
           echo "patchVersion=$patchVersion" >> version.properties
 
           VERSION=$majorVersion.$minorVersion.$patchVersion
+          VERSION_CODE=$((majorVersion * 10000 + minorVersion * 100 + patchVersion))
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "VERSION_CODE=$VERSION_CODE" >> $GITHUB_ENV
 
-      - name: Process Changelog Changes
+      - name: Update changelog.xml
+        id: update-changelog-xml
+        run: |
+
+          # Read the Unreleased section and process notes based on type
+          RELEASE_CONTENT="" CURRENT_TYPE=""
+          while IFS= read -r note; do
+            if [[ "$note" == "### Added"* ]]; then
+              CURRENT_TYPE="new"
+            elif [[ "$note" == "### Changed"* ]]; then
+              CURRENT_TYPE="info"
+            elif [[ "$note" == "### Fixed"* ]]; then
+              CURRENT_TYPE="bugfix"
+            elif [[ "$note" =~ ^- ]]; then
+              clean_note=$(echo "$note" | sed -E 's/^- //; s/ *\(.*\)//')
+              pr_number=$(echo "$note" | grep -oP 'pull/\K[0-9]+' || echo "N/A")
+              RELEASE_CONTENT+="        <${CURRENT_TYPE}>${clean_note} (#${pr_number})</${CURRENT_TYPE}>\n"
+            fi
+          done < <(sed -n '/## \[Unreleased\]/,/^## /p' CHANGELOG.md | sed '1,2d' | sed '$d')
+
+          # Generate, insert, and log the new release block
+          today=$(date +'%Y-%m-%d')
+          RELEASE_BLOCK="    <release date=\"$today\" versionCode=\"$VERSION_CODE\" versionName=\"v$VERSION\">\n"
+          RELEASE_BLOCK+="$RELEASE_CONTENT"
+          RELEASE_BLOCK+="    </release>"
+          sed -i "/<changelog>/a \\\n$RELEASE_BLOCK" app/src/main/res/raw/changelog.xml
+          echo "Generated release block:"
+          echo -e "$RELEASE_BLOCK"
+
+      - name: Process CHANGELOG.md
         id: process-changelog
         run: |
           unreleased_section=$(sed -n '/## \[Unreleased\]/,/^## /p' CHANGELOG.md | sed '1,2d' | sed '$d')

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -99,8 +99,10 @@ jobs:
               CURRENT_TYPE="bugfix"
             elif [[ "$note" =~ ^- ]]; then
               clean_note=$(echo "$note" | sed -E 's/^- //; s/ *\(.*\)//')
-              pr_number=$(echo "$note" | grep -oP 'pull/\K[0-9]+' || echo "N/A")
-              RELEASE_CONTENT+="        <${CURRENT_TYPE}>${clean_note} (#${pr_number})</${CURRENT_TYPE}>\n"
+              RELEASE_CONTENT+="        <${CURRENT_TYPE}>${clean_note}</${CURRENT_TYPE}>\n"
+              #pr_number=$(echo "$note" | grep -oP 'pull/\K[0-9]+' || echo "N/A")
+              #RELEASE_CONTENT+="        <${CURRENT_TYPE}>${clean_note} (#${pr_number})</${CURRENT_TYPE}>\n"
+              
             fi
           done < <(sed -n '/## \[Unreleased\]/,/^## /p' CHANGELOG.md | sed '1,2d' | sed '$d')
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -14,9 +14,53 @@ on:
     types: [trigger-release]
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      release_required: ${{ steps.release-check.outputs.release_required }}
+      bump_type: ${{ steps.release-check.outputs.bump_type }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ACTIONS_PAT }}
+          fetch-depth: 0
+
+      - name: Determine Release Type and Necessity
+        id: release-check
+        run: |
+          if [ "${{ github.event_name }}" == "schedule" ]; then
+            LAST_RELEASE_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
+            echo "LAST_RELEASE_TAG: $LAST_RELEASE_TAG"
+
+            LAST_RELEASE_COMMIT=$(git rev-list -n 1 $LAST_RELEASE_TAG)
+            echo "LAST_RELEASE_COMMIT: $LAST_RELEASE_COMMIT"
+
+            changed_files=$(git diff-tree --no-commit-id --name-only $LAST_RELEASE_COMMIT HEAD | grep '^app' || echo "none")
+            echo "Changed files: $changed_files"
+
+            if [ "$changed_files" != "none" ]; then
+              echo "App directory has changed since the last release, proceeding with new release"
+              echo "release_required=true" >> $GITHUB_OUTPUT
+              echo "bump_type=patch" >> $GITHUB_OUTPUT
+            else
+              echo "No app directory changes since the last release. Skipping release."
+              echo "release_required=false" >> $GITHUB_OUTPUT
+            fi
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "release_required=true" >> $GITHUB_OUTPUT
+            echo "bump_type=${{ github.event.inputs.bump_type }}" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == "repository_dispatch" ]; then
+            echo "release_required=true" >> $GITHUB_OUTPUT
+            echo "bump_type=${{ github.event.client_payload.bump_type }}" >> $GITHUB_OUTPUT
+          else
+            echo "Unknown trigger source."
+            exit 1
+          fi
   release:
     runs-on: ubuntu-latest
-
+    needs: check-changes
+    if: needs.check-changes.outputs.release_required == 'true'
     steps:
 
       - name: Checkout Repo
@@ -25,50 +69,19 @@ jobs:
           token: ${{ secrets.ACTIONS_PAT }}
           fetch-depth: 0
 
-      - name: Determine Bump Type Based on Trigger
-        id: determine-bump-type
-        run: |
-          if [ "${{ github.event_name }}" == "schedule" ]; then
-            LAST_RELEASE_TAG=$(git describe --tags $(git rev-list --tags --max-count=1))
-            echo "LAST_RELEASE_TAG was $LAST_RELEASE_TAG"
-
-            LAST_RELEASE_COMMIT=$(git rev-list -n 1 $LAST_RELEASE_TAG)
-            echo "LAST_RELEASE_COMMIT was $LAST_RELEASE_COMMIT"
-            changed_files=$(git diff-tree --no-commit-id --name-only $LAST_RELEASE_COMMIT HEAD | grep '^app' || echo "none")
-            if [ "$changed_files" != "none" ]; then
-              echo "App directory has changed since the last release, proceeding with new release"
-            else
-              echo "No app directory changes since the last release. Skipping release."
-              exit 0
-            fi
-            BUMP_TYPE="patch"
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            BUMP_TYPE="${{ github.event.inputs.bump_type }}"
-          elif [ "${{ github.event_name }}" == "repository_dispatch" ]; then
-            BUMP_TYPE="${{ github.event.client_payload.bump_type }}"
-          else
-            echo "Unknown trigger source."
-            exit 1
-          fi
-
-          if [[ ! "$BUMP_TYPE" =~ ^(major|minor|patch)$ ]]; then
-            echo "Invalid bump type: $BUMP_TYPE"
-            exit 1
-          fi
-          echo "BUMP_TYPE=$BUMP_TYPE" >> $GITHUB_ENV
-
       - name: Bump Version in version.properties
         id: bump-version
         run: |
-          echo "Bumping version with BUMP_TYPE: $BUMP_TYPE"
+          bump_type="${{ needs.check-changes.outputs.bump_type }}"
+          echo "Bumping version with BUMP_TYPE: $bump_type"
 
           source version.properties
 
-          if [ "$BUMP_TYPE" == "major" ]; then
+          if [ "$bump_type" == "major" ]; then
               majorVersion=$((majorVersion + 1))
               minorVersion=0
               patchVersion=0
-          elif [ "$BUMP_TYPE" == "minor" ]; then
+          elif [ "$bump_type" == "minor" ]; then
               minorVersion=$((minorVersion + 1))
               patchVersion=0
           else

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,7 +1,38 @@
 <changelog>
 
     <release
-        date="2024-12-01"
+        date="2024-12-16"
+        versionCode="60020"
+        versionName="v6.0.2">
+        <new>Trial name included in BrAPI import and field details page</new>
+        <new>Image EXIF tag metadata includes the device pitch, roll, and yaw at the time of capture</new>
+        <new>Setting added to reset preferences to default</new>
+        <info>Fields with different BrAPI study IDs can now have the same name</info>
+        <bugfix>Min and max values now correctly saved for BrAPI traits</bugfix>
+        <bugfix>Label print observations are now assigned to the correct entry when navigating before the print is complete</bugfix>
+        <bugfix>Improved database export messaging</bugfix>
+        <bugfix>Go to ID dialog now has cursor focus when opened</bugfix>
+    </release>
+
+    <release
+        date="2024-12-09"
+        versionCode="60010"
+        versionName="v6.0.1">
+        <new>Accession number now included for germplasm imported via BrAPI</new>
+        <new>Option added at trait creation to keep keyboard closed when navigating to text traits</new>
+        <new>Proximity check added to disable GeoNav when away from field</new>
+        <new>Experimental setting to use media keys for entry/trait navigation and picture capture</new>
+        <info>Fields and traits that have already been imported are now hidden on the BrAPI import screen</info>
+        <info>Long-pressing delete button on bottom toolbar will remove all observations for that trait</info>
+        <info>Current time now used as lastSyncedTime when downloading Observations via BrAPI</info>
+        <info>lastSyncedTime updated after creating/updating Observations</info>
+        <info>Improved support for BrAPI servers not using https</info>
+        <bugfix>"observation_time_stamp" and "last_synced_time" now correctly saved in DAO</bugfix>
+        <bugfix>Synced and updated records now correctly identified</bugfix>
+    </release>
+
+    <release
+        date="2024-12-02"
         versionCode="60000"
         versionName="v6.0">
         <new>Fields list updated to include bulk actions and individual field pages</new>


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

Adds step to update changelog.xml file in github release action
closes #605

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [x] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note

```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)