### PR TITLE
Canon Parameter change

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/devices/camera/CanonApi.kt
+++ b/app/src/main/java/com/fieldbook/tracker/devices/camera/CanonApi.kt
@@ -282,10 +282,6 @@ class CanonApi @Inject constructor(@param:ActivityContext private val context: C
 
             if (response) {
 
-                writeParameter3(session, storageId)
-
-            } else {
-
                 writeParameter902f(session, storageId)
 
             }


### PR DESCRIPTION
### Description

disabled Canon parameter causing EOS 6D Mark II to not work



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [x] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Canon trait now works correctly with EOS 6D Mark II
```