### PR TITLE
GeoJSON Encoding Fix

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/traits/GNSSTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/GNSSTraitLayout.kt
@@ -359,13 +359,6 @@ class GNSSTraitLayout : BaseTraitLayout, GPSTracker.GPSTrackerListener {
 
             val studyDbId = prefs.getInt(GeneralKeys.SELECTED_FIELD_ID, 0).toString()
 
-            //geo json object : elevation (stored in obs. units, used in navigation)
-            //geo json has properties map for additional info
-            val geoJson = GeoJsonUtil.GeoJSON(
-                geometry = GeoJsonUtil.Geometry(coordinates = arrayOf(longitude, latitude)),
-                properties = mapOf("altitude" to elevation, "fix" to precision)
-            )
-
             //save fix length to truncate the average later if needed
             val latLength = latitude.length
             val lngLength = longitude.length
@@ -373,6 +366,13 @@ class GNSSTraitLayout : BaseTraitLayout, GPSTracker.GPSTrackerListener {
             //temporary variables to also update obs if obs units are averaged
             val newLat = latitude.toDouble()
             val newLng = longitude.toDouble()
+
+            //geo json object : elevation (stored in obs. units, used in navigation)
+            //geo json has properties map for additional info
+            val geoJson = GeoJsonUtil.GeoJSON(
+                geometry = GeoJsonUtil.Geometry(coordinates = arrayOf(newLng, newLat)),
+                properties = mapOf("altitude" to elevation, "fix" to precision)
+            )
 
             val units = database.getAllObservationUnits(studyDbId.toInt())
                 .filter { it.observation_unit_db_id == currentRange.uniqueId }
@@ -532,7 +532,7 @@ class GNSSTraitLayout : BaseTraitLayout, GPSTracker.GPSTrackerListener {
 
         val averageJson = GeoJsonUtil.GeoJSON(
             geometry = GeoJsonUtil.Geometry(
-                coordinates = arrayOf(avgPoint.second.toString(), avgPoint.first.toString())
+                coordinates = arrayOf(avgPoint.second, avgPoint.first)
             ),
             properties = mapOf(
                 "altitude" to (location?.altitude?.toString() ?: ""),

--- a/app/src/main/java/com/fieldbook/tracker/utilities/GeoJsonUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/GeoJsonUtil.kt
@@ -19,7 +19,7 @@ class GeoJsonUtil {
     //    "name": "Dinagat Islands"
     //  }
     //}
-    data class Geometry(val type: String = "Point", val coordinates: Array<String>) {
+    data class Geometry(val type: String = "Point", val coordinates: Array<Double>) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false

--- a/app/src/main/java/com/fieldbook/tracker/utilities/GeodeticUtils.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/GeodeticUtils.kt
@@ -305,7 +305,7 @@ class GeodeticUtils {
         fun parseGeoCoordinate(latLng: String?): Location? {
 
             val coords =
-                (if (latLng == null || latLng.isBlank()) ""
+                (if (latLng.isNullOrBlank()) ""
                 else latLng)
 
             val location = Location("search")
@@ -318,9 +318,9 @@ class GeodeticUtils {
 
                 val geoJson = Gson().fromJson(coords, GeoJsonUtil.GeoJSON::class.java)
 
-                location.latitude = geoJson.geometry.coordinates[1].toDouble()
+                location.latitude = geoJson.geometry.coordinates[1]
 
-                location.longitude = geoJson.geometry.coordinates[0].toDouble()
+                location.longitude = geoJson.geometry.coordinates[0]
 
                 geoJson.properties?.get("fix")?.let { fix ->
 


### PR DESCRIPTION
updated GeoJSON Geometry encoding (coordinates from String -> Double) to correctly follow spec RFC 7956.

fixes #1314 

### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Internal GeoJSON data are now saved as doubles
```