### PR TITLE
crop_image_feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -227,7 +227,10 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:1.3.6"
 
     //camerax
-    def camerax_version = "1.3.3"
+    def camerax_version = "1.4.1"
+
+    implementation "androidx.camera:camera-effects:$camerax_version"
+
     implementation "androidx.camera:camera-camera2:$camerax_version"
     implementation "androidx.camera:camera-lifecycle:$camerax_version"
     implementation "androidx.camera:camera-view:$camerax_version"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -206,6 +206,10 @@
                     android:scheme="fieldbook" />
             </intent-filter>
         </activity>
+        <activity android:name=".activities.CropImageActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize|locale"
+            android:launchMode="singleTop"
+            android:screenOrientation="portrait" />
         <activity
             android:name=".activities.brapi.BrapiExportActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|locale"

--- a/app/src/main/java/com/fieldbook/tracker/activities/CameraActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CameraActivity.kt
@@ -1,6 +1,8 @@
 package com.fieldbook.tracker.activities
 
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.util.Size
 import android.widget.ImageButton
 import android.widget.TextView
@@ -31,15 +33,20 @@ class CameraActivity : ThemedActivity() {
 
     private var supportedResolutions: List<Size> = listOf()
 
+    private var traitId: String? = null
+
     companion object {
 
         val TAG = CameraActivity::class.simpleName
         const val EXTRA_TITLE = "title"
-
+        const val EXTRA_TRAIT_ID = "trait_id"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        //get trait id from extras
+        traitId = intent.getStringExtra(EXTRA_TRAIT_ID)
 
         setContentView(R.layout.activity_camera)
 
@@ -115,7 +122,9 @@ class CameraActivity : ThemedActivity() {
             val resolution = getSupportedResolutionByPreferences()
 
             cameraXFacade.bindPreview(
-                previewView, resolution
+                previewView, resolution,
+                traitId,
+                Handler(Looper.getMainLooper())
             ) { camera, executor, capture ->
 
                 setupCaptureUi(camera, executor, capture)
@@ -139,8 +148,10 @@ class CameraActivity : ThemedActivity() {
                     object : ImageCapture.OnImageSavedCallback {
                         override fun onError(error: ImageCaptureException) {}
                         override fun onImageSaved(outputFileResults: ImageCapture.OutputFileResults) {
-                            setResult(RESULT_OK)
-                            finish()
+                            runOnUiThread {
+                                setResult(RESULT_OK)
+                                finish()
+                            }
                         }
                     })
             }

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -2902,6 +2902,7 @@ public class CollectActivity extends ThemedActivity
             Intent intent = new Intent(this, CropImageActivity.class);
             intent.putExtra(CropImageFragment.EXTRA_TRAIT_ID, Integer.parseInt(traitId));
             intent.putExtra(CropImageFragment.EXTRA_IMAGE_URI, uri.toString());
+            cameraXFacade.unbind();
             startActivity(intent);
         } catch (Exception e) {
             e.printStackTrace();
@@ -2912,6 +2913,7 @@ public class CollectActivity extends ThemedActivity
         try {
             Intent intent = new Intent(this, CameraActivity.class);
             intent.putExtra(CropImageFragment.EXTRA_TRAIT_ID, Integer.parseInt(getCurrentTrait().getId()));
+            cameraXFacade.unbind();
             startActivityForResult(intent, REQUEST_CROP_IMAGE_CODE);
         } catch (Exception e) {
             e.printStackTrace();

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -55,6 +55,7 @@ import com.fieldbook.tracker.devices.camera.CanonApi;
 import com.fieldbook.tracker.dialogs.GeoNavCollectDialog;
 import com.fieldbook.tracker.dialogs.ObservationMetadataFragment;
 import com.fieldbook.tracker.dialogs.SearchDialog;
+import com.fieldbook.tracker.fragments.CropImageFragment;
 import com.fieldbook.tracker.interfaces.FieldSwitcher;
 import com.fieldbook.tracker.location.GPSTracker;
 import com.fieldbook.tracker.objects.FieldObject;
@@ -117,6 +118,7 @@ import org.phenoapps.utils.SoftKeyboardUtil;
 import org.phenoapps.utils.TextToSpeechHelper;
 import org.threeten.bp.OffsetDateTime;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -153,6 +155,7 @@ public class CollectActivity extends ThemedActivity
         SensorHelper.RelativeRotationListener {
 
     public static final int REQUEST_FILE_EXPLORER_CODE = 1;
+    public static final int REQUEST_CROP_IMAGE_CODE = 101;
     public static final int BARCODE_COLLECT_CODE = 99;
     public static final int BARCODE_SEARCH_CODE = 98;
 
@@ -2116,6 +2119,13 @@ public class CollectActivity extends ThemedActivity
 
                 } else triggerTts(fail);
                 break;
+            case REQUEST_CROP_IMAGE_CODE:
+                if (resultCode == RESULT_OK) {
+                    File f = new File(getContext().getCacheDir(), AbstractCameraTrait.TEMPORARY_IMAGE_NAME);
+                    Uri uri = Uri.fromFile(f);
+                    startCropActivity(getCurrentTrait().getId(), uri);
+                }
+                break;
         }
     }
 
@@ -2881,6 +2891,50 @@ public class CollectActivity extends ThemedActivity
 
             Log.e(TAG, "Error logging study entry attributes: " + ex);
 
+        }
+    }
+
+    /**
+     * a function that starts the crop activity and sends it required intent data
+     */
+    public void startCropActivity(String traitId, Uri uri) {
+        try {
+            Intent intent = new Intent(this, CropImageActivity.class);
+            intent.putExtra(CropImageFragment.EXTRA_TRAIT_ID, Integer.parseInt(traitId));
+            intent.putExtra(CropImageFragment.EXTRA_IMAGE_URI, uri.toString());
+            startActivity(intent);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void requestAndCropImage() {
+        try {
+            Intent intent = new Intent(this, CameraActivity.class);
+            intent.putExtra(CropImageFragment.EXTRA_TRAIT_ID, Integer.parseInt(getCurrentTrait().getId()));
+            startActivityForResult(intent, REQUEST_CROP_IMAGE_CODE);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * shows an alert dialog that asks user to define a crop region
+     */
+    public void showCropDialog(String traitId, Uri uri) {
+        try {
+            AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.AppAlertDialog);
+            builder.setTitle(R.string.dialog_crop_title);
+            builder.setMessage(R.string.dialog_crop_message);
+            builder.setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                startCropActivity(traitId, uri);
+            });
+            builder.setNegativeButton(android.R.string.no, (dialog, which) -> {
+                dialog.dismiss();
+            });
+            builder.create().show();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/activities/CropImageActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CropImageActivity.kt
@@ -1,0 +1,34 @@
+package com.fieldbook.tracker.activities
+
+import android.os.Bundle
+import androidx.core.os.bundleOf
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
+import com.fieldbook.tracker.R
+import com.fieldbook.tracker.fragments.CropImageFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class CropImageActivity: ThemedActivity() {
+
+    companion object {
+        const val TAG = "CropImageActivity"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_crop_image)
+        if (savedInstanceState == null) {
+
+            val bundle = bundleOf(
+                CropImageFragment.EXTRA_TRAIT_ID to intent.getIntExtra(CropImageFragment.EXTRA_TRAIT_ID, -1),
+                CropImageFragment.EXTRA_IMAGE_URI to intent.getStringExtra(CropImageFragment.EXTRA_IMAGE_URI),
+            )
+
+            supportFragmentManager.commit {
+                setReorderingAllowed(true)
+                add<CropImageFragment>(R.id.fragment_container_view, args = bundle)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/activities/TraitEditorActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/TraitEditorActivity.java
@@ -399,6 +399,9 @@ public class TraitEditorActivity extends ThemedActivity implements TraitAdapterC
             Toast.makeText(this, R.string.act_trait_editor_no_traits_exist, Toast.LENGTH_SHORT).show();
         } else {
             showDeleteTraitDialog((dialog, which) -> {
+                for (TraitObject t : traits) {
+                    preferences.edit().remove(GeneralKeys.getCropCoordinatesKey(Integer.parseInt(t.getId()))).apply();
+                }
                 database.deleteTraitsTable();
                 queryAndLoadTraits();
                 dialog.dismiss();
@@ -585,6 +588,10 @@ public class TraitEditorActivity extends ThemedActivity implements TraitAdapterC
         ArrayList<TraitObject> traits = database.getAllTraitObjects();
 
         if (!traits.isEmpty()) {
+
+            for (TraitObject t : traits) {
+                preferences.edit().remove(GeneralKeys.getCropCoordinatesKey(Integer.parseInt(t.getId()))).apply();
+            }
 
             showDeleteTraitDialog((dialog, which) -> {
 
@@ -923,6 +930,8 @@ public class TraitEditorActivity extends ThemedActivity implements TraitAdapterC
 
         builder.setPositiveButton(getString(R.string.dialog_yes), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
+
+                preferences.edit().remove(GeneralKeys.getCropCoordinatesKey(Integer.parseInt(trait.getId()))).apply();
 
                 getDatabase().deleteTrait(trait.getId());
 

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -2104,12 +2104,13 @@ public class DataHelper {
      */
     public long editTraits(String traitDbId, String trait, String format, String defaultValue,
                            String minimum, String maximum, String details, String categories,
-                           Boolean closeKeyboardOnOpen) {
+                           Boolean closeKeyboardOnOpen,
+                           Boolean cropImage) {
 
         open();
 
         return ObservationVariableDao.Companion.editTraits(traitDbId, trait, format, defaultValue,
-                minimum, maximum, details, categories, closeKeyboardOnOpen);
+                minimum, maximum, details, categories, closeKeyboardOnOpen, cropImage);
 //        try {
 //            ContentValues c = new ContentValues();
 //            c.put("trait", trait);
@@ -2147,7 +2148,7 @@ public class DataHelper {
 
         return ObservationVariableDao.Companion.editTraits(trait.getId(), trait.getName(),
                 trait.getFormat(), trait.getDefaultValue(), trait.getMinimum(), trait.getMaximum(),
-                trait.getDetails(), trait.getCategories(), trait.getCloseKeyboardOnOpen());
+                trait.getDetails(), trait.getCategories(), trait.getCloseKeyboardOnOpen(), trait.getCropImage());
     }
 
     public boolean checkUnique(HashMap<String, String> values) {

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationVariableDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationVariableDao.kt
@@ -243,6 +243,7 @@ class ObservationVariableDao {
                         minimum = ""
                         categories = ""
                         closeKeyboardOnOpen = false
+                        cropImage = false
 
                         val values = ObservationVariableValueDao.getVariableValues(id.toInt())
                         values?.forEach { value ->
@@ -252,6 +253,7 @@ class ObservationVariableDao {
                                 "validValuesMax" -> maximum = value["observation_variable_attribute_value"] as? String ?: ""
                                 "category" -> categories = value["observation_variable_attribute_value"] as? String ?: ""
                                 "closeKeyboardOnOpen" -> closeKeyboardOnOpen = (value["observation_variable_attribute_value"] as? String ?: "false").toBoolean()
+                                "cropImage" -> cropImage = (value["observation_variable_attribute_value"] as? String ?: "false").toBoolean()
                             }
                         }
                     }
@@ -350,6 +352,7 @@ class ObservationVariableDao {
                 Log.d("ObservationVariableDao", "maximum: ${t.maximum.orEmpty()}")
                 Log.d("ObservationVariableDao", "categories: ${t.categories.orEmpty()}")
                 Log.d("ObservationVariableDao", "closeKeyboardOnOpen: ${t.closeKeyboardOnOpen ?: "false"}")
+                Log.d("ObservationVariableDao", "cropImage: ${t.cropImage ?: "false"}")
 
                 val varRowId = db.insert(ObservationVariable.tableName, null, contentValues)
 
@@ -359,6 +362,7 @@ class ObservationVariableDao {
                         t.maximum.orEmpty(),
                         t.categories.orEmpty(),
                         (t.closeKeyboardOnOpen ?: "false").toString(),
+                        (t.cropImage ?: "false").toString(),
                         varRowId.toString()
                     )
                     Log.d("ObservationVariableDao", "Trait ${t.name} inserted successfully with row ID: $varRowId")
@@ -390,7 +394,8 @@ class ObservationVariableDao {
         //TODO need to edit min/max/category obs. var. val/attrs
         fun editTraits(id: String, trait: String, format: String, defaultValue: String,
                        minimum: String, maximum: String, details: String, categories: String,
-                       closeKeyboardOnOpen: Boolean): Long = withDatabase { db ->
+                       closeKeyboardOnOpen: Boolean,
+                       cropImage: Boolean): Long = withDatabase { db ->
 
             val rowid = db.update(ObservationVariable.tableName, ContentValues().apply {
                 put("observation_variable_name", trait)
@@ -415,7 +420,10 @@ class ObservationVariableDao {
                         ObservationVariableValueDao.update(id, attrId.toString(), categories)
                     }
                     "closeKeyboardOnOpen" -> {
-                        ObservationVariableValueDao.insertCloseKeyboard(closeKeyboardOnOpen.toString(), id)
+                        ObservationVariableValueDao.insertAttributeValue(it, closeKeyboardOnOpen.toString(), id)
+                    }
+                    "cropImage" -> {
+                        ObservationVariableValueDao.insertAttributeValue(it, cropImage.toString(), id)
                     }
                 }
             }

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationVariableValueDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationVariableValueDao.kt
@@ -27,38 +27,32 @@ class ObservationVariableValueDao {
 
         }
 
-        fun insertCloseKeyboard(closeKeyboardOnOpen: String, id: String) = withDatabase { db ->
+        fun insertAttributeValue(attrName: String, value: String, id: String) = withDatabase { db ->
 
-            val attrId = ObservationVariableAttributeDao.getAttributeIdByName("closeKeyboardOnOpen")
+            val attrId = ObservationVariableAttributeDao.getAttributeIdByName(attrName)
 
             db.insert(ObservationVariableValue.tableName, null, contentValuesOf(
 
                 ObservationVariable.FK to id,
                 Migrator.ObservationVariableAttribute.FK to attrId,
-                "observation_variable_attribute_value" to closeKeyboardOnOpen
+                "observation_variable_attribute_value" to value
 
             ))
         }
 
-        fun insert(min: String, max: String, categories: String, closeKeyboardOnOpen: String, id: String) = withDatabase { db ->
+        fun insert(min: String, max: String, categories: String, closeKeyboardOnOpen: String, cropImage: String, id: String) = withDatabase { db ->
 
             //iterate through mapping of the old columns that are now attr/vals
             mapOf(
                     "validValuesMin" to min,
                     "validValuesMax" to max,
                     "category" to categories,
-                    "closeKeyboardOnOpen" to closeKeyboardOnOpen
+                    "closeKeyboardOnOpen" to closeKeyboardOnOpen,
+                    "cropImage" to cropImage
             ).asSequence().forEach { attrValue ->
 
-                val attrId = ObservationVariableAttributeDao.getAttributeIdByName(attrValue.key)
+                insertAttributeValue(attrValue.key, attrValue.value, id)
 
-                db.insert(ObservationVariableValue.tableName, null, contentValuesOf(
-
-                        ObservationVariable.FK to id,
-                        Migrator.ObservationVariableAttribute.FK to attrId,
-                        "observation_variable_attribute_value" to attrValue.value
-
-                ))
             }
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/VisibleObservationVariableDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/VisibleObservationVariableDao.kt
@@ -84,8 +84,10 @@ class VisibleObservationVariableDao {
 
                             "closeKeyboardOnOpen" -> closeKeyboardOnOpen =
                                 (it["observation_variable_attribute_value"] as? String ?: "false").toBoolean()
-                        }
 
+                            "cropImage" -> cropImage =
+                                (it["observation_variable_attribute_value"] as? String ?: "false").toBoolean()
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/fieldbook/tracker/dialogs/NewTraitDialog.kt
+++ b/app/src/main/java/com/fieldbook/tracker/dialogs/NewTraitDialog.kt
@@ -493,7 +493,8 @@ class NewTraitDialog(
             traitObject.maximum,
             traitObject.details,
             traitObject.categories,
-            traitObject.closeKeyboardOnOpen
+            traitObject.closeKeyboardOnOpen,
+            traitObject.cropImage
         )
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/fragments/CropImageFragment.kt
+++ b/app/src/main/java/com/fieldbook/tracker/fragments/CropImageFragment.kt
@@ -1,0 +1,92 @@
+package com.fieldbook.tracker.fragments
+
+import android.content.SharedPreferences
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import com.fieldbook.tracker.R
+import com.fieldbook.tracker.preferences.GeneralKeys
+import com.fieldbook.tracker.utilities.BitmapLoader
+import com.fieldbook.tracker.views.CropImageView
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * Controller code for handling user input for cropping an image.
+ */
+@AndroidEntryPoint
+class CropImageFragment: Fragment(R.layout.crop_image_fragment), CoroutineScope by MainScope() {
+
+    companion object {
+        const val TAG = "CropImageFragment"
+        const val EXTRA_TRAIT_ID = "traitId"
+        const val EXTRA_IMAGE_URI = "imageUri"
+    }
+
+    @Inject
+    lateinit var prefs: SharedPreferences
+
+    private var cropImageView: CropImageView? = null
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val traitId = requireArguments().getInt(EXTRA_TRAIT_ID)
+        val imageUri = requireArguments().getString(EXTRA_IMAGE_URI) ?: ""
+        cropImageView = view.findViewById(R.id.crop_image_view)
+        setupCropImageView(traitId, imageUri)
+    }
+
+    private fun setupCropImageView(traitId: Int, imageUri: String) {
+
+        cropImageView?.cropImageHandler = object: CropImageView.CropImageHandler {
+
+            override fun onCropImageSaved(rectCoordinates: String) {
+
+                //save the coordinate text to preferences, make the key relative to the input trait id
+                prefs.edit().putString(GeneralKeys.getCropCoordinatesKey(traitId), rectCoordinates).apply()
+
+                launch(Dispatchers.IO) {
+
+                    val uri = Uri.parse(imageUri)
+
+                    val croppedBmp = BitmapLoader.cropBitmap(context, uri, rectCoordinates)
+
+                    //save cropped bmp to uri
+                    context?.contentResolver?.openOutputStream(uri)?.use { output ->
+                        croppedBmp.compress(Bitmap.CompressFormat.JPEG, 80, output)
+                    }
+
+                    withContext(Dispatchers.Main) {
+
+                        //finish from the crop activity
+                        activity?.finish()
+                    }
+                }
+            }
+
+            override fun getCropCoordinates(): String {
+
+                return prefs.getString(GeneralKeys.getCropCoordinatesKey(traitId), "") ?: ""
+            }
+
+            override fun getImageUri() = imageUri
+        }
+
+        cropImageView?.post {
+            cropImageView?.initialize()
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        cancel()
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/objects/TraitObject.java
+++ b/app/src/main/java/com/fieldbook/tracker/objects/TraitObject.java
@@ -31,6 +31,7 @@ public class TraitObject {
     private String traitDataSource;
     private String additionalInfo;
     private Boolean closeKeyboardOnOpen = false;
+    private Boolean cropImage = false;
 
     /**
      * This is a BMS specific field. This will be populated when traits are imported from
@@ -189,12 +190,12 @@ public class TraitObject {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TraitObject that = (TraitObject) o;
-        return realPosition == that.realPosition && Objects.equals(name, that.name) && Objects.equals(format, that.format) && Objects.equals(defaultValue, that.defaultValue) && Objects.equals(minimum, that.minimum) && Objects.equals(maximum, that.maximum) && Objects.equals(details, that.details) && Objects.equals(categories, that.categories) && Objects.equals(id, that.id) && Objects.equals(visible, that.visible) && Objects.equals(externalDbId, that.externalDbId) && Objects.equals(traitDataSource, that.traitDataSource) && Objects.equals(additionalInfo, that.additionalInfo) && Objects.equals(observationLevelNames, that.observationLevelNames) && Objects.equals(closeKeyboardOnOpen, that.closeKeyboardOnOpen);
+        return realPosition == that.realPosition && Objects.equals(name, that.name) && Objects.equals(format, that.format) && Objects.equals(defaultValue, that.defaultValue) && Objects.equals(minimum, that.minimum) && Objects.equals(maximum, that.maximum) && Objects.equals(details, that.details) && Objects.equals(categories, that.categories) && Objects.equals(id, that.id) && Objects.equals(visible, that.visible) && Objects.equals(externalDbId, that.externalDbId) && Objects.equals(traitDataSource, that.traitDataSource) && Objects.equals(additionalInfo, that.additionalInfo) && Objects.equals(observationLevelNames, that.observationLevelNames) && Objects.equals(closeKeyboardOnOpen, that.closeKeyboardOnOpen) && Objects.equals(cropImage, that.cropImage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, format, defaultValue, minimum, maximum, details, categories, realPosition, id, visible, externalDbId, traitDataSource, additionalInfo, observationLevelNames, closeKeyboardOnOpen);
+        return Objects.hash(name, format, defaultValue, minimum, maximum, details, categories, realPosition, id, visible, externalDbId, traitDataSource, additionalInfo, observationLevelNames, closeKeyboardOnOpen, cropImage);
     }
 
     public TraitObject clone() {
@@ -215,6 +216,7 @@ public class TraitObject {
         t.setAdditionalInfo(this.additionalInfo);
         t.setObservationLevelNames(this.observationLevelNames);
         t.setCloseKeyboardOnOpen(this.closeKeyboardOnOpen);
+        t.setCropImage(this.cropImage);
 
         return t;
     }
@@ -225,5 +227,13 @@ public class TraitObject {
 
     public void setCloseKeyboardOnOpen(Boolean closeKeyboardOnOpen) {
         this.closeKeyboardOnOpen = closeKeyboardOnOpen;
+    }
+
+    public Boolean getCropImage() {
+        return cropImage;
+    }
+
+    public void setCropImage(Boolean cropImage) {
+        this.cropImage = cropImage;
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
@@ -278,6 +278,16 @@ public class GeneralKeys {
     @NotNull
     public static final String RESET_PREFERENCES = "RESET_PREFERENCES";
 
+    /**
+     * Function that returns the key for the crop coordinates of a trait
+     * @param traitId --the internal db id of the trait
+     * @return key used in preferences to obtain the (tl, tr, br, bl) coordinates used for cropping images
+     */
+    @NotNull
+    public static String getCropCoordinatesKey(int traitId) {
+        return "com.fieldbook.tracker.crop_coordinates." + traitId;
+    }
+
     private GeneralKeys() {
 
     }

--- a/app/src/main/java/com/fieldbook/tracker/traits/AbstractCameraTrait.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/AbstractCameraTrait.kt
@@ -39,6 +39,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import org.threeten.bp.OffsetDateTime
 import java.io.File
@@ -162,6 +163,16 @@ abstract class AbstractCameraTrait :
                 shutterButton?.performClick()
             }
         }
+    }
+
+    protected fun isCropRequired() = (currentTrait?.cropImage ?: false)
+
+    protected fun isCropExist() = (preferences.getString(GeneralKeys.getCropCoordinatesKey(currentTrait?.id?.toInt() ?: -1), "") ?: "").isNotEmpty()
+
+    protected fun requestCropDefinition(traitId: String, imageUri: Uri) {
+
+        (context as CollectActivity).showCropDialog(traitId, imageUri)
+
     }
 
     protected fun saveJpegToStorage(
@@ -318,7 +329,7 @@ abstract class AbstractCameraTrait :
 
                                 writeExif(file, studyId, saveTime)
 
-                                notifyItemInserted()
+                                notifyItemInserted(file.uri)
                             }
                         }
 
@@ -338,7 +349,7 @@ abstract class AbstractCameraTrait :
 
                                 writeExif(file, studyId, saveTime)
 
-                                notifyItemInserted()
+                                notifyItemInserted(file.uri)
 
                             } else {
 
@@ -352,15 +363,50 @@ abstract class AbstractCameraTrait :
         }
     }
 
-    private fun notifyItemInserted() {
+    private fun notifyItemInserted(uri: Uri) {
 
         ui.launch {
 
-            loadAdapterItems()
+            if (isCropRequired()) {
 
-            // update trait status as observation was saved
-            (context as CollectActivity).updateCurrentTraitStatus(true)
+                if (isCropExist()) {
+
+                    //get bitmap from uri, create new bitmap from preference roi and update uri to database
+                    val cropRect = preferences.getString(GeneralKeys.getCropCoordinatesKey(currentTrait.id.toInt()), "") ?: ""
+
+                    withContext(Dispatchers.IO) {
+
+                        //crop bmp
+                        val croppedBmp = BitmapLoader.cropBitmap(context, uri, cropRect)
+
+                        //save cropped bmp to uri
+                        context.contentResolver.openOutputStream(uri)?.use { output ->
+                            croppedBmp.compress(Bitmap.CompressFormat.JPEG, 80, output)
+                        }
+
+                        withContext(Dispatchers.Main) {
+                            loadItems()
+                        }
+                    }
+
+                } else {
+
+                    requestCropDefinition(currentTrait.id, uri)
+                }
+
+            } else {
+
+                loadItems()
+            }
         }
+    }
+
+    private fun loadItems() {
+
+        loadAdapterItems()
+
+        // update trait status as observation was saved
+        (context as CollectActivity).updateCurrentTraitStatus(true)
     }
 
     private fun getSelectedImage(): ImageAdapter.Model? {

--- a/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.kt
@@ -144,7 +144,9 @@ class PhotoTraitLayout : CameraTrait {
                 setupCaptureUi(camera, executor, capture)
             }
 
-        } catch (_: IllegalArgumentException) {
+        } catch (e: IllegalArgumentException) {
+
+            e.printStackTrace()
 
         }
     }
@@ -189,14 +191,17 @@ class PhotoTraitLayout : CameraTrait {
 
             controller.getCameraXFacade().bindPreview(
                 previewViewHolder?.previewView,
-                resolution
+                resolution,
+                currentTrait.id,
+                Handler(Looper.getMainLooper())
             ) { camera, executor, capture ->
 
                 setupCaptureUi(camera, executor, capture)
             }
 
-        } catch (_: IllegalArgumentException) {
+        } catch (e: IllegalArgumentException) {
 
+            e.printStackTrace()
         }
     }
 
@@ -246,6 +251,8 @@ class PhotoTraitLayout : CameraTrait {
             setupSystemCameraMode()
 
         } else {
+
+            controller.getCameraXFacade().unbind()
 
             previewViewHolder = null
 
@@ -323,7 +330,6 @@ class PhotoTraitLayout : CameraTrait {
         }
     }
 
-
     /**
      * When button is pressed, create a cached image and switch to the camera intent.
      * CollectActivity will receive REQUEST_IMAGE_CAPTURE and call this layout's makeImage() method.
@@ -352,7 +358,10 @@ class PhotoTraitLayout : CameraTrait {
     }
 
     private fun launchCameraX() {
+        controller.getCameraXFacade().unbind()
         val intent = Intent(context, CameraActivity::class.java)
+        //set current trait id to set crop region
+        intent.putExtra(CameraActivity.EXTRA_TRAIT_ID, currentTrait.id)
         activity?.startActivityForResult(intent, PICTURE_REQUEST_CODE)
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/BasePhotoFormat.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/BasePhotoFormat.kt
@@ -3,6 +3,7 @@ package com.fieldbook.tracker.traits.formats
 import android.content.Context
 import android.view.View
 import com.fieldbook.tracker.R
+import com.fieldbook.tracker.traits.formats.parameters.CropImageParameter
 import com.fieldbook.tracker.traits.formats.parameters.DetailsParameter
 import com.fieldbook.tracker.traits.formats.parameters.NameParameter
 import com.fieldbook.tracker.traits.formats.presenters.UriPresenter
@@ -26,4 +27,5 @@ open class BasePhotoFormat(
     stringNameAux = stringNameAux,
     NameParameter(),
     DetailsParameter(),
+    CropImageParameter()
 ), ValuePresenter by UriPresenter()

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/parameters/CropImageParameter.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/parameters/CropImageParameter.kt
@@ -1,0 +1,55 @@
+package com.fieldbook.tracker.traits.formats.parameters
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ToggleButton
+import com.fieldbook.tracker.R
+import com.fieldbook.tracker.database.DataHelper
+import com.fieldbook.tracker.objects.TraitObject
+import com.fieldbook.tracker.traits.formats.ValidationResult
+
+class CropImageParameter(private val initialDefaultValue: Boolean? = null) :
+    BaseFormatParameter(
+        nameStringResourceId = R.string.traits_crop_image_parameter,
+        defaultLayoutId = R.layout.list_item_trait_parameter_default_toggle_value,
+        parameter = Parameters.CROP_IMAGE
+    ) {
+
+    override fun createViewHolder(
+        parent: ViewGroup,
+    ): BaseFormatParameter.ViewHolder {
+        val v = LayoutInflater.from(parent.context)
+            .inflate(R.layout.list_item_trait_parameter_default_toggle_value, parent, false)
+        return ViewHolder(v)
+    }
+
+    inner class ViewHolder(itemView: View) : BaseFormatParameter.ViewHolder(itemView) {
+
+        val defaultValueToggle =
+            itemView.findViewById<ToggleButton>(R.id.dialog_new_trait_default_toggle_btn).also {
+                initialDefaultValue?.let { value ->
+                    it.isChecked = value
+                }
+            }
+
+        override fun merge(traitObject: TraitObject) = traitObject.apply {
+            cropImage = defaultValueToggle.isChecked
+        }
+
+        override fun load(traitObject: TraitObject?): Boolean {
+            try {
+                defaultValueToggle.isChecked = traitObject?.cropImage == true
+            } catch (e: Exception) {
+                e.printStackTrace()
+                return false
+            }
+            return true
+        }
+
+        override fun validate(
+            database: DataHelper,
+            initialTraitObject: TraitObject?
+        ) = ValidationResult()
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/traits/formats/parameters/Parameters.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/formats/parameters/Parameters.kt
@@ -2,7 +2,7 @@ package com.fieldbook.tracker.traits.formats.parameters
 
 enum class Parameters {
 
-    FORMAT, NAME, DEFAULT_VALUE, DETAILS, MAXIMUM, MINIMUM, CATEGORIES, CAMERA, CLOSE_KEYBOARD;
+    FORMAT, NAME, DEFAULT_VALUE, DETAILS, MAXIMUM, MINIMUM, CATEGORIES, CAMERA, CLOSE_KEYBOARD, CROP_IMAGE;
 
     companion object {
 
@@ -10,7 +10,8 @@ enum class Parameters {
             "validValuesMin",
             "validValuesMax",
             "category",
-            "closeKeyboardOnOpen"
+            "closeKeyboardOnOpen",
+            "cropImage",
         )
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/utilities/CameraXFacade.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/CameraXFacade.kt
@@ -1,26 +1,43 @@
 package com.fieldbook.tracker.utilities
 
 import android.content.Context
-import android.content.res.Configuration
+import android.graphics.Color
 import android.graphics.ImageFormat
+import android.graphics.Matrix
+import android.graphics.PorterDuff
+import android.graphics.Rect
+import android.graphics.RectF
+import android.graphics.Region
 import android.hardware.camera2.CameraCharacteristics
+import android.os.Build
+import android.os.Handler
 import android.util.Log
 import android.util.Size
+import android.util.TypedValue
 import androidx.annotation.OptIn
 import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.AspectRatio
 import androidx.camera.core.Camera
+import androidx.camera.core.CameraEffect.PREVIEW
+import androidx.camera.core.CameraEffect.IMAGE_CAPTURE
+import androidx.camera.core.CameraEffect.VIDEO_CAPTURE
 import androidx.camera.core.CameraSelector
 import androidx.camera.core.ImageCapture
 import androidx.camera.core.Preview
+import androidx.camera.core.UseCaseGroup
 import androidx.camera.core.resolutionselector.AspectRatioStrategy
 import androidx.camera.core.resolutionselector.ResolutionSelector
 import androidx.camera.core.resolutionselector.ResolutionStrategy
+import androidx.camera.effects.OverlayEffect
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
+import com.fieldbook.tracker.R
+import com.fieldbook.tracker.activities.ThemedActivity
+import com.fieldbook.tracker.preferences.GeneralKeys
+import com.fieldbook.tracker.views.CropImageView
 import dagger.hilt.android.qualifiers.ActivityContext
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -50,6 +67,7 @@ class CameraXFacade @Inject constructor(@ActivityContext private val context: Co
     }
 
     fun await(context: Context, onBindReady: () -> Unit) {
+        cameraXInstance.get().unbind()
         cameraXInstance.addListener({
             onBindReady()
         }, ContextCompat.getMainExecutor(context))
@@ -130,9 +148,13 @@ class CameraXFacade @Inject constructor(@ActivityContext private val context: Co
         }
     }
 
+    private var cropEffect: OverlayEffect? = null
+
     fun bindPreview(
         previewView: PreviewView?,
         targetResolution: Size?,
+        traitId: String? = null,
+        handler: Handler,
         onBind: (Camera, ExecutorService, ImageCapture) -> Unit
     ) {
 
@@ -163,13 +185,91 @@ class CameraXFacade @Inject constructor(@ActivityContext private val context: Co
 
         val p = prevBuilder.build()
 
-        p.setSurfaceProvider(previewView?.surfaceProvider)
+        p.surfaceProvider = previewView?.surfaceProvider
+
+        //close previous crop effect or else EGL leak
+        cropEffect?.close()
+
+        //create an overlay effect to draw a rectangle on the preview
+        cropEffect = OverlayEffect(VIDEO_CAPTURE or PREVIEW or IMAGE_CAPTURE, 0, handler) { e ->
+            Log.e(TAG, "OverlayEffect error: $e")
+        }
+
+        //parse crop from prefs
+        val cropCoordinates = (context as? ThemedActivity)?.prefs?.getString(GeneralKeys.getCropCoordinatesKey(
+            traitId?.toInt() ?: -1), "")
+
+        //overlay effect gives a frame that has an 'overlayCanvas'
+        cropEffect?.setOnDrawListener { frame ->
+            try {
+
+                //convert the camera sensor coordinates to local preview view coordinates
+                val sensorToUi = previewView!!.sensorToViewTransform
+                if (sensorToUi != null) {
+                    val sensorToEffect = frame.sensorToBufferTransform
+                    val uiToSensor = Matrix()
+                    sensorToUi.invert(uiToSensor)
+                    uiToSensor.postConcat(sensorToEffect)
+
+                    //get canvas and clear color, apply affine transformation
+                    val canvas = frame.overlayCanvas
+                    canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR)
+                    canvas.setMatrix(uiToSensor)
+
+                    //check that coordinates are correct, parse and draw the rect
+                    if (!cropCoordinates.isNullOrEmpty()) {
+                        val rect = CropImageView.parseRectCoordinates(cropCoordinates)
+                        if (rect != null) {
+                            //draw a rectangle on the left of the canvas
+                            //converts normalized coordinates to previewView-relative
+                            val left = rect.left*previewView.width
+                            val top = rect.top*previewView.height
+                            val right = rect.right*previewView.width
+                            val bottom = rect.bottom*previewView.height
+
+                            //newer APIs allow clipping a rect in two commands, earlier is a little more complex
+                            val clipRect = RectF(left, top, right, bottom)
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                canvas.clipOutRect(clipRect)
+                            } else {
+                                canvas.clipRect(clipRect, Region.Op.DIFFERENCE)
+                            }
+
+                            val typedValue = TypedValue()
+                            context.theme?.resolveAttribute(R.attr.fb_inverse_crop_region_color, typedValue, true)
+
+                            canvas.drawARGB(
+                                Color.alpha(typedValue.data),
+                                Color.red(typedValue.data),
+                                Color.green(typedValue.data),
+                                Color.blue(typedValue.data)
+                            )
+
+                            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                                canvas.clipRect(Rect(0, 0, previewView.width, previewView.height), Region.Op.REPLACE)
+                            }
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                //skip invalid region exceptions
+                if ("Region.Op" !in e.message.orEmpty())
+                    e.printStackTrace()
+            }
+
+            true
+        }
+
+        val useCaseGroup = UseCaseGroup.Builder()
+            .addUseCase(p)
+            .addUseCase(imageCapture)
+            .addEffect(cropEffect!!)
+            .build()
 
         val camera = cameraXInstance.get().bindToLifecycle(
             context as LifecycleOwner,
             frontSelector,
-            p,
-            imageCapture
+            useCaseGroup
         )
 
         Log.d(TAG, "Camera lifecycle bound: ${camera.cameraInfo}")

--- a/app/src/main/java/com/fieldbook/tracker/views/CameraTraitSettingsView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/CameraTraitSettingsView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.util.Size
 import android.view.View
+import android.widget.Button
 import android.widget.CheckBox
 import android.widget.FrameLayout
 import android.widget.RadioButton
@@ -12,6 +13,7 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.preference.PreferenceManager
 import com.fieldbook.tracker.R
+import com.fieldbook.tracker.activities.CollectActivity
 import com.fieldbook.tracker.preferences.GeneralKeys
 
 /**
@@ -29,6 +31,7 @@ open class CameraTraitSettingsView: ConstraintLayout {
     protected val resolutionGroup: RadioGroup
     protected val resolutionTitle: TextView
     protected val resolutionFrameLayout: FrameLayout
+    protected val cropButton: Button
 
     private var lastCameraId: Int? = null
     private var lastPreview: Boolean? = null
@@ -42,6 +45,7 @@ open class CameraTraitSettingsView: ConstraintLayout {
         resolutionGroup = view.findViewById(R.id.view_trait_photo_settings_resolution_rg)
         resolutionTitle = view.findViewById(R.id.view_trait_photo_settings_resolution_tv)
         resolutionFrameLayout = view.findViewById(R.id.view_trait_photo_settings_resolution_fl)
+        cropButton = view.findViewById(R.id.view_trait_photo_settings_crop_btn)
     }
 
     constructor(ctx: Context, supportedResolutions: List<Size>) : super(ctx) {
@@ -107,7 +111,16 @@ open class CameraTraitSettingsView: ConstraintLayout {
     private fun setup() {
 
         setupSystemCheckBox()
+        setupCropButton()
+    }
 
+    private fun setupCropButton() {
+
+        cropButton.setOnClickListener {
+
+            (context as CollectActivity).requestAndCropImage()
+
+        }
     }
 
     private fun setupSettingsModeBasedOnPreference(checkedRadioButtonId: Int) {

--- a/app/src/main/java/com/fieldbook/tracker/views/CameraTraitSettingsView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/CameraTraitSettingsView.kt
@@ -45,7 +45,12 @@ open class CameraTraitSettingsView: ConstraintLayout {
         resolutionGroup = view.findViewById(R.id.view_trait_photo_settings_resolution_rg)
         resolutionTitle = view.findViewById(R.id.view_trait_photo_settings_resolution_tv)
         resolutionFrameLayout = view.findViewById(R.id.view_trait_photo_settings_resolution_fl)
+
         cropButton = view.findViewById(R.id.view_trait_photo_settings_crop_btn)
+        // Set the visibility of the crop button to GONE if the trait does not support cropping
+        (context as CollectActivity).currentTrait.cropImage?.let {
+            cropButton.visibility = if (it) View.VISIBLE else View.GONE
+        }
     }
 
     constructor(ctx: Context, supportedResolutions: List<Size>) : super(ctx) {

--- a/app/src/main/java/com/fieldbook/tracker/views/CropImageView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/CropImageView.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
+import android.graphics.RectF
 import android.net.Uri
 import android.util.AttributeSet
 import android.view.MotionEvent
@@ -45,6 +46,31 @@ class CropImageView : ConstraintLayout {
     companion object {
         const val TAG = "CropImageView"
         const val MIN_DISTANCE_BETWEEN_HANDLES = 32
+
+        fun parseRectCoordinates(rectCoordinates: String): RectF? {
+
+            if (rectCoordinates.isNotBlank()) {
+                val rect = RectF()
+                val values = rectCoordinates.split(",")
+                if (values.size == 4) {
+                    try {
+                        rect.left = values[0].toFloat()
+                        rect.top = values[1].toFloat()
+                        rect.right = values[2].toFloat()
+                        rect.bottom = values[3].toFloat()
+
+                        return rect
+
+                    } catch (e: Exception) {
+
+                        e.printStackTrace()
+
+                    }
+                }
+            }
+
+            return null
+        }
     }
 
     interface CropImageHandler {

--- a/app/src/main/java/com/fieldbook/tracker/views/CropImageView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/CropImageView.kt
@@ -46,7 +46,7 @@ class CropImageView : ConstraintLayout {
     companion object {
         const val TAG = "CropImageView"
         const val MIN_DISTANCE_BETWEEN_HANDLES = 32
-
+        const val DEFAULT_CROP_COORDINATES = "0.00, 0.00, 1.00, 1.00"
         fun parseRectCoordinates(rectCoordinates: String): RectF? {
 
             if (rectCoordinates.isNotBlank()) {

--- a/app/src/main/java/com/fieldbook/tracker/views/CropImageView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/CropImageView.kt
@@ -1,0 +1,598 @@
+package com.fieldbook.tracker.views
+
+import android.annotation.SuppressLint
+import android.content.ClipData
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.net.Uri
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.inputmethod.EditorInfo
+import android.widget.EditText
+import android.widget.ImageButton
+import android.widget.ImageView
+import android.widget.RelativeLayout
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.marginBottom
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.fieldbook.tracker.R
+import com.fieldbook.tracker.utilities.VibrateUtil
+import com.google.android.material.button.MaterialButton
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.Locale
+import javax.inject.Inject
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.round
+import kotlin.math.sqrt
+
+/**
+ * Custom view to crop an image using handles.
+ * The view contains a bitmap image, and five handles to crop the image.
+ * The handles are draggable, and the image is cropped to the rectangle defined by the handles.
+ * The fifth handle is a middle handle that adjusts the location of the entire rect.
+ * The view also contains buttons to save, reset, copy, and expand the crop rectangle.
+ */
+@AndroidEntryPoint
+class CropImageView : ConstraintLayout {
+
+    companion object {
+        const val TAG = "CropImageView"
+        const val MIN_DISTANCE_BETWEEN_HANDLES = 32
+    }
+
+    interface CropImageHandler {
+        fun onCropImageSaved(rectCoordinates: String)
+        fun getImageUri(): String
+        fun getCropCoordinates(): String
+    }
+
+    @Inject
+    lateinit var vibrateUtil: VibrateUtil
+
+    //interface reference
+    var cropImageHandler: CropImageHandler? = null
+
+    private var cropHandleTop: ImageView? = null
+    private var cropHandleBottom: ImageView? = null
+    private var cropHandleStart: ImageView? = null
+    private var cropHandleEnd: ImageView? = null
+    private var cropHandleMid: ImageView? = null
+
+    //declare buttons
+    private var saveButton: MaterialButton? = null
+    private var resetButton: ImageButton? = null
+    private var copyButton: ImageButton? = null
+    private var expandButton: ImageButton? = null
+
+    private var relativeLayout: RelativeLayout? = null
+
+    //declare edit text
+    private var editText: EditText? = null
+
+    private var imageView: OverlayImageView? = null
+
+    //size of the handle image view, set in dimens.xml
+    private val handleSize: Int
+
+    //global handle that tracks which handle was last clicked
+    private var handle: ImageView? = null
+
+    //bitmap that holds the image to crop
+    private var bitmap: Bitmap? =
+        null // = BitmapFactory.decodeStream(resources.openRawResource(R.raw.chip))
+
+    init {
+
+        //allows child views to run onDraw function on invalidation
+        setWillNotDraw(false)
+
+        //half the size of the handle, to center on lines
+        handleSize = resources.getDimensionPixelSize(R.dimen.crop_handle_size)
+
+        val view = inflate(context, R.layout.view_crop_image, this)
+
+        //get the handles
+        cropHandleTop = view.findViewById(R.id.crop_top_handle)
+        cropHandleBottom = view.findViewById(R.id.crop_bottom_handle)
+        cropHandleStart = view.findViewById(R.id.crop_start_handle)
+        cropHandleEnd = view.findViewById(R.id.crop_end_handle)
+        cropHandleMid = view.findViewById(R.id.crop_mid_handle)
+
+        //initialize buttons
+        saveButton = view.findViewById(R.id.crop_save_btn)
+        resetButton = view.findViewById(R.id.crop_reset_btn)
+        copyButton = view.findViewById(R.id.crop_copy_btn)
+        expandButton = view.findViewById(R.id.crop_expand_btn)
+
+        //initialize edit text
+        editText = view.findViewById(R.id.crop_image_tv)
+
+        //initialize image view
+        imageView = view.findViewById(R.id.crop_image_iv)
+
+        //initialize relative layout
+        relativeLayout = view.findViewById(R.id.crop_image_rl)
+
+        initExpandButton()
+        initEditText()
+        initResetButton()
+        initCopyButton()
+        initSaveButton()
+        init()
+    }
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
+        context,
+        attrs,
+        defStyleAttr
+    )
+
+    private fun distance(x1: Float, y1: Float, x2: Float, y2: Float): Float {
+        return sqrt((x2 - x1).toDouble() * (x2 - x1) + (y2 - y1).toDouble() * (y2 - y1)).toFloat()
+    }
+
+    fun initialize() {
+
+        try {
+
+            //set the crop coordinates from the handler
+            val rectCoordinates = cropImageHandler?.getCropCoordinates()
+            val imageUri = Uri.parse(cropImageHandler?.getImageUri())
+
+            editText?.setText(rectCoordinates)
+
+            //load, rotate and scale the image using a background coroutine
+            findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+
+                withContext(Dispatchers.IO) {
+
+                    //set the image uri from the handler
+                    BitmapFactory.decodeStream(context.contentResolver.openInputStream(imageUri))?.let { bmp ->
+
+                        bitmap = bmp
+
+                        //rotate bitmap if portrait
+                        if (bmp.width > bmp.height) {
+                            val matrix = android.graphics.Matrix()
+                            matrix.postRotate(90f)
+                            bitmap = Bitmap.createBitmap(
+                                bmp,
+                                0,
+                                0,
+                                bmp.width,
+                                bmp.height,
+                                matrix,
+                                true
+                            )
+                        }
+
+                        withContext(Dispatchers.Main) {
+
+                            invalidate()
+
+                            submitCoordinatesToUi()
+                        }
+                    }
+                }
+            }
+
+        } catch (e: Exception) {
+
+            e.printStackTrace()
+
+        }
+    }
+
+    /**
+     * Expand rect coordinates to the size of the image
+     */
+    private fun initExpandButton() {
+
+        expandButton?.setOnClickListener {
+
+            VibrateUtil(context).vibrate(1L)
+            VibrateUtil(context).vibrate(1L)
+
+            imageView?.let { iv ->
+
+                //reset handles to default positions
+                cropHandleTop?.let { top ->
+                    top.x = iv.x + iv.width / 2 - handleSize / 2
+                    top.y = iv.y - handleSize / 2
+                }
+
+                cropHandleBottom?.let { bot ->
+                    bot.x = iv.x + iv.width / 2 - handleSize / 2
+                    bot.y = iv.y + iv.height - handleSize / 2
+                }
+
+                cropHandleStart?.let { start ->
+                    start.x = iv.x - handleSize / 2
+                    start.y = iv.y + iv.height / 2 - handleSize / 2
+                }
+
+                cropHandleEnd?.let { end ->
+                    end.x = iv.x + iv.width - handleSize / 2
+                    end.y = iv.y + iv.height / 2 - handleSize / 2
+                }
+            }
+
+            invalidate()
+        }
+    }
+
+    private fun submitCoordinatesToUi() {
+        val input = editText!!.text.toString()
+        if (input.isNotBlank()) {
+            val values = input.split(",")
+            if (values.size == 4) {
+                try {
+                    val topLeftX = values[0].toFloat()
+                    val topLeftY = values[1].toFloat()
+                    val bottomRightX = values[2].toFloat()
+                    val bottomRightY = values[3].toFloat()
+
+                    imageView?.let { iv ->
+                        cropHandleTop?.y =
+                            iv.y + topLeftY * iv.height - handleSize / 2
+                        cropHandleBottom?.y =
+                            iv.y + bottomRightY * iv.height - handleSize / 2
+                        cropHandleStart?.x =
+                            iv.x + topLeftX * iv.width - handleSize / 2
+                        cropHandleEnd?.x =
+                            iv.x + bottomRightX * iv.width - handleSize / 2
+                    }
+
+                    editText?.clearFocus()
+
+                    invalidate()
+
+                } catch (e: Exception) {
+
+                    e.printStackTrace()
+
+                }
+            }
+        }
+    }
+
+    private fun initEditText() {
+
+        //detect action ime done on keyboard
+        editText?.setOnEditorActionListener { _, actionId, _ ->
+            //on action done/ok
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                submitCoordinatesToUi()
+            }
+            true
+        }
+    }
+
+    /**
+     * Save the coordinates to preferences.
+     */
+    private fun initSaveButton() {
+
+        saveButton?.setOnClickListener {
+
+            vibrateUtil.vibrate(1L)
+            vibrateUtil.vibrate(1L)
+
+            try {
+                cropImageHandler?.onCropImageSaved(editText?.text.toString())
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    /**
+     * Copies the coordinates to user clipboard.
+     */
+    private fun initCopyButton() {
+
+        copyButton?.setOnClickListener {
+
+            vibrateUtil.vibrate(1L)
+            vibrateUtil.vibrate(1L)
+
+            try {
+                //start a text share chooser
+                val text = editText?.text.toString()
+                val clipboard =
+                    context.getSystemService(Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                val clip = ClipData.newPlainText(context.getString(R.string.crop_image_clip_data_label), text)
+                clipboard.setPrimaryClip(clip)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    /**
+     * Resets the rect coordinates to what is saved currently.
+     */
+    private fun initResetButton() {
+
+        resetButton?.setOnClickListener {
+
+            vibrateUtil.vibrate(1L)
+            vibrateUtil.vibrate(1L)
+
+            //reset handles to default positions in preferences
+            editText?.setText(cropImageHandler?.getCropCoordinates())
+
+            submitCoordinatesToUi()
+
+            invalidate()
+        }
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    private fun init() {
+
+        /**
+         * pass touch events to parent, mid has slightly less elevation to give others priority
+         */
+        cropHandleTop?.setOnTouchListener { _, _ ->
+            handle = cropHandleTop
+            false
+        }
+
+        cropHandleBottom?.setOnTouchListener { _, _ ->
+            handle = cropHandleBottom
+            false
+        }
+
+        cropHandleStart?.setOnTouchListener { _, _ ->
+            handle = cropHandleStart
+            false
+        }
+
+        cropHandleEnd?.setOnTouchListener { _, _ ->
+            handle = cropHandleEnd
+            false
+        }
+
+        cropHandleMid?.setOnTouchListener { _, _ ->
+            handle = cropHandleMid
+            false
+        }
+
+        /**
+         * Handle touch events over the entire view, ignore some touch events that are outside the image
+         */
+        //set touch area to the size of the crop image view
+        setOnTouchListener { _, event ->
+
+            imageView?.let { iv ->
+
+                //return early if views are null
+                if (cropHandleBottom == null
+                    || cropHandleTop == null
+                    || cropHandleStart == null
+                    || cropHandleEnd == null
+                    || cropHandleMid == null) return@setOnTouchListener true
+
+                //don't allow touch events below the image
+                if (event.y > iv.y + iv.height + iv.marginBottom / 2) {
+                    return@setOnTouchListener true
+                }
+
+                //detect the closest handle to the touch event on action down
+                if (event.action == MotionEvent.ACTION_DOWN) {
+
+                    vibrateUtil.vibrate(1L)
+
+                    //find handle that the event is closest to
+                    val topDistance = distance(event.x, event.y, cropHandleTop!!.x, cropHandleTop!!.y)
+                    val bottomDistance =
+                        distance(event.x, event.y, cropHandleBottom!!.x, cropHandleBottom!!.y)
+                    val startDistance =
+                        distance(event.x, event.y, cropHandleStart!!.x, cropHandleStart!!.y)
+                    val endDistance = distance(event.x, event.y, cropHandleEnd!!.x, cropHandleEnd!!.y)
+                    val midDistance = distance(event.x, event.y, cropHandleMid!!.x, cropHandleMid!!.y)
+
+                    if (topDistance <= bottomDistance && topDistance <= startDistance && topDistance <= endDistance) {
+                        handle = cropHandleTop
+                    }
+
+                    if (bottomDistance <= topDistance && bottomDistance <= startDistance && bottomDistance <= endDistance) {
+                        handle = cropHandleBottom
+                    }
+
+                    if (startDistance <= topDistance && startDistance <= bottomDistance && startDistance <= endDistance) {
+                        handle = cropHandleStart
+                    }
+
+                    if (endDistance <= topDistance && endDistance <= bottomDistance && endDistance <= startDistance) {
+                        handle = cropHandleEnd
+                    }
+
+                    if (midDistance <= topDistance && midDistance <= bottomDistance && midDistance <= startDistance && midDistance <= endDistance) {
+                        handle = cropHandleMid
+                    }
+                }
+
+                //when touch drags, drag the handle that was closest on touch, but keep handle within bounds of image
+                //middle handle drags the entire crop rectangle
+                if (event.action == MotionEvent.ACTION_MOVE) {
+
+                    handle?.let { h ->
+
+                        if (h == cropHandleTop) {
+                            h.y = event.y
+                            if (h.y + handleSize / 2 < iv.y) {
+                                h.y = iv.y - handleSize / 2
+                            }
+                        } else if (h == cropHandleBottom) {
+                            h.y = event.y
+                            if (h.y + handleSize / 2 > iv.height + iv.y) {
+                                h.y = iv.height + iv.y - handleSize / 2
+                            }
+                        } else if (h == cropHandleStart) {
+                            h.x = event.x
+                            if (h.x < iv.x) {
+                                h.x = iv.x - handleSize / 2
+                            }
+                        } else if (h == cropHandleEnd) {
+                            h.x = event.x
+                            if (h.x + handleSize / 2 > iv.width + iv.x) {
+                                h.x = iv.width + iv.x - handleSize / 2
+                            }
+                        } else {
+                            //middle handle position is updated, other handles are updated in onDraw
+                            val deltaX = event.x - h.x
+                            val deltaY = event.y - h.y
+
+                            for (hand in setOf(
+                                cropHandleTop,
+                                cropHandleBottom,
+                                cropHandleStart,
+                                cropHandleEnd,
+                                cropHandleMid
+                            )) {
+                                hand?.x = hand!!.x + deltaX
+                                hand.y += deltaY
+                            }
+                        }
+
+                        invalidate()
+                    }
+
+                }
+            }
+
+            true
+        }
+    }
+
+    private fun updateEditTextValue() {
+
+        try {
+            val topLeftX = (cropHandleStart!!.x - imageView!!.x + handleSize / 2) / imageView!!.width
+            val topLeftY = (cropHandleTop!!.y - imageView!!.y + handleSize / 2) / imageView!!.height
+            val bottomRightX = (cropHandleEnd!!.x + handleSize / 2 - imageView!!.x) / imageView!!.width
+            val bottomRightY =
+                (cropHandleBottom!!.y - imageView!!.y + handleSize / 2) / imageView!!.height
+
+            editText?.setText(
+                String.format(
+                    Locale.getDefault(),
+                    "%.2f, %.2f, %.2f, %.2f",
+                    topLeftX,
+                    topLeftY,
+                    bottomRightX,
+                    bottomRightY
+                )
+            )
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+
+        try {
+
+            if (bitmap == null) {
+                return
+            }
+
+            //update handles to be within the bounds of the image
+            cropHandleTop?.y = round(
+                max(
+                    imageView!!.y - handleSize / 2,
+                    min(cropHandleTop!!.y, imageView!!.height.toFloat() + imageView!!.y)
+                )
+            )
+            cropHandleBottom?.y = round(
+                max(
+                    imageView!!.y,
+                    min(cropHandleBottom!!.y, imageView!!.height.toFloat() + imageView!!.y)
+                )
+            )
+            cropHandleStart?.x = round(
+                max(
+                    imageView!!.x - handleSize / 2,
+                    min(cropHandleStart!!.x, imageView!!.width.toFloat() + imageView!!.x)
+                )
+            )
+            cropHandleEnd?.x = round(
+                max(
+                    imageView!!.x,
+                    min(cropHandleEnd!!.x, imageView!!.width.toFloat() + imageView!!.x)
+                )
+            )
+            cropHandleMid?.x = round(
+                max(
+                    imageView!!.x,
+                    min(cropHandleMid!!.x, imageView!!.width.toFloat() + imageView!!.x)
+                )
+            )
+            cropHandleMid?.y = round(
+                max(
+                    imageView!!.y,
+                    min(cropHandleMid!!.y, imageView!!.height.toFloat() + imageView!!.y)
+                )
+            )
+
+            //update handles to not cross each other
+            if (cropHandleTop!!.y > cropHandleBottom!!.y - MIN_DISTANCE_BETWEEN_HANDLES) {
+                cropHandleTop!!.y = round(cropHandleBottom!!.y - MIN_DISTANCE_BETWEEN_HANDLES)
+            }
+
+            if (cropHandleStart!!.x > cropHandleEnd!!.x - MIN_DISTANCE_BETWEEN_HANDLES) {
+                cropHandleStart!!.x = round(cropHandleEnd!!.x - MIN_DISTANCE_BETWEEN_HANDLES)
+            }
+
+            if (cropHandleBottom!!.y < cropHandleTop!!.y + MIN_DISTANCE_BETWEEN_HANDLES) {
+                cropHandleBottom!!.y = round(cropHandleTop!!.y + MIN_DISTANCE_BETWEEN_HANDLES)
+            }
+
+            if (cropHandleEnd!!.x < cropHandleStart!!.x + MIN_DISTANCE_BETWEEN_HANDLES) {
+                cropHandleEnd!!.x = round(cropHandleStart!!.x + MIN_DISTANCE_BETWEEN_HANDLES)
+            }
+
+            //get midpoints
+            val midX = round((cropHandleStart!!.x + cropHandleEnd!!.x) / 2)
+            val midY = round((cropHandleTop!!.y + cropHandleBottom!!.y) / 2)
+
+            //set points to be middle of rect lines
+            cropHandleTop!!.x = midX
+            cropHandleBottom!!.x = midX
+            cropHandleStart!!.y = midY
+            cropHandleEnd!!.y = midY
+
+            //update mid handle to the mid point
+            cropHandleMid!!.x = midX
+            cropHandleMid!!.y = midY
+
+            //draw a rectangle between the two handles, notice relative to the imageView using OverlayImageView
+            //otherwise canvas draws underneath the image
+            //also add offset so rectangle intersects middle of handles
+            imageView?.drawRectangle(
+                bitmap!!, imageView!!.x, imageView!!.y, imageView!!.width, imageView!!.height,
+                cropHandleStart!!.x + handleSize / 2,
+                cropHandleTop!!.y + handleSize / 2,
+                cropHandleEnd!!.x + handleSize / 2,
+                cropHandleBottom!!.y + handleSize / 2
+            )
+
+            updateEditTextValue()
+
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/views/OverlayImageView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/OverlayImageView.kt
@@ -1,0 +1,90 @@
+package com.fieldbook.tracker.views
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.Rect
+import android.os.Build
+import android.util.AttributeSet
+import androidx.annotation.RequiresApi
+import com.fieldbook.tracker.R
+import androidx.appcompat.widget.AppCompatImageView
+
+/**
+ * An ImageView wrapper class that draws a rectangle around an image, leaving the outside semi-transparent.
+ */
+class OverlayImageView: AppCompatImageView {
+
+    private var topX: Float = 0f
+    private var topY: Float = 0f
+    private var bottomX: Float = 0f
+    private var bottomY: Float = 0f
+    private var bitmap: Bitmap? = null
+    private var parentX: Float = 0f
+    private var parentY: Float = 0f
+    private var parentWidth: Int = 0
+    private var parentHeight: Int = 0
+    private var parentRect: Rect? = null
+
+    private val rectPaint = Paint().also { paint ->
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            paint.color = context.getColor(R.color.main_primary)
+        } else {
+            paint.color = Color.BLACK
+        }
+        //create a dashed path
+        paint.style = Paint.Style.STROKE
+        paint.strokeWidth = 15f
+    }
+
+    private val paint = Paint()
+    private val porterDuffXfermode = PorterDuffXfermode(PorterDuff.Mode.OVERLAY)
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
+    //draw rect relative to this image view
+    fun drawRectangle(bitmap: Bitmap, parentX: Float, parentY: Float, parentWidth: Int, parentHeight: Int,
+                      topX: Float, topY: Float, bottomX: Float, bottomY: Float) {
+        this.topX = topX - x
+        this.topY = topY - y
+        this.bottomX = bottomX - x
+        this.bottomY = bottomY - y
+        this.bitmap = bitmap
+        this.parentX = parentX
+        this.parentY = parentY
+        this.parentWidth = parentWidth
+        this.parentHeight = parentHeight
+        this.parentRect = Rect(0, 0, parentWidth, parentHeight)
+
+        invalidate()
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+
+        bitmap?.let { bmp ->
+
+            parentRect?.let { parentRect ->
+
+                //set alpha to half and draw the full bitmap scaled to the parent
+                paint.alpha = 128
+                canvas.drawBitmap(bmp, null, parentRect, paint)
+
+                //enable porter duff overlay, draw rect with full alpha and then disable
+                paint.alpha = 255
+                paint.xfermode = porterDuffXfermode
+                canvas.drawRect(topX, topY, bottomX, bottomY, paint)
+                paint.xfermode = null
+
+                //draw the crop border
+                canvas.drawRect(topX, topY, bottomX, bottomY, rectPaint)
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/content_copy.xml
+++ b/app/src/main/res/drawable/content_copy.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M19,21H8V7H19M19,5H8A2,2 0,0 0,6 7V21A2,2 0,0 0,8 23H19A2,2 0,0 0,21 21V7A2,2 0,0 0,19 5M16,1H4A2,2 0,0 0,2 3V17H4V3H16V1Z"/>
+</vector>

--- a/app/src/main/res/drawable/crop_handle.xml
+++ b/app/src/main/res/drawable/crop_handle.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape android:shape="oval"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/main_primary" />
+</shape>

--- a/app/src/main/res/drawable/undo.xml
+++ b/app/src/main/res/drawable/undo.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M12.5,8C9.85,8 7.45,9 5.6,10.6L2,7V16H11L7.38,12.38C8.77,11.22 10.54,10.5 12.5,10.5C16.04,10.5 19.05,12.81 20.1,16L22.47,15.22C21.08,11.03 17.15,8 12.5,8Z"/>
+</vector>

--- a/app/src/main/res/drawable/undo_variant.xml
+++ b/app/src/main/res/drawable/undo_variant.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M13.5,7A6.5,6.5 0,0 1,20 13.5A6.5,6.5 0,0 1,13.5 20H10V18H13.5C16,18 18,16 18,13.5C18,11 16,9 13.5,9H7.83L10.91,12.09L9.5,13.5L4,8L9.5,2.5L10.92,3.91L7.83,7H13.5M6,18H8V20H6V18Z"/>
+</vector>

--- a/app/src/main/res/layout/activity_crop_image.xml
+++ b/app/src/main/res/layout/activity_crop_image.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/crop_image_fragment.xml
+++ b/app/src/main/res/layout/crop_image_fragment.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.fieldbook.tracker.views.CropImageView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/crop_image_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/list_item_image.xml
+++ b/app/src/main/res/layout/list_item_image.xml
@@ -5,7 +5,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_margin="4dp"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="@drawable/cell">
 
     <androidx.cardview.widget.CardView
         android:layout_width="@dimen/camera_preview_portrait_width"
@@ -41,6 +42,7 @@
         app:layout_constraintBottom_toBottomOf="parent"/>
 
     <ImageButton
+        android:layout_margin="8dp"
         android:background="@drawable/circle_background_simple"
         android:padding="8dp"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/list_item_image.xml
+++ b/app/src/main/res/layout/list_item_image.xml
@@ -20,7 +20,7 @@
 
         <ImageView
             android:adjustViewBounds="true"
-            android:scaleType="centerCrop"
+            android:scaleType="fitCenter"
             tools:src="@raw/chip"
             android:id="@+id/list_item_image_iv"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/view_crop_image.xml
+++ b/app/src/main/res/layout/view_crop_image.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageView
+        android:id="@+id/crop_top_handle"
+        android:layout_width="@dimen/crop_handle_size"
+        android:layout_height="@dimen/crop_handle_size"
+        android:contentDescription="TODO"
+        android:src="@drawable/crop_handle"
+        app:layout_constraintStart_toStartOf="@id/crop_image_iv"
+        app:layout_constraintEnd_toEndOf="@id/crop_image_iv"
+        app:layout_constraintTop_toTopOf="@id/crop_image_iv"
+        app:layout_constraintBottom_toTopOf="@id/crop_image_iv"
+        android:elevation="2dp"/>
+
+    <ImageView
+        android:id="@+id/crop_bottom_handle"
+        android:layout_width="@dimen/crop_handle_size"
+        android:layout_height="@dimen/crop_handle_size"
+        android:contentDescription="TODO"
+        android:src="@drawable/crop_handle"
+        app:layout_constraintTop_toBottomOf="@id/crop_image_iv"
+        app:layout_constraintStart_toStartOf="@id/crop_image_iv"
+        app:layout_constraintEnd_toEndOf="@id/crop_image_iv"
+        app:layout_constraintBottom_toBottomOf="@id/crop_image_iv"
+        android:elevation="2dp"/>
+
+    <ImageView
+        android:id="@+id/crop_start_handle"
+        android:layout_width="@dimen/crop_handle_size"
+        android:layout_height="@dimen/crop_handle_size"
+        android:contentDescription="TODO"
+        android:src="@drawable/crop_handle"
+        app:layout_constraintEnd_toStartOf="@id/crop_image_iv"
+        app:layout_constraintStart_toStartOf="@id/crop_image_iv"
+        app:layout_constraintTop_toTopOf="@id/crop_image_iv"
+        app:layout_constraintBottom_toBottomOf="@id/crop_image_iv"
+        android:elevation="2dp"/>
+
+    <ImageView
+        android:id="@+id/crop_end_handle"
+        android:layout_width="@dimen/crop_handle_size"
+        android:layout_height="@dimen/crop_handle_size"
+        android:contentDescription="TODO"
+        android:src="@drawable/crop_handle"
+        app:layout_constraintStart_toEndOf="@id/crop_image_iv"
+        app:layout_constraintEnd_toEndOf="@id/crop_image_iv"
+        app:layout_constraintBottom_toBottomOf="@id/crop_image_iv"
+        app:layout_constraintTop_toTopOf="@id/crop_image_iv"
+        android:elevation="2dp"/>
+
+    <ImageView
+        android:id="@+id/crop_mid_handle"
+        android:layout_width="@dimen/crop_handle_size"
+        android:layout_height="@dimen/crop_handle_size"
+        android:contentDescription="TODO"
+        android:src="@drawable/crop_handle"
+        app:layout_constraintStart_toStartOf="@id/crop_image_iv"
+        app:layout_constraintEnd_toEndOf="@id/crop_image_iv"
+        app:layout_constraintBottom_toBottomOf="@id/crop_image_iv"
+        app:layout_constraintTop_toTopOf="@id/crop_image_iv"
+        android:elevation="1dp"/>
+
+    <com.fieldbook.tracker.views.OverlayImageView
+        android:layout_width="@dimen/crop_image_portrait_width"
+        android:layout_height="@dimen/crop_image_portrait_height"
+        android:adjustViewBounds="true"
+        android:cropToPadding="true"
+        android:scaleType="centerCrop"
+        android:id="@+id/crop_image_iv"
+        tools:src="@raw/chip"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintVertical_bias="0.33"
+        app:layout_constraintDimensionRatio="4:3"/>
+
+    <RelativeLayout
+        android:id="@+id/crop_image_rl"
+        android:layout_marginTop="32dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:background="@drawable/cell"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/guideline"
+        app:layout_constraintTop_toBottomOf="@id/crop_image_iv">
+
+        <EditText
+            style="@style/CropEditTextStyle"
+            android:layout_margin="16dp"
+            android:id="@+id/crop_image_tv"
+            android:inputType="text"
+            android:text=""
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAlignment="center"
+            android:imeOptions="actionDone"
+            android:maxLines="1"
+            android:hint="(tl_x, tl_y, br_x, br_y)"/>
+
+    </RelativeLayout>
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.75"/>
+
+    <ImageButton
+        android:id="@+id/crop_copy_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="TODO"
+        android:scaleType="fitXY"
+        android:background="@drawable/cell"
+        android:src="@drawable/content_copy"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toEndOf="@id/guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/crop_image_rl"/>
+
+    <ImageButton
+        android:layout_marginStart="8dp"
+        android:id="@+id/crop_expand_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="TODO"
+        android:scaleType="fitXY"
+        android:background="@drawable/cell"
+        android:src="@drawable/arrow_expand"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toEndOf="@id/crop_copy_btn"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/crop_image_rl"/>
+
+    <ImageButton
+        android:id="@+id/crop_reset_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="TODO"
+        android:background="@drawable/cell"
+        android:scaleType="fitXY"
+        android:src="@drawable/undo_variant"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toEndOf="@id/guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/crop_copy_btn"
+        app:layout_constraintBottom_toBottomOf="@id/crop_image_rl"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:layout_margin="16dp"
+        android:id="@+id/crop_save_btn"
+        android:layout_width="0dp"
+        android:layout_height="?actionBarSize"
+        android:contentDescription="TODO"
+        android:text="Save"
+        android:textColor="@color/BLACK"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintVertical_bias="1"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/view_trait_photo_settings.xml
+++ b/app/src/main/res/layout/view_trait_photo_settings.xml
@@ -61,7 +61,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/view_trait_photo_settings_resolution_tv"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/view_trait_photo_settings_crop_btn"
         app:layout_constraintVertical_bias="0">
 
         <ScrollView
@@ -80,6 +80,17 @@
 
         </ScrollView>
     </FrameLayout>
+
+    <Button
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/view_trait_photo_settings_crop_btn"
+        android:text="@string/view_trait_photo_settings_crop"
+        android:layout_margin="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/view_trait_photo_settings_resolution_fl" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -314,4 +314,6 @@
     <attr name="fb_third_chip_color" format="color" />
     <attr name="fb_fourth_chip_color" format="color" />
 
+    <attr name="fb_inverse_crop_region_color" format="color"/>
+
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -37,6 +37,7 @@
     <color name="main_chip_first_color">#47b65d</color>
     <color name="main_chip_second_color">#00a771</color>
     <color name="main_chip_third_color">#009683</color>
+    <color name="main_inverse_crop_region_color">#80101010</color>
 
     <!-- blue theme colors -->
     <color name="blue_border">@color/BLACK</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+    <!-- crop handle default size -->
+    <dimen name="crop_handle_size">32dp</dimen>
+
     <!-- landscape image preview sizes for camera trait recycler view, these should be 4:3-->
     <dimen name="camera_preview_landscape_width">150dp</dimen>
     <dimen name="camera_preview_landscape_height">115dp</dimen>
@@ -8,6 +11,10 @@
     <!-- portrait image preview sizes for camera trait recycler view, these should be 4:3-->
     <dimen name="camera_preview_portrait_width">230dp</dimen>
     <dimen name="camera_preview_portrait_height">300dp</dimen>
+
+    <!-- 4:3 crop image sizes, a bit larger than the preview -->
+    <dimen name="crop_image_portrait_width">340dp</dimen>
+    <dimen name="crop_image_portrait_height">480dp</dimen>
 
     <dimen name="brapi_importer_filter_height">40dp</dimen>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1392,5 +1392,10 @@
     <string name="trait_error_invalid_multicat_value">Invalid categorical data was entered.</string>
     <string name="dialog_crash_report_title">Failed to load data</string>
     <string name="dialog_crash_report_message">Press OK to send an anonymous diagnostic report to help improve the app.</string>
+    <string name="traits_crop_image_parameter">Crop</string>
+    <string name="dialog_crop_title">Setup Crop Region</string>
+    <string name="dialog_crop_message">Define a crop region that will be applied to all future pictures for this trait.</string>
+    <string name="view_trait_photo_settings_crop">Set Crop Region</string>
+    <string name="crop_image_clip_data_label">Field Book crop region data</string>
 
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -129,6 +129,8 @@
         <item name="fb_heatmap_color_max">@color/main_heatmap_color_max</item>
 
         <item name="selected_date_circle_color">?fb_heatmap_color_medium</item>
+
+        <item name="fb_inverse_crop_region_color">@color/main_inverse_crop_region_color</item>
     </style>
 
     <!-- Blue Theme -->

--- a/app/src/main/res/values/styles_widgets.xml
+++ b/app/src/main/res/values/styles_widgets.xml
@@ -48,6 +48,12 @@
         <item name="android:textSize">?attr/fb_body_text_size</item>
     </style>
 
+    <style name="CropEditTextStyle" parent="EditTextStyle">
+        <item name="editTextColor">?attr/fb_color_text_dark</item>
+        <item name="backgroundTint">?attr/fb_color_primary_dark</item>
+        <item name="android:textSize">?attr/fb_body_text_size</item>
+    </style>
+
     <!-- generic text view styling -->
     <style name="TextViewStyle" parent="Widget.AppCompat.TextView">
         <item name="android:textSize">?attr/fb_body_text_size</item>


### PR DESCRIPTION
### Description

Photo traits can now define a crop region.

Workflow:
User must enable crop in trait definition, right now it is set to false as default. Like other trait parameters, this cannot be edited if data for that trait is already captured.

When observing data for that photo trait, the user can click the settings and define a crop region, or a dialog will show if the trait requires cropping and no region is defined when a photo is taken. In the latter case, the photo will be cropped and saved.

This feature introduced CropImageView which I added a fragment controller implementation along with an activity wrapper for the fragment. This is a modular and independent view, but requires two intent-based parameters, traitId (internal db id of the trait to update the crop region) and imageUri for the image to preview as it is cropped.

UI:
The CropImageView has a couple functionalities:
1. Users can drag the 4 boundary handles (top, bottom, start, end) within the bounds of the image to adjust ROI size
2. Users can drag the middle handle to move the entire region
3. Users can click save to save the rectangle coordinates to preferences for that trait
4. Users can click copy to save the rectangle coordinates to clipboard
5. Users can click reset to reset coordinates to the currently saved preferences
6. Users can click expand to reset coordinate to the image dimensions
7. Users can click/edit coordinate edit text, but coordinates will not be updated/invalidated unless the ACTION_DONE ime is pressed (the enter button)

Working with multiple devices:
User 1: set ROI, copy coordinate text and send to User 2
User 2: paste roi coordinates in edit text, press enter and save



- [ ] Needs testing on non-system cameras.
- [ ] Needs to disable crop setting button for traits that have it disabled.



https://github.com/user-attachments/assets/e8f68db7-df09-4071-b1d3-40b2f24c47dc




### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [x] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note

```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)