### PR TITLE
adds new brapi traits to end of the trait list

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/BrapiStudyImportActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/BrapiStudyImportActivity.kt
@@ -51,6 +51,7 @@ import org.brapi.v2.model.pheno.BrAPIPositionCoordinateTypeEnum
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.collections.set
+import kotlin.math.max
 
 /**
  * receive study information including trial
@@ -623,7 +624,7 @@ class BrapiStudyImportActivity : ThemedActivity(), CoroutineScope by MainScope()
         sortId: String
     ) {
 
-        var maxVariableIndex = db.allTraitObjects.size - 1
+        var maxVariableIndex = db.maxPositionFromTraits + 1
 
         attributesTable?.get(study.studyDbId)?.let { studyAttributes ->
 

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/BrapiStudyImportActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/BrapiStudyImportActivity.kt
@@ -623,6 +623,8 @@ class BrapiStudyImportActivity : ThemedActivity(), CoroutineScope by MainScope()
         sortId: String
     ) {
 
+        var maxVariableIndex = db.allTraitObjects.size - 1
+
         attributesTable?.get(study.studyDbId)?.let { studyAttributes ->
 
             observationUnits[study.studyDbId]?.filter {
@@ -639,7 +641,9 @@ class BrapiStudyImportActivity : ThemedActivity(), CoroutineScope by MainScope()
                     details.trialName = study.trialName
 
                     details.traits = observationVariables[study.studyDbId]?.toList()
-                        ?.map { it.toTraitObject(this@BrapiStudyImportActivity) } ?: listOf()
+                        ?.map { it.toTraitObject(this@BrapiStudyImportActivity).also {
+                            it.realPosition = maxVariableIndex++
+                        } } ?: listOf()
 
                     val geoCoordinateColumnName = "geo_coordinates"
 

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/BrapiTraitImporterActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/BrapiTraitImporterActivity.kt
@@ -100,6 +100,8 @@ class BrapiTraitImporterActivity : BrapiTraitImportAdapter.TraitLoader, ThemedAc
             it.submitList(cache)
         }
 
+        var nextPosition = database.allTraitObjects?.size ?: 0
+
         finishButton?.setOnClickListener {
 
             recyclerView?.visibility = View.GONE
@@ -114,7 +116,9 @@ class BrapiTraitImporterActivity : BrapiTraitImportAdapter.TraitLoader, ThemedAc
 
             varUpdates.forEach { (t, u) ->
                 if (t in dbIds!!) {
-                    database.insertTraits(u)
+                    database.insertTraits(u.apply {
+                        realPosition = nextPosition++
+                    })
                 }
             }
 

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/BrapiTraitImporterActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/BrapiTraitImporterActivity.kt
@@ -100,7 +100,7 @@ class BrapiTraitImporterActivity : BrapiTraitImportAdapter.TraitLoader, ThemedAc
             it.submitList(cache)
         }
 
-        var nextPosition = database.allTraitObjects?.size ?: 0
+        var nextPosition = database.maxPositionFromTraits + 1
 
         finishButton?.setOnClickListener {
 

--- a/app/src/main/java/com/fieldbook/tracker/adapters/TraitAdapter.kt
+++ b/app/src/main/java/com/fieldbook/tracker/adapters/TraitAdapter.kt
@@ -81,7 +81,7 @@ class TraitAdapter(private val sorter: TraitSorter):
 
         val size = list.size
         for (i in 0 until size) {
-            sorter.getDatabase().updateTraitPosition(list[i].id, i)
+            sorter.getDatabase().updateTraitPosition(list[i].id, i + 1)
         }
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/dialogs/BrapiSyncObsDialog.kt
+++ b/app/src/main/java/com/fieldbook/tracker/dialogs/BrapiSyncObsDialog.kt
@@ -250,11 +250,14 @@ class BrapiSyncObsDialog(private val context: Context, private val syncControlle
             println("dbId: ${studyObservations.fieldBookStudyDbId}")
             val dataHelper = DataHelper(context)
 
+            var maxPosition = dataHelper.maxPositionFromTraits + 1
             val traitIdToType = mutableMapOf<String,String>()
             try {
                 //Sync the traits first and update date
                 for (trait in studyObservations.traitList) {
-                    dataHelper.insertTraits(trait)
+                    dataHelper.insertTraits(trait.also {
+                        it.realPosition = maxPosition++
+                    })
                 }
                 //link up the ids to the type for when we add in the observations
                 for (trait in studyObservations.traitList) {


### PR DESCRIPTION
fixes #1252

### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
New traits from BrAPI now appear at the end of the trait list
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)