### PR TITLE
display with default max of 100 if max not set

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/traits/PercentTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PercentTraitLayout.java
@@ -144,7 +144,10 @@ public class PercentTraitLayout extends BaseTraitLayout {
 
         if (value != null && !value.equals("NA") && !value.isEmpty()) {
 
-            seekBar.setMax(Integer.parseInt(getCurrentTrait().getMaximum()));
+            // Default to max 100 if maximum is not set
+            String maxString = getCurrentTrait().getMaximum();
+            int max = (maxString != null && !maxString.isEmpty()) ? Integer.parseInt(maxString) : 100;
+            seekBar.setMax(max);
 
             int textColor = value.equals(getDefaultValue()) ? Color.BLACK : Color.parseColor(getDisplayColor());
             setCurrentValueText(value, textColor);


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

Modifies code that displays collected percent values to use default of 100 if max is not set. This prevents crashes if max is not set and data has been collected, and [is consistent with the default max value used on init of the empty format](https://github.com/PhenoApps/Field-Book/blob/6dbbd7d903cbacecc676b0040efaa4f5acdb6465/app/src/main/java/com/fieldbook/tracker/traits/PercentTraitLayout.java#L56).

closes #1126

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Percent traits imported via BrAPI without min and max values default to 0/100
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)