### PR TITLE
EXIF Bug

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/traits/AbstractCameraTrait.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/AbstractCameraTrait.kt
@@ -26,6 +26,7 @@ import com.fieldbook.tracker.adapters.ImageAdapter
 import com.fieldbook.tracker.database.internalTimeFormatter
 import com.fieldbook.tracker.database.models.ObservationModel
 import com.fieldbook.tracker.objects.RangeObject
+import com.fieldbook.tracker.objects.TraitObject
 import com.fieldbook.tracker.preferences.GeneralKeys
 import com.fieldbook.tracker.provider.GenericFileProvider
 import com.fieldbook.tracker.traits.formats.Formats
@@ -176,15 +177,15 @@ abstract class AbstractCameraTrait :
     }
 
     protected fun saveJpegToStorage(
-        format: String,
         data: ByteArray,
         obsUnit: RangeObject,
+        traitObj: TraitObject,
         saveTime: String,
         saveState: SaveState,
         offset: Int? = null
     ) {
 
-        saveToStorage(format, obsUnit, saveTime, saveState) { uri ->
+        saveToStorage(obsUnit, traitObj, saveTime, saveState) { uri ->
 
             if (saveState != SaveState.SINGLE_SHOT) {
 
@@ -244,10 +245,10 @@ abstract class AbstractCameraTrait :
         }
     }
 
-    protected fun saveBitmapToStorage(format: String, bmp: Bitmap, obsUnit: RangeObject) {
+    protected fun saveBitmapToStorage(bmp: Bitmap, obsUnit: RangeObject, traitObj: TraitObject) {
 
         saveToStorage(
-            format, obsUnit, saveTime = FileUtil.sanitizeFileName(
+            obsUnit, traitObj, saveTime = FileUtil.sanitizeFileName(
                 OffsetDateTime.now().format(
                     internalTimeFormatter
                 )
@@ -262,7 +263,7 @@ abstract class AbstractCameraTrait :
         }
     }
 
-    private fun writeExif(file: DocumentFile, studyId: String, timestamp: String) {
+    private fun writeExif(file: DocumentFile, studyId: String, entryId: String, traitId: String, timestamp: String) {
 
         //if sdk > 24, can write exif information to the image
         //goal is to encode observation variable model into the user comments
@@ -273,8 +274,8 @@ abstract class AbstractCameraTrait :
                 (controller.getContext() as CollectActivity).person,
                 timestamp,
                 database.getStudyById(studyId),
-                database.getObservationUnitById(currentRange.uniqueId),
-                database.getObservationVariableById(currentTrait.id),
+                database.getObservationUnitById(entryId),
+                database.getObservationVariableById(traitId),
                 file.uri,
                 controller.getRotationRelativeToDevice()
             )
@@ -282,14 +283,15 @@ abstract class AbstractCameraTrait :
     }
 
     private fun saveToStorage(
-        format: String,
         obsUnit: RangeObject,
+        traitObj: TraitObject,
         saveTime: String,
         saveState: SaveState,
         saver: (Uri) -> Unit
     ) {
 
         val plot = obsUnit.uniqueId
+        val traitId = traitObj.id.toString()
         val studyId = collectActivity.studyId
         val person = (activity as? CollectActivity)?.person
         val location = (activity as? CollectActivity)?.locationByPreferences
@@ -327,7 +329,7 @@ abstract class AbstractCameraTrait :
 
                             if (saveState == SaveState.SINGLE_SHOT) {
 
-                                writeExif(file, studyId, saveTime)
+                                writeExif(file, studyId, plot, traitId, saveTime)
 
                                 notifyItemInserted(file.uri)
                             }
@@ -347,7 +349,7 @@ abstract class AbstractCameraTrait :
 
                                 saver.invoke(file.uri)
 
-                                writeExif(file, studyId, saveTime)
+                                writeExif(file, studyId, plot, traitId, saveTime)
 
                                 notifyItemInserted(file.uri)
 

--- a/app/src/main/java/com/fieldbook/tracker/traits/CanonTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/CanonTraitLayout.kt
@@ -216,7 +216,7 @@ class CanonTraitLayout :
 
         uiScope.launch(Dispatchers.Main) {
 
-            saveJpegToStorage(type(), data, obsUnit, saveTime, saveState, offset)
+            saveJpegToStorage(data, obsUnit, currentTrait, saveTime, saveState, offset)
 
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/traits/GoProTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/GoProTraitLayout.kt
@@ -176,7 +176,7 @@ class GoProTraitLayout :
 
         ui.launch {
 
-            saveJpegToStorage(type(), bytes, data.range, data.time, SaveState.SINGLE_SHOT)
+            saveJpegToStorage(bytes, data.range, data.trait, data.time, SaveState.SINGLE_SHOT)
 
             shutterButton?.isEnabled = true
 

--- a/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.kt
@@ -323,9 +323,9 @@ class PhotoTraitLayout : CameraTrait {
             val data = stream.readBytes()
 
             saveJpegToStorage(
-                currentTrait.format,
                 data,
                 currentRange,
+                currentTrait,
                 FileUtil.sanitizeFileName(OffsetDateTime.now().format(internalTimeFormatter)),
                 SaveState.SINGLE_SHOT
             )

--- a/app/src/main/java/com/fieldbook/tracker/traits/UsbCameraTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/UsbCameraTraitLayout.kt
@@ -200,7 +200,7 @@ class UsbCameraTraitLayout : CameraTrait, UsbCameraApi.Callbacks {
 
                     controller.getSoundHelper().playShutter()
 
-                    saveBitmapToStorage(type(), bmp, currentRange)
+                    saveBitmapToStorage(bmp, currentRange, currentTrait)
 
                     activity?.runOnUiThread {
 


### PR DESCRIPTION
### Description
If user navigates while image is saving, an incorrect plot id could be saved in exif.

fixes #1301

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Exif user comment tag no longer populated by incorrect data
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)