### PR TITLE
refactored duplicate insert observation code from obs sync dialog

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -1442,7 +1442,7 @@ public class CollectActivity extends ThemedActivity
             if (!pass) {
                 database.insertObservation(obsUnit, trait.getId(), value, person,
                         getLocationByPreferences(), "", studyId, observationDbId,
-                        lastSyncedTime, rep);
+                        null, lastSyncedTime, rep);
 
                 runOnUiThread(() -> updateCurrentTraitStatus(true));
             }
@@ -1461,7 +1461,7 @@ public class CollectActivity extends ThemedActivity
         String traitDbId = getTraitDbId();
 
         database.insertObservation(obsUnit, traitDbId, value, person,
-                getLocationByPreferences(), "", studyId, null, null, rep);
+                getLocationByPreferences(), "", studyId, null, null, null, rep);
     }
 
     public void deleteRep(String rep) {
@@ -2226,6 +2226,7 @@ public class CollectActivity extends ThemedActivity
                                     getStudyId(),
                                     "",
                                     null,
+                                    null,
                                     getRep());
                         }
 
@@ -2546,7 +2547,7 @@ public class CollectActivity extends ThemedActivity
         database.insertObservation(plotID, traitID, labelNumber,
                 getPerson(),
                 getLocationByPreferences(), "", studyId, "",
-                null, null);
+                null, null, null);
     }
 
     @Override

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -348,11 +348,11 @@ public class DataHelper {
      * this function as well
      * v1.6 - Amended to consider both trait and user data
      */
-    public long insertObservation(String plotId, String traitDbId, String value, String person, String location, String notes, String studyId, String observationDbId, OffsetDateTime lastSyncedTime, String rep) {
+    public long insertObservation(String plotId, String traitDbId, String value, String person, String location, String notes, String studyId, String observationDbId, OffsetDateTime timestamp, OffsetDateTime lastSyncedTime, String rep) {
 
         open();
 
-        return ObservationDao.Companion.insertObservation(plotId, traitDbId, value, person, location, notes, studyId, observationDbId, lastSyncedTime, rep);
+        return ObservationDao.Companion.insertObservation(plotId, traitDbId, value, person, location, notes, studyId, observationDbId, timestamp, lastSyncedTime, rep);
     }
 
     /**
@@ -395,10 +395,6 @@ public class DataHelper {
         open();
 
         return ObservationDao.Companion.isBrapiSynced(studyId, plotId, traitDbId, rep);
-    }
-
-    public void setTraitObservations(Integer studyId, Observation observation) {
-        ObservationDao.Companion.insertObservation(studyId, observation);
     }
 
     /**

--- a/app/src/main/java/com/fieldbook/tracker/database/saver/NixSpectralSaver.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/saver/NixSpectralSaver.kt
@@ -174,6 +174,7 @@ class NixSpectralSaver @Inject constructor(private val database: DataHelper) : D
             studyId,
             null,
             null,
+            null,
             rep
         )
 

--- a/app/src/main/java/com/fieldbook/tracker/dialogs/BrapiSyncObsDialog.kt
+++ b/app/src/main/java/com/fieldbook/tracker/dialogs/BrapiSyncObsDialog.kt
@@ -304,11 +304,21 @@ class BrapiSyncObsDialog(private val context: Context, private val syncControlle
                     val nextRep = baseRep + 1
                     obs.rep = nextRep.toString()
 
+                    val obsId = dataHelper.getObservation(obs.studyId, obs.unitDbId, obs.variableDbId, obs.rep)
+
                     // Save observation to the database and update highest rep # for the pair
-                    dataHelper.setTraitObservations(studyObservations.fieldBookStudyDbId, obs)
+                    if (obsId == null) {
+
+                        dataHelper.insertObservation(obs.unitDbId, obs.variableDbId, obs.value,
+                            obs.collector, "", "", obs.studyId,
+                            null, obs.timestamp, obs.lastSyncedTime, obs.rep)
+                    }
+
                     observationRepBaseMap[key] = nextRep
                 }
+
                 return 0
+
             } catch (exc: Exception) {
                 fail = true
                 failMessage = exc.message ?: "ERROR"

--- a/app/src/main/java/com/fieldbook/tracker/traits/AbstractCameraTrait.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/AbstractCameraTrait.kt
@@ -324,6 +324,7 @@ abstract class AbstractCameraTrait :
                                 location, "", studyId,
                                 null,
                                 null,
+                                null,
                                 rep
                             )
 
@@ -629,6 +630,7 @@ abstract class AbstractCameraTrait :
             (activity as? CollectActivity)?.locationByPreferences,
             "",
             (activity as? CollectActivity)?.studyId,
+            null,
             null,
             null,
             (activity as? CollectActivity)?.rep

--- a/app/src/main/java/com/fieldbook/tracker/traits/SpectralTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/SpectralTraitLayout.kt
@@ -785,6 +785,7 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
             collectActivity.studyId,
             null,
             null,
+            null,
             "1"
         )
 


### PR DESCRIPTION
added nullable timestamp as parameter to insert obs

### Description

fixes #525 



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note

```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)