### PR TITLE
extend delete fields dialog with confirmation and archive options

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/FieldEditorActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/FieldEditorActivity.kt
@@ -1044,12 +1044,4 @@ class FieldEditorActivity : BaseFieldActivity(), FieldSortController {
         dialog.show()
     }
 
-    private fun archiveFields(fieldIds: List<Int>) {
-        for (fieldId in fieldIds) {
-            db.setIsArchived(fieldId, true)
-        }
-        queryAndLoadFields()
-        mAdapter.exitSelectionMode()
-        invalidateOptionsMenu()
-    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,6 +168,8 @@
     <string name="fields_delete">Delete</string>
     <string name="fields_delete_study">Delete field</string>
     <string name="fields_delete_study_confirmation">Are you sure you want to delete this field? This will delete all data from this field.</string>
+    <string name="fields_delete_archive_instead">Archive instead</string>
+    <string name="fields_delete_permanent_warning">Deleting a field is permanent and cannot be undone. Would you like to archive it instead?</string>
 
     <plurals name="fields_delete_confirmation">
         <item quantity="one">Are you sure you want to delete the field "%s"?</item>


### PR DESCRIPTION
### Description

Closes #1285

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [x] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Delete field dialog now includes an archive option
```