### PR TITLE
brapi_export_window_leak_fix

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiActivity.java
@@ -1,5 +1,6 @@
 package com.fieldbook.tracker.activities.brapi;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.Gravity;
@@ -15,9 +16,11 @@ import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.arch.core.util.Function;
+import androidx.fragment.app.FragmentActivity;
 
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.ThemedActivity;
+import com.fieldbook.tracker.brapi.BrapiAuthDialogFragment;
 import com.fieldbook.tracker.brapi.BrapiLoadDialog;
 import com.fieldbook.tracker.brapi.model.BrapiObservationLevel;
 import com.fieldbook.tracker.brapi.model.BrapiStudyDetails;
@@ -48,6 +51,8 @@ public class BrapiActivity extends ThemedActivity {
     public static final String PROGRAM_DB_ID_INTENT_PARAM = "programDbId";
     private List<BrapiObservationLevel> observationLevels;
     private BrapiObservationLevel selectedObservationLevel;
+
+    private BrapiAuthDialogFragment brapiAuth = new BrapiAuthDialogFragment().newInstance();
 
     @Override
     public void onDestroy() {
@@ -177,7 +182,9 @@ public class BrapiActivity extends ThemedActivity {
                     public void run() {
                         // Show error message. We don't finish the activity intentionally.
                         if(BrAPIService.isConnectionError(code)){
-                            BrAPIService.handleConnectionError(BrapiActivity.this, code);
+                            if (BrAPIService.handleConnectionError(BrapiActivity.this, code)) {
+                                showBrapiAuthDialog();
+                            }
                         }else {
                             Toast.makeText(getApplicationContext(), getString(R.string.brapi_studies_error), Toast.LENGTH_LONG).show();
                         }
@@ -189,6 +196,18 @@ public class BrapiActivity extends ThemedActivity {
 
             }
         });
+    }
+
+    private void showBrapiAuthDialog() {
+        try {
+            runOnUiThread(() -> {
+                if (!brapiAuth.isVisible()) {
+                    brapiAuth.show(getSupportFragmentManager(), "BrapiAuthDialogFragment");
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     private void loadObservationLevels() {

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiExportActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiExportActivity.java
@@ -14,10 +14,12 @@ import android.widget.Toast;
 
 import androidx.appcompat.widget.Toolbar;
 import androidx.arch.core.util.Function;
+import androidx.fragment.app.FragmentActivity;
 
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.ThemedActivity;
 import com.fieldbook.tracker.brapi.ApiErrorCode;
+import com.fieldbook.tracker.brapi.BrapiAuthDialogFragment;
 import com.fieldbook.tracker.brapi.BrapiControllerResponse;
 import com.fieldbook.tracker.brapi.model.FieldBookImage;
 import com.fieldbook.tracker.brapi.model.Observation;
@@ -76,6 +78,8 @@ public class BrapiExportActivity extends ThemedActivity {
     private UploadError postImageMetaDataError;
     private UploadError putImageContentError;
     private UploadError putImageMetaDataError;
+
+    private final BrapiAuthDialogFragment brapiAuth = new BrapiAuthDialogFragment().newInstance();
 
     public BrapiExportActivity() {
 
@@ -547,7 +551,18 @@ public class BrapiExportActivity extends ThemedActivity {
                     putImageContentError == UploadError.API_UNAUTHORIZED_ERROR ||
                     putImageMetaDataError == UploadError.API_UNAUTHORIZED_ERROR) {
                 reset();
-                BrAPIService.handleConnectionError(this, 401);
+                boolean showDialog = BrAPIService.handleConnectionError(this, 401);
+                if (showDialog) {
+                    try {
+                        runOnUiThread(() -> {
+                            if (!brapiAuth.isVisible()) {
+                                brapiAuth.show(getSupportFragmentManager(), "BrapiAuthDialogFragment");
+                            }
+                        });
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
                 return;
             } else {
                 String message;
@@ -606,6 +621,14 @@ public class BrapiExportActivity extends ThemedActivity {
         editedObservations.clear();
         imagesNew.clear();
         imagesEditedIncomplete.clear();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (brapiAuth != null && brapiAuth.isAdded() && brapiAuth.isVisible()) {
+            brapiAuth.dismiss();
+        }
     }
 
     private UploadError processResponse(List<Observation> observationDbIds, List<Observation> observationsNeedingSync) {

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiProgramActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiProgramActivity.java
@@ -20,6 +20,7 @@ import androidx.arch.core.util.Function;
 
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.ThemedActivity;
+import com.fieldbook.tracker.brapi.BrapiAuthDialogFragment;
 import com.fieldbook.tracker.brapi.model.BrapiProgram;
 import com.fieldbook.tracker.brapi.service.BrAPIService;
 import com.fieldbook.tracker.brapi.service.BrAPIServiceFactory;
@@ -36,6 +37,8 @@ public class BrapiProgramActivity extends ThemedActivity {
     private BrapiPaginationManager paginationManager;
     private ListView programsView;
     private final ArrayList<BrapiProgram> programsList = new ArrayList<>();
+
+    private BrapiAuthDialogFragment brapiAuth = new BrapiAuthDialogFragment().newInstance();
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -141,7 +144,9 @@ public class BrapiProgramActivity extends ThemedActivity {
             (BrapiProgramActivity.this).runOnUiThread(() -> {
                 // Show error message. We don't finish the activity intentionally.
                 if(BrAPIService.isConnectionError(code)){
-                    BrAPIService.handleConnectionError(BrapiProgramActivity.this, code);
+                    if (BrAPIService.handleConnectionError(BrapiProgramActivity.this, code)) {
+                        showBrapiAuthDialog();
+                    }
                 }else {
                     Toast.makeText(getApplicationContext(), getString(R.string.brapi_programs_error), Toast.LENGTH_LONG).show();
                 }
@@ -149,6 +154,18 @@ public class BrapiProgramActivity extends ThemedActivity {
             });
             return null;
         });
+    }
+
+    private void showBrapiAuthDialog() {
+        try {
+            runOnUiThread(() -> {
+                if (!brapiAuth.isVisible()) {
+                    brapiAuth.show(getSupportFragmentManager(), "BrapiAuthDialogFragment");
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     private ListAdapter buildProgramsArrayAdapter(List<BrapiProgram> programs) {

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiTraitActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiTraitActivity.java
@@ -16,6 +16,7 @@ import androidx.arch.core.util.Function;
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.CollectActivity;
 import com.fieldbook.tracker.activities.ThemedActivity;
+import com.fieldbook.tracker.brapi.BrapiAuthDialogFragment;
 import com.fieldbook.tracker.brapi.service.BrAPIService;
 import com.fieldbook.tracker.brapi.service.BrAPIServiceFactory;
 import com.fieldbook.tracker.brapi.service.BrapiPaginationManager;
@@ -38,6 +39,8 @@ public class BrapiTraitActivity extends ThemedActivity {
     private BrAPIService brAPIService;
     private List<TraitObject> selectedTraits;
     private BrapiPaginationManager paginationManager;
+
+    private final BrapiAuthDialogFragment brapiAuth = new BrapiAuthDialogFragment().newInstance();
 
     @Inject
     DataHelper database;
@@ -188,7 +191,9 @@ public class BrapiTraitActivity extends ThemedActivity {
                     public void run() {
                         // Show error message. We don't finish the activity intentionally.
                         if(BrAPIService.isConnectionError(code)){
-                            BrAPIService.handleConnectionError(BrapiTraitActivity.this, code);
+                            if (BrAPIService.handleConnectionError(BrapiTraitActivity.this, code)) {
+                                showBrapiAuthDialog();
+                            }
                         }else {
                             Toast.makeText(getApplicationContext(), getString(R.string.brapi_ontology_error), Toast.LENGTH_LONG).show();
                         }
@@ -199,6 +204,18 @@ public class BrapiTraitActivity extends ThemedActivity {
                 return null;
             }
         });
+    }
+
+    private void showBrapiAuthDialog() {
+        try {
+            runOnUiThread(() -> {
+                if (!brapiAuth.isVisible()) {
+                    brapiAuth.show(getSupportFragmentManager(), "BrapiAuthDialogFragment");
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     // Transforms the trait data to display it on the screen.

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiTrialActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiTrialActivity.java
@@ -18,6 +18,7 @@ import androidx.arch.core.util.Function;
 
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.ThemedActivity;
+import com.fieldbook.tracker.brapi.BrapiAuthDialogFragment;
 import com.fieldbook.tracker.brapi.model.BrapiTrial;
 import com.fieldbook.tracker.brapi.service.BrAPIService;
 import com.fieldbook.tracker.brapi.service.BrAPIServiceFactory;
@@ -31,6 +32,8 @@ public class BrapiTrialActivity extends ThemedActivity {
     private BrAPIService brAPIService;
     private BrapiTrial brapiTrial;
     private BrapiPaginationManager paginationManager;
+
+    private final BrapiAuthDialogFragment brapiAuth = new BrapiAuthDialogFragment().newInstance();
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -114,7 +117,9 @@ public class BrapiTrialActivity extends ThemedActivity {
                     public void run() {
                         // Show error message. We don't finish the activity intentionally.
                         if(BrAPIService.isConnectionError(code)){
-                            BrAPIService.handleConnectionError(BrapiTrialActivity.this, code);
+                            if (BrAPIService.handleConnectionError(BrapiTrialActivity.this, code)) {
+                                showBrapiAuthDialog();
+                            }
                         }else {
                             Toast.makeText(getApplicationContext(), getString(R.string.brapi_trials_error), Toast.LENGTH_LONG).show();
                         }
@@ -124,6 +129,18 @@ public class BrapiTrialActivity extends ThemedActivity {
                 return null;
             }
         });
+    }
+
+    private void showBrapiAuthDialog() {
+        try {
+            runOnUiThread(() -> {
+                if (!brapiAuth.isVisible()) {
+                    brapiAuth.show(getSupportFragmentManager(), "BrapiAuthDialogFragment");
+                }
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     private ListAdapter buildTrialsArrayAdapter(List<BrapiTrial> trials) {

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
@@ -129,18 +129,15 @@ public interface BrAPIService {
         return code == 401 || code == 403 || code == 404;
     }
 
-    static void handleConnectionError(Context context, int code) {
+    static boolean handleConnectionError(Context context, int code) {
         ApiErrorCode apiErrorCode = ApiErrorCode.processErrorCode(code);
         String toastMsg;
 
+        boolean returnVal = false;
         switch (apiErrorCode) {
             case UNAUTHORIZED:
-                // Start the login process
-                ((Activity) context).runOnUiThread(() -> {
-                    BrapiAuthDialogFragment brapiAuth = new BrapiAuthDialogFragment().newInstance();
-                    brapiAuth.show(((FragmentActivity) context).getSupportFragmentManager(), "BrapiAuthDialogFragment");
-                });
                 toastMsg = context.getString(R.string.brapi_auth_deny);
+                returnVal = true;
                 break;
             case FORBIDDEN:
                 toastMsg = context.getString(R.string.brapi_auth_permission_deny);
@@ -155,6 +152,8 @@ public interface BrAPIService {
         ((Activity)context).runOnUiThread(() -> {
             Toast.makeText(context.getApplicationContext(), toastMsg, Toast.LENGTH_LONG).show();
         });
+
+        return returnVal;
     }
 
     void postImageMetaData(FieldBookImage image, final Function<FieldBookImage, Void> function, final Function<Integer, Void> failFunction);


### PR DESCRIPTION
### Description

closes #520



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
BrAPI export no longer crashes when authentication token is expired
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)