### PR TITLE
Fix field creator insets

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/FieldCreatorActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/FieldCreatorActivity.kt
@@ -18,6 +18,7 @@ import com.fieldbook.tracker.fragments.field_creator.FieldCreatorDirectionFragme
 import com.fieldbook.tracker.fragments.field_creator.FieldCreatorPatternTypeFragmentDirections
 import com.fieldbook.tracker.fragments.field_creator.FieldCreatorSizeFragmentDirections
 import com.fieldbook.tracker.fragments.field_creator.FieldCreatorStartCornerFragmentDirections
+import com.fieldbook.tracker.utilities.InsetHandler
 import com.fieldbook.tracker.utilities.Utils
 import com.fieldbook.tracker.viewmodels.FieldConfig
 import com.fieldbook.tracker.viewmodels.FieldCreatorViewModel
@@ -63,9 +64,18 @@ class FieldCreatorActivity : ThemedActivity() {
             setHomeButtonEnabled(true)
         }
 
+        setupFieldCreatorWindowInsets()
+
         stepperView = findViewById(R.id.field_creator_stepper)
         setupStepper(getCurrentStepFromViewModel())
         observeForStepper()
+    }
+
+    private fun setupFieldCreatorWindowInsets() {
+        val rootView = findViewById<View>(android.R.id.content)
+        val toolbar = findViewById<Toolbar>(R.id.field_creator_toolbar)
+
+        InsetHandler.setupStandardInsets(rootView, toolbar)
     }
 
     fun setCreationInProgress(inProgress: Boolean) {

--- a/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitDetailViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitDetailViewModel.kt
@@ -155,9 +155,9 @@ class TraitDetailViewModel @Inject constructor(
             runCatching {
                 repo.updateAttributes(trait)
 
+                notifyCollectReload()
                 //reload the observations, in case they need reformatting in the graph
                 loadObservationData(trait)
-                notifyCollectReload()
             }.onSuccess { obsData ->
                 _uiState.value = TraitDetailUiState.Success(trait, obsData)
             }.onFailure { e ->


### PR DESCRIPTION
### Description
Fix insets for field creator activity

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [X] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note

```