### PR TITLE
repeated measures locked data fixes

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -2116,7 +2116,11 @@ public class CollectActivity extends ThemedActivity
             enableDataEntry();
         } else {
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_lock_clock);
-            if (collectInputView.getText().isEmpty()) {
+            // For repeated measures, never block the overlay at the plot level.
+            // Lock state is managed per-observation via isLocked in each trait layout.
+            // Use isObservationSaved (not getText) so traits like counter that display
+            // a placeholder "0" before any real data is entered are not incorrectly frozen.
+            if (collectInputView.isRepeatEnabled() || !collectInputView.getIsObservationSaved()) {
                 enableDataEntry();
             } else disableDataEntry(R.string.activity_collect_frozen_state);
         }
@@ -2136,7 +2140,11 @@ public class CollectActivity extends ThemedActivity
             enableDataEntry();
         } else {
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_lock_clock);
-            if (collectInputView.getText().isEmpty()) {
+            // For repeated measures, never block the overlay at the plot level.
+            // Lock state is managed per-observation via isLocked in each trait layout.
+            // Use isObservationSaved (not getText) so traits like counter that display
+            // a placeholder "0" before any real data is entered are not incorrectly frozen.
+            if (collectInputView.isRepeatEnabled() || !collectInputView.getIsObservationSaved()) {
                 enableDataEntry();
             } else disableDataEntry(R.string.activity_collect_frozen_state);
         }
@@ -2914,7 +2922,7 @@ public class CollectActivity extends ThemedActivity
      */
     public boolean isDataLocked() {
         return (dataLocked == LOCKED)
-                || (!collectInputView.getText().isEmpty() && dataLocked == FROZEN);
+                || (collectInputView.getIsObservationSaved() && dataLocked == FROZEN);
     }
 
     public boolean isFrozen() {

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -60,9 +60,9 @@ import com.fieldbook.tracker.database.repository.SpectralRepository;
 import com.fieldbook.tracker.database.repository.TraitRepository;
 import com.fieldbook.tracker.database.viewmodels.CollectViewModel;
 import com.fieldbook.tracker.database.viewmodels.SpectralViewModel;
-import com.fieldbook.tracker.devices.camera.UsbCameraApi;
-import com.fieldbook.tracker.devices.camera.GoProApi;
 import com.fieldbook.tracker.devices.camera.CanonApi;
+import com.fieldbook.tracker.devices.camera.GoProApi;
+import com.fieldbook.tracker.devices.camera.UsbCameraApi;
 import com.fieldbook.tracker.devices.spectrometers.innospectra.InnoSpectraViewModel;
 import com.fieldbook.tracker.dialogs.GeoNavCollectDialog;
 import com.fieldbook.tracker.dialogs.InvalidValueDialog;
@@ -79,27 +79,27 @@ import com.fieldbook.tracker.objects.FieldObject;
 import com.fieldbook.tracker.objects.InfoBarModel;
 import com.fieldbook.tracker.objects.RangeObject;
 import com.fieldbook.tracker.objects.TraitObject;
-import com.fieldbook.tracker.preferences.PreferenceKeys;
-import com.fieldbook.tracker.preferences.models.ReturnCharacterMode;
-import com.fieldbook.tracker.preferences.enums.BarcodeScanningOptions;
-import com.fieldbook.tracker.traits.AbstractCameraTrait;
-import com.fieldbook.tracker.traits.InnoSpectraTraitLayout;
-import com.fieldbook.tracker.traits.SpectralTraitLayout;
-import com.fieldbook.tracker.traits.formats.Formats;
 import com.fieldbook.tracker.preferences.GeneralKeys;
+import com.fieldbook.tracker.preferences.PreferenceKeys;
+import com.fieldbook.tracker.preferences.enums.BarcodeScanningOptions;
+import com.fieldbook.tracker.preferences.models.ReturnCharacterMode;
+import com.fieldbook.tracker.traits.AbstractCameraTrait;
 import com.fieldbook.tracker.traits.AudioTraitLayout;
 import com.fieldbook.tracker.traits.BaseTraitLayout;
 import com.fieldbook.tracker.traits.CanonTraitLayout;
 import com.fieldbook.tracker.traits.GNSSTraitLayout;
 import com.fieldbook.tracker.traits.LayoutCollections;
 import com.fieldbook.tracker.traits.PhotoTraitLayout;
-import com.fieldbook.tracker.traits.formats.feature.Scannable;
+import com.fieldbook.tracker.traits.SpectralTraitLayout;
+import com.fieldbook.tracker.traits.formats.Formats;
 import com.fieldbook.tracker.traits.formats.TraitFormat;
 import com.fieldbook.tracker.traits.formats.coders.StringCoder;
+import com.fieldbook.tracker.traits.formats.feature.Scannable;
 import com.fieldbook.tracker.traits.formats.presenters.ValuePresenter;
 import com.fieldbook.tracker.utilities.CameraXFacade;
 import com.fieldbook.tracker.utilities.CategoryJsonUtil;
 import com.fieldbook.tracker.utilities.DocumentTreeUtil;
+import com.fieldbook.tracker.utilities.ExifUtil;
 import com.fieldbook.tracker.utilities.FfmpegHelper;
 import com.fieldbook.tracker.utilities.FieldAudioHelper;
 import com.fieldbook.tracker.utilities.FieldSwitchImpl;
@@ -119,7 +119,6 @@ import com.fieldbook.tracker.utilities.SensorHelper;
 import com.fieldbook.tracker.utilities.SnackbarUtils;
 import com.fieldbook.tracker.utilities.SoundHelperImpl;
 import com.fieldbook.tracker.utilities.TapTargetUtil;
-import com.fieldbook.tracker.utilities.ExifUtil;
 import com.fieldbook.tracker.utilities.Utils;
 import com.fieldbook.tracker.utilities.VerifyPersonHelper;
 import com.fieldbook.tracker.utilities.VibrateUtil;
@@ -146,11 +145,11 @@ import org.threeten.bp.OffsetDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -779,17 +778,20 @@ public class CollectActivity extends ThemedActivity
         com.fieldbook.tracker.ui.BottomToolbarListener toolbarListener = new com.fieldbook.tracker.ui.BottomToolbarListener() {
             @Override
             public void onMissing() {
-                triggerTts(naTts);
-                TraitObject currentTrait = traitBox.getCurrentTrait();
-                if (currentTrait != null) {
-                    String format = currentTrait.getFormat();
-                    if (Formats.Companion.isCameraTrait(format)) {
-                        ((AbstractCameraTrait) traitLayouts.getTraitLayout(format)).setImageNa();
-                    } else if (Formats.Companion.isSpectralFormat(format)) {
-                        ((SpectralTraitLayout) traitLayouts.getTraitLayout(format)).setNa();
-                    } else {
-                        updateObservation(currentTrait, "NA", null);
-                        setNaText();
+
+                if (!isDataLocked()) {
+                    triggerTts(naTts);
+                    TraitObject currentTrait = traitBox.getCurrentTrait();
+                    if (currentTrait != null) {
+                        String format = currentTrait.getFormat();
+                        if (Formats.Companion.isCameraTrait(format)) {
+                            ((AbstractCameraTrait) traitLayouts.getTraitLayout(format)).setImageNa();
+                        } else if (Formats.Companion.isSpectralFormat(format)) {
+                            ((SpectralTraitLayout) traitLayouts.getTraitLayout(format)).setNa();
+                        } else {
+                            updateObservation(currentTrait, "NA", null);
+                            setNaText();
+                        }
                     }
                 }
             }
@@ -803,47 +805,63 @@ public class CollectActivity extends ThemedActivity
 
             @Override
             public void onDelete() {
-                // check for attached media on the current observation
-                ObservationModel obs = null;
-                try {
-                    obs = getCurrentObservation();
-                } catch (Exception ignored) {}
 
-                if (obs != null) {
-                    boolean hasMedia = obs.getAttachedMediaCount() > 0;
+                if (!isDataLocked()) {
+                    // check for attached media on the current observation
+                    ObservationModel obs = null;
+                    try {
+                        obs = getCurrentObservation();
+                    } catch (Exception ignored) {}
 
-                    if (hasMedia) {
-                        // Warn the user that attached media will also be removed
-                        ObservationModel finalObs = obs;
-                        new AlertDialog.Builder(CollectActivity.this, R.style.AppAlertDialog)
-                                .setTitle(R.string.confirm_delete_with_media_title)
-                                .setMessage(getString(R.string.confirm_delete_with_media_message))
-                                .setPositiveButton(R.string.delete, (dialog, which) -> {
-                                    // delete attached media files
-                                    try {
-                                        deleteMediaUrisForObservation(finalObs);
-                                    } catch (Exception e) {
-                                        Log.e(TAG, "Error deleting attached media", e);
-                                    }
+                    if (obs != null) {
+                        boolean hasMedia = obs.getAttachedMediaCount() > 0;
 
-                                    // proceed with existing delete behavior
-                                    performTraitDeleteAfterMediaCheck();
-                                })
-                                .setNegativeButton(android.R.string.cancel, null)
-                                .show();
-                        return;
+                        if (hasMedia) {
+                            // Warn the user that attached media will also be removed
+                            ObservationModel finalObs = obs;
+                            new AlertDialog.Builder(CollectActivity.this, R.style.AppAlertDialog)
+                                    .setTitle(R.string.confirm_delete_with_media_title)
+                                    .setMessage(getString(R.string.confirm_delete_with_media_message))
+                                    .setPositiveButton(R.string.delete, (dialog, which) -> {
+                                        // delete attached media files
+                                        try {
+                                            deleteMediaUrisForObservation(finalObs);
+                                        } catch (Exception e) {
+                                            Log.e(TAG, "Error deleting attached media", e);
+                                        }
+
+                                        // proceed with existing delete behavior
+                                        performTraitDeleteAfterMediaCheck();
+                                    })
+                                    .setNegativeButton(android.R.string.cancel, null)
+                                    .show();
+                            return;
+                        }
                     }
-                }
 
-                // If no media or no current observation, proceed with original behavior
-                performTraitDeleteAfterMediaCheck();
+                    // If no media or no current observation, proceed with original behavior
+                    performTraitDeleteAfterMediaCheck();
+                }
             }
 
             @Override
             public void onDeleteLong() {
-                ObservationModel[] models = database.getRepeatedValues(getStudyId(), getObservationUnit(), getTraitDbId());
-                if (models.length > 0) {
-                    showConfirmMultiMeasureDeleteDialog(java.util.List.of(models));
+
+                List<Integer> savedIds = collectInputView.getSavedIds();
+
+                if (!isDataLocked()) {
+                    ObservationModel[] models = database.getRepeatedValues(getStudyId(), getObservationUnit(), getTraitDbId());
+                    ArrayList<ObservationModel> deleteable = new ArrayList<>();
+                    for (ObservationModel m : models) {
+                        if (dataLocked == LOCKED || dataLocked == FROZEN) {
+                            if (!savedIds.contains(m.getInternal_id_observation())) {
+                                deleteable.add(m);
+                            }
+                        } else deleteable.add(m);
+                    }
+                    if (!deleteable.isEmpty()) {
+                        showConfirmMultiMeasureDeleteDialog(deleteable);
+                    }
                 }
             }
 
@@ -1932,7 +1950,10 @@ public class CollectActivity extends ThemedActivity
 
             return true;
         } else if (itemId == R.id.action_act_collect_repeated_values_indicator) {
-            showRepeatedMeasuresDeleteDialog();
+
+            if (!isDataLocked()) {
+                showRepeatedMeasuresDeleteDialog();
+            }
 
             return true;
         }
@@ -1946,9 +1967,17 @@ public class CollectActivity extends ThemedActivity
 
         ArrayList<String> is = new ArrayList<>();
         ArrayList<ObservationModel> observations = new ArrayList<>();
+        List<Integer> savedIds = collectInputView.getSavedIds();
 
         for (ObservationModel m: values) {
             if (!m.getValue().isEmpty()) {
+
+                if (dataLocked == LOCKED || dataLocked == FROZEN) {
+                    if (savedIds.contains(m.getInternal_id_observation())) {
+                        continue;
+                    }
+                }
+
                 TraitObject trait = database.getTraitById(String.valueOf(m.getObservation_variable_db_id()));
                 String format = m.getObservation_variable_field_book_format();
                 if (format != null) {
@@ -2116,10 +2145,7 @@ public class CollectActivity extends ThemedActivity
             enableDataEntry();
         } else {
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_lock_clock);
-            // For repeated measures, never block the overlay at the plot level.
-            // Lock state is managed per-observation via isLocked in each trait layout.
-            // Use isObservationSaved (not getText) so traits like counter that display
-            // a placeholder "0" before any real data is entered are not incorrectly frozen.
+            // For repeated measures, never block the add new repeated measure or navigation buttons.
             if (collectInputView.isRepeatEnabled() || !collectInputView.getIsObservationSaved()) {
                 enableDataEntry();
             } else disableDataEntry(R.string.activity_collect_frozen_state);
@@ -2140,10 +2166,7 @@ public class CollectActivity extends ThemedActivity
             enableDataEntry();
         } else {
             systemMenu.findItem(R.id.lockData).setIcon(R.drawable.ic_lock_clock);
-            // For repeated measures, never block the overlay at the plot level.
-            // Lock state is managed per-observation via isLocked in each trait layout.
-            // Use isObservationSaved (not getText) so traits like counter that display
-            // a placeholder "0" before any real data is entered are not incorrectly frozen.
+            // For repeated measures, never block the add new repeated measure or navigation buttons.
             if (collectInputView.isRepeatEnabled() || !collectInputView.getIsObservationSaved()) {
                 enableDataEntry();
             } else disableDataEntry(R.string.activity_collect_frozen_state);

--- a/app/src/main/java/com/fieldbook/tracker/adapters/RepeatedValuesPagerAdapter.kt
+++ b/app/src/main/java/com/fieldbook/tracker/adapters/RepeatedValuesPagerAdapter.kt
@@ -7,9 +7,11 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import androidx.viewpager.widget.PagerAdapter
+import androidx.viewpager.widget.PagerAdapter.POSITION_NONE
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.activities.CollectActivity
 import com.fieldbook.tracker.views.RepeatedValuesView
+import com.mikepenz.fastadapter.adapters.ItemAdapter.items
 
 /**
  * Used in the repeated values view.
@@ -35,8 +37,12 @@ class RepeatedValuesPagerAdapter(private val mContext: Context) : PagerAdapter()
 
         // Set the long click listener
         editText.setOnLongClickListener {
-            val observationId = items[position].model.internal_id_observation
-            (mContext as CollectActivity).showObservationMetadataDialog(observationId)
+            try {
+                val observationId = items[position].model.internal_id_observation
+                (mContext as CollectActivity).showObservationMetadataDialog(observationId)
+            } catch (_: NoSuchElementException) {
+                // in case the observation is not found we can just ignore the long clicl
+            }
             true
         }
 

--- a/app/src/main/java/com/fieldbook/tracker/traits/BaseTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/BaseTraitLayout.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
@@ -27,7 +26,6 @@ import com.fieldbook.tracker.preferences.PreferenceKeys;
 import com.fieldbook.tracker.traits.formats.Formats;
 import com.fieldbook.tracker.traits.formats.feature.DisplayValue;
 import com.fieldbook.tracker.views.CollectInputView;
-import com.fieldbook.tracker.views.RepeatedValuesView;
 
 import java.util.Arrays;
 import java.util.List;
@@ -230,20 +228,29 @@ public abstract class BaseTraitLayout extends LinearLayout {
      * If this feature is enabled, the list will be modified and updated.
      */
     public void deleteTraitListener() {
-        CollectInputView inputView = getCollectInputView();
-        if (inputView.isRepeatEnabled()) {
-            inputView.getRepeatView().userDeleteCurrentRep();
-        }
-        //check if sound on delete is enabled in preferences and play sound
-        if (getPrefs().getBoolean(PreferenceKeys.DELETE_OBSERVATION_SOUND, false)) {
-            controller.getSoundHelper().playDelete();
+        if (!isLocked) {
+            CollectInputView inputView = getCollectInputView();
+            if (inputView.isRepeatEnabled()) {
+                inputView.getRepeatView().userDeleteCurrentRep();
+            }
+            //check if sound on delete is enabled in preferences and play sound
+            if (getPrefs().getBoolean(PreferenceKeys.DELETE_OBSERVATION_SOUND, false)) {
+                controller.getSoundHelper().playDelete();
+            }
         }
     }
 
     public abstract void setNaTraitsText();
 
     public void refreshLock() {
-        //((CollectActivity) getContext()).traitLockData();
+
+        if (getCurrentObservation() != null) {
+            // If there is an existing observation for the current rep, lock if frozen or locked
+            isLocked = getCollectActivity().isFrozen() || getCollectActivity().isLocked();
+        } else {
+            // If there is no existing observation, only lock if locked (not frozen)
+            isLocked = getCollectActivity().isLocked();
+        }
     }
 
     public TraitObject getCurrentTrait() {

--- a/app/src/main/java/com/fieldbook/tracker/traits/BaseTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/BaseTraitLayout.java
@@ -93,6 +93,13 @@ public abstract class BaseTraitLayout extends LinearLayout {
      */
     public void refreshLayout(Boolean onNew) {
 
+        // When frozen with repeated measures, update isLocked per-observation so
+        // existing rep values stay read-only while new empty reps remain editable.
+        CollectActivity act = (CollectActivity) getContext();
+        if (act.isFrozen() && getCollectInputView().isRepeatEnabled()) {
+            isLocked = !getCollectInputView().getText().isEmpty();
+        }
+
         getCollectInputView().getRepeatView().refresh();
 
     }

--- a/app/src/main/java/com/fieldbook/tracker/traits/CounterTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/CounterTraitLayout.java
@@ -49,6 +49,7 @@ public class CounterTraitLayout extends BaseTraitLayout {
 
         // Add counter
         addCounterBtn.setOnClickListener(view -> {
+            if (isLocked) return;
             TraitObject trait = getCurrentTrait();
             if (trait != null) {
                 if (getCurrentObservation() == null || getCurrentObservation().getValue().equals("NA")) {
@@ -71,6 +72,7 @@ public class CounterTraitLayout extends BaseTraitLayout {
 
         // Minus counter
         minusCounterBtn.setOnClickListener(view -> {
+            if (isLocked) return;
             if (getCurrentObservation() == null || getCurrentObservation().getValue().equals("NA")) {
                 getCollectInputView().setText("-1");
             } else {

--- a/app/src/main/java/com/fieldbook/tracker/traits/PercentTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PercentTraitLayout.java
@@ -137,6 +137,13 @@ public class PercentTraitLayout extends BaseTraitLayout {
 
         ObservationModel model = getCurrentObservation();
         if (model != null) {
+            // When frozen with repeated measures, update isLocked per-observation
+            // so existing rep values stay read-only while new empty reps remain editable.
+            CollectActivity act = (CollectActivity) getContext();
+            if (act.isFrozen() && getCollectInputView().isRepeatEnabled()) {
+                isLocked = !model.getValue().isEmpty();
+                seekBar.setEnabled(!isLocked);
+            }
             if (model.getValue().equals("NA")) {
                 getCollectInputView().setText("NA");
                 getSeekBar().setProgress(0);

--- a/app/src/main/java/com/fieldbook/tracker/traits/TextTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/TextTraitLayout.kt
@@ -227,13 +227,16 @@ class TextTraitLayout : BaseTraitLayout {
     }
 
     override fun refreshLayout(onNew: Boolean) {
-        super.refreshLayout(false)
+        super.refreshLayout(false) // updates isLocked for frozen+repeated measure state
         inputEditText?.removeTextChangedListener(textWatcher)
         inputEditText?.text?.clear()
         if (currentObservation != null) {
             inputEditText?.setText(currentObservation.value)
             inputEditText?.setSelection(currentObservation.value.length)
         }
+        // Re-apply lock state to the edit text after per-rep isLocked update
+        inputEditText?.isEnabled = !isLocked
+        inputEditText?.inputType = if (isLocked) EditorInfo.TYPE_NULL else EditorInfo.TYPE_TEXT_FLAG_NO_SUGGESTIONS
         selectEditText()
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/ui/BottomToolbarBindings.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/BottomToolbarBindings.kt
@@ -143,16 +143,17 @@ fun BottomToolbar(
                 }
 
                 // Delete button: support click and long-press (long triggers onDeleteLong)
-                IconButton(
-                    onClick = { listener?.onDelete() },
-                    enabled = deleteValueButtonEnabled,
-                    modifier = Modifier.pointerInput(Unit) {
-                        detectTapGestures(
-                            onLongPress = {
-                                listener?.onDeleteLong()
-                            }
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .combinedClickable(
+                            onClick = { listener?.onDelete() },
+                            onLongClick = { listener?.onDeleteLong() },
+                            enabled = deleteValueButtonEnabled,
+                            role = Role.Button
                         )
-                    }
+                        .padding(8.dp),
+                    contentAlignment = Alignment.Center
                 ) {
                     Icon(painter = painterResource(id = R.drawable.main_ic_delete_forever),
                         contentDescription = null,

--- a/app/src/main/java/com/fieldbook/tracker/views/CollectInputView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/CollectInputView.kt
@@ -197,6 +197,8 @@ class CollectInputView(context: Context, attributeSet: AttributeSet) : Constrain
         forceInitialRep = -1
     }
 
+    fun getIsObservationSaved(): Boolean = isObservationSaved
+
     fun markObservationEdited() {
         isObservationSaved = false
         updateCurrentValueETStyle()

--- a/app/src/main/java/com/fieldbook/tracker/views/CollectInputView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/CollectInputView.kt
@@ -52,6 +52,8 @@ class CollectInputView(context: Context, attributeSet: AttributeSet) : Constrain
 
         if (isRepeatEnabled()) {
 
+            markObservationUnsaved();
+
             repeatView.prepareModeEmpty()
 
         } else {
@@ -197,7 +199,17 @@ class CollectInputView(context: Context, attributeSet: AttributeSet) : Constrain
         forceInitialRep = -1
     }
 
-    fun getIsObservationSaved(): Boolean = isObservationSaved
+    fun getIsObservationSaved(): Boolean {
+        return if (isRepeatEnabled()) {
+            repeatView.isSelectedSaved()
+        } else isObservationSaved
+    }
+
+    fun getSavedIds(): List<Int> = repeatView.getSavedIds()
+
+    fun markObservationUnsaved() {
+        isObservationSaved = false
+    }
 
     fun markObservationEdited() {
         isObservationSaved = false

--- a/app/src/main/java/com/fieldbook/tracker/views/RepeatedValuesView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/RepeatedValuesView.kt
@@ -121,7 +121,6 @@ class RepeatedValuesView(context: Context, attributeSet: AttributeSet) :
                     act.traitLayoutRefresh()
 
                 }
-
             }
         }
 
@@ -347,6 +346,20 @@ class RepeatedValuesView(context: Context, attributeSet: AttributeSet) :
 
     fun setTextColor(color: Int) {
         getEditText()?.setTextColor(color)
+    }
+
+    fun getSavedIds(): List<Int> {
+
+        return mValues.filter { it.model.study_id.toInt() >= 0 }.map { it.model.internal_id_observation }
+    }
+
+    fun isSelectedSaved(): Boolean {
+
+        return try {
+            mValues[pager.currentItem].model.internal_id_observation > 0
+        } catch (_: Exception) {
+            false
+        }
     }
 
     private fun getSelectedModel(): ObservationModel? {

--- a/app/src/main/res/layout/activity_collect.xml
+++ b/app/src/main/res/layout/activity_collect.xml
@@ -85,6 +85,7 @@
         android:id="@+id/svTraitContainer"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:fillViewport="false"
         android:isScrollContainer="true"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"

--- a/app/src/main/res/layout/trait_counter.xml
+++ b/app/src/main/res/layout/trait_counter.xml
@@ -6,13 +6,13 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:visibility="visible">
+    android:visibility="gone"
+    tools:visibility="visible">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_main"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <com.google.android.material.floatingactionbutton.FloatingActionButton
             style="@style/FloatingActionButtonStyle.TraitButtons"

--- a/app/src/main/res/layout/view_repeated_values.xml
+++ b/app/src/main/res/layout/view_repeated_values.xml
@@ -6,6 +6,7 @@
     android:layout_height="wrap_content">
 
     <Button
+        android:elevation="100dp"
         android:visibility="invisible"
         android:id="@+id/repeated_values_view_left_btn"
         android:layout_width="64dp"
@@ -42,18 +43,19 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:elevation="100dp"
         android:id="@+id/repeated_values_view_add_btn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
         android:src="@drawable/ic_plus"
         android:contentDescription="@string/view_repeated_values_add_button_content_description"
-        android:elevation="5dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Button
+        android:elevation="100dp"
         android:id="@+id/repeated_values_view_right_btn"
         android:layout_width="64dp"
         android:layout_height="64dp"


### PR DESCRIPTION
### Description

Closes #1455

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Repeated measures can now still be collected when data input is frozen
```