### PR TITLE
Fix trait completeness to calculate per-trait distinct_obs_units

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/database/dao/StudyDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/StudyDao.kt
@@ -336,10 +336,7 @@ class StudyDao {
 
                 val cursor = db.rawQuery("""
                     SELECT ov.observation_variable_name, ov.observation_variable_field_book_format, COUNT(*) as count, GROUP_CONCAT(o.value, '|') as observations,
-                    (SELECT COUNT(DISTINCT observation_unit_id) 
-                        FROM observations 
-                        JOIN observation_variables AS ov ON ov.${ObservationVariable.PK} = observations.${ObservationVariable.FK}
-                        WHERE study_id = ?) AS distinct_obs_units,
+                    COUNT(DISTINCT observation_unit_id) AS distinct_obs_units,
                     (SELECT COUNT(*) FROM observation_units WHERE study_id = ?) AS total_obs_units,
                     (SELECT v.observation_variable_attribute_value 
                      FROM observation_variable_values v
@@ -350,7 +347,7 @@ class StudyDao {
                     WHERE o.study_id = ? AND o.observation_variable_db_id > 0
                     GROUP BY ov.observation_variable_name, ov.observation_variable_field_book_format
                     ORDER BY ov.${if (sortOrder == "visible") "position" else sortOrder} COLLATE NOCASE ASC
-                """, arrayOf(studyId.toString(), studyId.toString(), studyId.toString()))
+                """, arrayOf(studyId.toString(), studyId.toString()))
 
                 if (cursor.moveToFirst()) {
                     do {


### PR DESCRIPTION
### Description
Fixes the bug where field detail page showed same completed % for all traits

### Change Type
- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [x] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note
```release-note

```
___

### Release Type

_For internal use - please leave these unchecked unless you are the one completing the merge._

<!--
- On merge:
  - If `MAJOR` or `MINOR` is checked, a release action will be dispatched to create a release of the selected type.
  - If `WAIT` is checked, the release action will be skipped. The merged changes will later be included in the next dispatched or scheduled release (A scheduled check for unreleased changes runs every Monday at 3pm EST).
-->

- [ ] **`MAJOR`**
- [ ] **`MINOR`**
- [ ] **`WAIT`** (No immediate release, but the changelog will be still be updated if there is a release note.)