### PR TITLE
fix changelog.xml release tag

### DIFF
--- a/.github/workflows/scripts/github-release.py
+++ b/.github/workflows/scripts/github-release.py
@@ -200,7 +200,7 @@ def update_changelog_xml(filtered_content, changelog_xml_path):
 
             content = f'''{newline}{newline.join(release_notes)}'''
 
-            opening_tag = f'''{newline}{tab}<release version="{version}" versionCode="{version_code}" date="{today}">'''
+            opening_tag = f'''{newline}{tab}<release date="{today}" versionCode="{version_code} versionName="v{version}"">'''
             closing_tag = f'''{newline}{tab}</release>'''
 
             release_block = f'''{opening_tag}{content}{closing_tag}'''

--- a/app/src/main/res/raw/changelog.xml
+++ b/app/src/main/res/raw/changelog.xml
@@ -1,6 +1,6 @@
 <changelog>
 
-    <release version="7.0.0" versionCode="70000" date="2026-01-01">
+    <release date="2026-01-01" versionCode="70000" versionName="v7.0.0">
         <new>Traits list now includes individual trait pages with options that are adjustable on a per trait basis</new>
         <new>Traits include an option to enable repeated measures</new>
         <new>Traits include an option to automatically switch to the next entry when data is input</new>


### PR DESCRIPTION
### Description
Fix changelog.xml release tag to have versionName instead of version


### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [x] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note

```