### PR TITLE
fix for some preferences not saving

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
@@ -237,39 +237,6 @@ public class ConfigActivity extends ThemedActivity {
         Log.d(TAG, "preferencesSetup: " + BuildConfig.DEBUG);
 
         firstRunSetup();
-
-        migratePreferencesToDefault();
-    }
-
-    /**
-     * Transfer "Settings" preference file map values to default preferences map
-     */
-    private void migratePreferencesToDefault() {
-
-        SharedPreferences oldPreferences = getSharedPreferences(GeneralKeys.SHARED_PREF_FILE_NAME, Context.MODE_PRIVATE);
-        Set<? extends Map.Entry<String, ?>> entries = oldPreferences.getAll().entrySet();
-
-        SharedPreferences.Editor edit = preferences.edit();
-        for (Map.Entry<String, ?> entry : entries) {
-            Object value = entry.getValue();
-            String key = entry.getKey();
-
-            if (value instanceof Boolean) {
-                edit.putBoolean(key, ((Boolean) value));
-            } else if (value instanceof String) {
-                edit.putString(key, ((String) value));
-            } else if (value instanceof Float) {
-                edit.putFloat(key, ((Float) value));
-            } else if (value instanceof Integer) {
-                edit.putInt(key, ((Integer) value));
-            } else if (value instanceof Long) {
-                edit.putLong(key, ((Long) value));
-            } else if (value instanceof HashSet) {
-                edit.putStringSet(key, ((HashSet<String>) value));
-            }
-        }
-
-        edit.apply();
     }
 
     private void showChangelog(Boolean managedShow, Boolean rateButton) {


### PR DESCRIPTION
fixes #1323

Reproduced this error by installing 5.4, which uses the old preference settings file, installing 6.2.5, which showed the issue's behavior. Deleted the respective code which was originally suppose to run once, but is likely unnecessary now.
 
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Settings are no longer reset on restart
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)