### PR TITLE
Export only active trait media files

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/utilities/ExportUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/ExportUtil.kt
@@ -506,7 +506,8 @@ class ExportUtil @Inject constructor(@ActivityContext private val context: Conte
      * will be added
      */
     private fun bundleMediaDirectories(studyName: String, mediaDir: DocumentFile) {
-        val traitList = exportTrait.map { trait -> trait.name }
+        // sanitize the trait names, this will be compared against already sanitized traitDirectories
+        val traitList = exportTrait.map { trait -> FileUtil.sanitizeFileName(trait.name) }
         val exportDir = BaseDocumentTreeUtil.getDirectory(context, R.string.dir_field_export)
         val tempDirName = "temp_export_${timeStamp.format(Calendar.getInstance().time)}"
         tempDirectory = exportDir?.createDirectory(tempDirName)


### PR DESCRIPTION
### Description
Fixes #995 

### Change Type

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Bundled media is now exported as expected for active and existing traits
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)