### PR TITLE
hide trait box arrow for one active trait

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
@@ -118,6 +118,8 @@ class TraitBoxView : ConstraintLayout {
         } else {
             traitsStatusBarRv?.visibility = GONE
         }
+
+        updateTraitBoxArrows()
     }
 
     fun handleTraitTypeWrapping() {
@@ -186,7 +188,14 @@ class TraitBoxView : ConstraintLayout {
         }
 
         updateTraitsStatusBar()
+        updateTraitBoxArrows()
+    }
 
+    private fun updateTraitBoxArrows() { // hide arrows if only one trait is active
+        val shouldShowArrows = visibleTraitsList.size > 1
+
+        traitLeft.visibility = if (shouldShowArrows) VISIBLE else GONE
+        traitRight.visibility = if (shouldShowArrows) VISIBLE else GONE
     }
 
     fun getRecyclerView(): RecyclerView? {


### PR DESCRIPTION
### Description
Closes #1251 


### Change Type

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [x] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

```release-note
Trait arrows are now hidden if only one trait is active
```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)