### PR TITLE
fix geonav popup header and search loop

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/utilities/GeoNavHelper.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/GeoNavHelper.kt
@@ -689,27 +689,19 @@ class GeoNavHelper @Inject constructor(private val controller: CollectController
 
         // handle the case where trait has been disabled by the user
         val popupItems = (controller.getContext() as CollectActivity).getGeoNavPopupSpinnerItems()
-        var index = -1
-        for (item in popupItems) {
-            if (item == popupHeader) {
-                newPopupHeader = item
-                preferences.edit {
-                    putString(GeneralKeys.GEONAV_POPUP_DISPLAY, newPopupHeader.label)
-                    putString(GeneralKeys.GEONAV_POPUP_TRAIT, newPopupHeader.trait?.id ?: DropDownKeyModel.DEFAULT_TRAIT_ID)
-                }
-                break
-            }
-            index++
+        val matchedItem = popupItems.find { it == popupHeader }
+
+        if (matchedItem != null) {
+            newPopupHeader = matchedItem
+        } else if (popupItems.isNotEmpty()) {
+            // if the attribute/trait cannot be found
+            // then default to first available attribute
+            newPopupHeader = popupItems.first()
         }
 
-        // if the attribute/trait cannot be found
-        // then default to 'plot_id'
-        if (index == -1) {
-            preferences.edit {
-                putString(GeneralKeys.GEONAV_POPUP_DISPLAY, DropDownKeyModel.DEFAULT_ATTRIBUTE_LABEL)
-                putString(GeneralKeys.GEONAV_POPUP_TRAIT, DropDownKeyModel.DEFAULT_TRAIT_ID)
-            }
-            newPopupHeader = AttributeModel(DropDownKeyModel.DEFAULT_ATTRIBUTE_LABEL, null)
+        preferences.edit {
+            putString(GeneralKeys.GEONAV_POPUP_DISPLAY, newPopupHeader.label)
+            putString(GeneralKeys.GEONAV_POPUP_TRAIT, newPopupHeader.trait?.id ?: DropDownKeyModel.DEFAULT_TRAIT_ID)
         }
 
         return geoNavController.queryForLabelValue(id, newPopupHeader)


### PR DESCRIPTION
### Description

Fields without a `plot_id` column can cause crashes when the geonav popup is displayed. This fixes the header and loop logic.

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
GeoNav popup no longer causes a crash when navigating
```