### PR TITLE
Fix for BrAPI Sync causing observation miscount and at times failure

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceV2.java
@@ -991,7 +991,7 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
                         Map<String, String> extVariableDbIdMap = getExtVariableDbIdMapping();
                         // Result contains a list of observation variables
                         List<BrAPIObservation> brapiObservationList = response.getResult().getData();
-                        final List<Observation> observationList = mapObservations(brapiObservationList, extVariableDbIdMap);
+                        final List<Observation> observationList = mapObservations(brapiObservationList, extVariableDbIdMap, observationVariableDbIds);
 
                         function.apply(observationList);
 
@@ -1072,9 +1072,13 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
      * @param brapiObservationList
      * @return list of Fieldbook Observation objects
      */
-    private List<Observation> mapObservations(List<BrAPIObservation> brapiObservationList, Map<String, String> extVariableDbIdMap) {
+    private List<Observation> mapObservations(List<BrAPIObservation> brapiObservationList, Map<String, String> extVariableDbIdMap, List<String> validVariableDbIds) {
         List<Observation> outputList = new ArrayList<>();
         for (BrAPIObservation brapiObservation : brapiObservationList) {
+
+            if (!validVariableDbIds.contains(brapiObservation.getObservationVariableDbId())) {
+                continue;
+            }
 
             Observation newObservation = new Observation();
             newObservation.setStudyId(brapiObservation.getStudyDbId());
@@ -1143,7 +1147,8 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
                             newObservations.addAll(
                                     mapObservations(
                                             phenotypesResponse.getResult().getData(),
-                                            getExtVariableDbIdMapping()
+                                            getExtVariableDbIdMapping(),
+                                            new ArrayList<>()
                                     )
                             );
                         }
@@ -1192,7 +1197,8 @@ public class BrAPIServiceV2 extends AbstractBrAPIService implements BrAPIService
                             newObservations.addAll(
                                     mapObservations(
                                             observationsResponse.getResult().getData(),
-                                            getExtVariableDbIdMapping()
+                                            getExtVariableDbIdMapping(),
+                                            new ArrayList<>()
                                     )
                             );
                         }


### PR DESCRIPTION
added obs. variable filtering in getObservations to match variables returned by getObservationVariables(studyId) (some programs send a subset of the actual variables, which lead to observation count mismatch from the getObservations(studyId) call)


### Change Type

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note

```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)