### PR TITLE
Pr/tablet rotation sw800

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/ThemedActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ThemedActivity.kt
@@ -3,7 +3,6 @@ package com.fieldbook.tracker.activities
 import android.app.Activity
 import android.content.Intent
 import android.content.SharedPreferences
-import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -15,6 +14,7 @@ import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.preferences.PreferenceKeys
+import com.fieldbook.tracker.utilities.RotationPolicy
 import com.fieldbook.tracker.utilities.SharedPreferenceUtils
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -25,8 +25,6 @@ open class ThemedActivity: AppCompatActivity() {
     companion object {
 
         val TAG = ThemedActivity::class.simpleName
-        // Tablets: allow rotation when system auto-rotate is enabled.
-        private const val TABLET_ROTATION_MIN_SW_DP = 800
 
         private data class ThemePair(val color: Int, val size: Int)
 
@@ -208,7 +206,7 @@ open class ThemedActivity: AppCompatActivity() {
         applyTheme(this)
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        applyTabletRotationPolicy()
+        RotationPolicy.apply(this)
     }
 
     override fun onResume() {
@@ -271,14 +269,4 @@ open class ThemedActivity: AppCompatActivity() {
         super.startActivity(intent)
     }
 
-    private fun applyTabletRotationPolicy() {
-        val swDp = resources.configuration.smallestScreenWidthDp
-        if (swDp >= TABLET_ROTATION_MIN_SW_DP) {
-            // Respect system auto-rotate: allow landscape only if user enabled rotation.
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
-        } else {
-            // Keep the app portrait-locked on smaller devices.
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        }
-    }
 }

--- a/app/src/main/java/com/fieldbook/tracker/activities/ThemedActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ThemedActivity.kt
@@ -3,6 +3,7 @@ package com.fieldbook.tracker.activities
 import android.app.Activity
 import android.content.Intent
 import android.content.SharedPreferences
+import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -24,6 +25,7 @@ open class ThemedActivity: AppCompatActivity() {
     companion object {
 
         val TAG = ThemedActivity::class.simpleName
+        private const val TABLET_ROTATION_MIN_SW_DP = 800
 
         private data class ThemePair(val color: Int, val size: Int)
 
@@ -205,6 +207,7 @@ open class ThemedActivity: AppCompatActivity() {
         applyTheme(this)
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        applyTabletRotationPolicy()
     }
 
     override fun onResume() {
@@ -265,5 +268,12 @@ open class ThemedActivity: AppCompatActivity() {
             intent?.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
         }
         super.startActivity(intent)
+    }
+
+    private fun applyTabletRotationPolicy() {
+        val swDp = resources.configuration.smallestScreenWidthDp
+        if (swDp >= TABLET_ROTATION_MIN_SW_DP) {
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+        }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/activities/ThemedActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ThemedActivity.kt
@@ -25,6 +25,7 @@ open class ThemedActivity: AppCompatActivity() {
     companion object {
 
         val TAG = ThemedActivity::class.simpleName
+        // EXPERIMENT: lowered to 360dp for phone testing. Restore to 800dp for tablets.
         private const val TABLET_ROTATION_MIN_SW_DP = 360
 
         private data class ThemePair(val color: Int, val size: Int)
@@ -273,7 +274,11 @@ open class ThemedActivity: AppCompatActivity() {
     private fun applyTabletRotationPolicy() {
         val swDp = resources.configuration.smallestScreenWidthDp
         if (swDp >= TABLET_ROTATION_MIN_SW_DP) {
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+            // Respect system auto-rotate: allow landscape only if user enabled rotation.
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
+        } else {
+            // Keep the app portrait-locked on smaller devices.
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/activities/ThemedActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ThemedActivity.kt
@@ -25,7 +25,7 @@ open class ThemedActivity: AppCompatActivity() {
     companion object {
 
         val TAG = ThemedActivity::class.simpleName
-        private const val TABLET_ROTATION_MIN_SW_DP = 800
+        private const val TABLET_ROTATION_MIN_SW_DP = 360
 
         private data class ThemePair(val color: Int, val size: Int)
 

--- a/app/src/main/java/com/fieldbook/tracker/activities/ThemedActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ThemedActivity.kt
@@ -25,8 +25,8 @@ open class ThemedActivity: AppCompatActivity() {
     companion object {
 
         val TAG = ThemedActivity::class.simpleName
-        // EXPERIMENT: lowered to 360dp for phone testing. Restore to 800dp for tablets.
-        private const val TABLET_ROTATION_MIN_SW_DP = 360
+        // Tablets: allow rotation when system auto-rotate is enabled.
+        private const val TABLET_ROTATION_MIN_SW_DP = 800
 
         private data class ThemePair(val color: Int, val size: Int)
 

--- a/app/src/main/java/com/fieldbook/tracker/ui/MediaViewerScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/MediaViewerScreen.kt
@@ -1,6 +1,7 @@
 package com.fieldbook.tracker.ui
 
 import android.app.Activity
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -51,6 +52,8 @@ class MediaViewerActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        applyTabletRotationPolicy()
+
         val studyId = intent.getStringExtra(EXTRA_STUDY_ID) ?: "0"
         val obsUnit = intent.getStringExtra(EXTRA_OBS_UNIT) ?: ""
         val traitDbId = intent.getStringExtra(EXTRA_TRAIT_DB_ID) ?: ""
@@ -73,6 +76,15 @@ class MediaViewerActivity : ComponentActivity() {
         const val EXTRA_STUDY_ID = "extra_study_id"
         const val EXTRA_OBS_UNIT = "extra_observation_unit"
         const val EXTRA_TRAIT_DB_ID = "extra_trait_db_id"
+
+        private const val TABLET_ROTATION_MIN_SW_DP = 800
+    }
+
+    private fun applyTabletRotationPolicy() {
+        val swDp = resources.configuration.smallestScreenWidthDp
+        if (swDp >= TABLET_ROTATION_MIN_SW_DP) {
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+        }
     }
 }
 

--- a/app/src/main/java/com/fieldbook/tracker/ui/MediaViewerScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/MediaViewerScreen.kt
@@ -1,7 +1,6 @@
 package com.fieldbook.tracker.ui
 
 import android.app.Activity
-import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -42,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.ui.components.appBar.AppBar
 import com.fieldbook.tracker.ui.theme.AppTheme
+import com.fieldbook.tracker.utilities.RotationPolicy
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -52,7 +52,7 @@ class MediaViewerActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        applyTabletRotationPolicy()
+        RotationPolicy.apply(this)
 
         val studyId = intent.getStringExtra(EXTRA_STUDY_ID) ?: "0"
         val obsUnit = intent.getStringExtra(EXTRA_OBS_UNIT) ?: ""
@@ -76,20 +76,6 @@ class MediaViewerActivity : ComponentActivity() {
         const val EXTRA_STUDY_ID = "extra_study_id"
         const val EXTRA_OBS_UNIT = "extra_observation_unit"
         const val EXTRA_TRAIT_DB_ID = "extra_trait_db_id"
-
-        // Tablets: allow rotation when system auto-rotate is enabled.
-        private const val TABLET_ROTATION_MIN_SW_DP = 800
-    }
-
-    private fun applyTabletRotationPolicy() {
-        val swDp = resources.configuration.smallestScreenWidthDp
-        if (swDp >= TABLET_ROTATION_MIN_SW_DP) {
-            // Respect system auto-rotate: allow landscape only if user enabled rotation.
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
-        } else {
-            // Keep the app portrait-locked on smaller devices.
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        }
     }
 }
 

--- a/app/src/main/java/com/fieldbook/tracker/ui/MediaViewerScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/MediaViewerScreen.kt
@@ -77,8 +77,8 @@ class MediaViewerActivity : ComponentActivity() {
         const val EXTRA_OBS_UNIT = "extra_observation_unit"
         const val EXTRA_TRAIT_DB_ID = "extra_trait_db_id"
 
-        // EXPERIMENT: lowered to 360dp for phone testing. Restore to 800dp for tablets.
-        private const val TABLET_ROTATION_MIN_SW_DP = 360
+        // Tablets: allow rotation when system auto-rotate is enabled.
+        private const val TABLET_ROTATION_MIN_SW_DP = 800
     }
 
     private fun applyTabletRotationPolicy() {

--- a/app/src/main/java/com/fieldbook/tracker/ui/MediaViewerScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/MediaViewerScreen.kt
@@ -77,7 +77,7 @@ class MediaViewerActivity : ComponentActivity() {
         const val EXTRA_OBS_UNIT = "extra_observation_unit"
         const val EXTRA_TRAIT_DB_ID = "extra_trait_db_id"
 
-        private const val TABLET_ROTATION_MIN_SW_DP = 800
+        private const val TABLET_ROTATION_MIN_SW_DP = 360
     }
 
     private fun applyTabletRotationPolicy() {

--- a/app/src/main/java/com/fieldbook/tracker/ui/MediaViewerScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/MediaViewerScreen.kt
@@ -77,13 +77,18 @@ class MediaViewerActivity : ComponentActivity() {
         const val EXTRA_OBS_UNIT = "extra_observation_unit"
         const val EXTRA_TRAIT_DB_ID = "extra_trait_db_id"
 
+        // EXPERIMENT: lowered to 360dp for phone testing. Restore to 800dp for tablets.
         private const val TABLET_ROTATION_MIN_SW_DP = 360
     }
 
     private fun applyTabletRotationPolicy() {
         val swDp = resources.configuration.smallestScreenWidthDp
         if (swDp >= TABLET_ROTATION_MIN_SW_DP) {
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+            // Respect system auto-rotate: allow landscape only if user enabled rotation.
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
+        } else {
+            // Keep the app portrait-locked on smaller devices.
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/utilities/RotationPolicy.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/RotationPolicy.kt
@@ -1,0 +1,26 @@
+package com.fieldbook.tracker.utilities
+
+import android.app.Activity
+import android.content.pm.ActivityInfo
+
+/**
+ * Centralized orientation policy used by a few screens.
+ *
+ * - Phones: keep portrait-locked
+ * - Tablets: respect the user's auto-rotate setting
+ */
+object RotationPolicy {
+    // Tablets: allow rotation when system auto-rotate is enabled.
+    const val TABLET_ROTATION_MIN_SW_DP = 800
+
+    fun apply(activity: Activity) {
+        val swDp = activity.resources.configuration.smallestScreenWidthDp
+        activity.requestedOrientation =
+            if (swDp >= TABLET_ROTATION_MIN_SW_DP) {
+                ActivityInfo.SCREEN_ORIENTATION_USER
+            } else {
+                ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            }
+    }
+}
+


### PR DESCRIPTION
### Description

This PR <strong>re-introduces tablet rotation support</strong> for Field Book.

Tablet rotation used to be a supported / expected workflow for teams collecting data on <strong>tablet devices</strong>, but many screens are currently <strong>portrait-locked</strong> by default. This change restores a tablet-friendly behavior while keeping phone UX stable:

<ul>
  <li><strong>Tablets</strong> (smallest width &ge; 800dp): allow rotation <strong>only when system auto-rotate is enabled</strong> (respects the OS rotation lock).</li>
  <li><strong>Phones / smaller devices</strong>: remain <strong>portrait-locked</strong>.</li>
</ul>

<strong>Testing / follow-ups</strong>: this branch will be tested on real tablets used for field work, and we will iterate (threshold, affected screens, edge cases) based on results and maintainer feedback.

### Change Type

- [x] <strong><code>CHANGE</code></strong>

### Release Note

```release-note
Allow Field Book to rotate on tablets when system auto-rotate is enabled; smaller devices remain portrait-locked.