### PR TITLE
added data validation to repeated measures

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/traits/DateTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/DateTraitLayout.java
@@ -31,6 +31,8 @@ import java.util.Locale;
 public class DateTraitLayout extends BaseTraitLayout {
 
     private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    private final SimpleDateFormat previewFormat = new SimpleDateFormat("MMM dd", Locale.getDefault());
+
     FloatingActionButton addDayBtn;
     FloatingActionButton minusDayBtn;
     FloatingActionButton saveDayBtn;
@@ -427,6 +429,10 @@ public class DateTraitLayout extends BaseTraitLayout {
             }
             return true;
         } catch (Exception e) {
+            try {
+                Date d = previewFormat.parse(data);
+                return true;
+            } catch (Exception ignore) {}
             return false;
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/views/CollectInputView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/CollectInputView.kt
@@ -131,7 +131,7 @@ class CollectInputView(context: Context, attributeSet: AttributeSet) : Constrain
      */
     fun clear() {
         if (isRepeatEnabled()) {
-            repeatView.clear()
+            repeatView.text = ""
         } else editText.text.clear()
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/views/RepeatedValuesView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/RepeatedValuesView.kt
@@ -98,6 +98,12 @@ class RepeatedValuesView(context: Context, attributeSet: AttributeSet) :
 
             if (!act.isTraitBlocked) {
 
+                val current = getSelectedModel()
+
+                if (current != null && !act.validateData(current.value)) {
+                    return@setOnClickListener
+                }
+
                 if (pager.currentItem < (pager.adapter?.count ?: 1) - 1) {
 
                     setCurrentItem(pager.currentItem + 1)
@@ -116,6 +122,12 @@ class RepeatedValuesView(context: Context, attributeSet: AttributeSet) :
             val act = context as CollectActivity
 
             if (!act.isTraitBlocked) {
+
+                val current = getSelectedModel()
+
+                if (current != null && !act.validateData(current.value)) {
+                    return@setOnClickListener
+                }
 
                 if (pager.currentItem > 0) {
 
@@ -140,6 +152,10 @@ class RepeatedValuesView(context: Context, attributeSet: AttributeSet) :
 
                 //only add new measurements if the current one has been observed
                 if (current != null && current.value.isNotEmpty()) {
+
+                    if (!act.validateData(current.value)) {
+                        return@setOnClickListener
+                    }
 
                     val model =
                         insertNewRep((mValues.maxOf { it.model.rep.toInt() } + 1).toString())


### PR DESCRIPTION
TODO: possibly add date trait intermediate representation

fixes #1268

### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Repeated measures no longer ignore trait limits
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)