### PR TITLE
Unable to switch to new/downloaded values in the data grid

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/DataGridActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/DataGridActivity.kt
@@ -299,8 +299,28 @@ class DataGridActivity : ThemedActivity(), CoroutineScope by MainScope() {
 
                                     // check repeated values and replace cellvalue with an ellipses
                                     if (repeatedValues.size > 1) {
-                                        // data list is a trait row in the data grid
-                                        dataList.add(CellData("...", id))
+                                        // If repeated measures is disabled, show the latest value
+                                        // Otherwise show ellipses to indicate multiple values
+                                        val displayValue = if (!variable.repeatedMeasures) {
+                                            // Get the latest observation (highest rep number)
+                                            val latestObs = repeatedValues.maxByOrNull { it.rep.toInt() }
+                                            if (latestObs != null && isCategorical) {
+                                                try {
+                                                    CategoryJsonUtil.flattenMultiCategoryValue(
+                                                        CategoryJsonUtil.decode(latestObs.value),
+                                                        !variable.categoryDisplayValue
+                                                    )
+                                                } catch (e: Exception) {
+                                                    e.printStackTrace()
+                                                    latestObs.value
+                                                }
+                                            } else {
+                                                latestObs?.value ?: ""
+                                            }
+                                        } else {
+                                            "..."
+                                        }
+                                        dataList.add(CellData(displayValue, id))
                                     } else {
                                         dataList.add(CellData(cellValue, id))
                                     }
@@ -516,24 +536,35 @@ class DataGridActivity : ThemedActivity(), CoroutineScope by MainScope() {
         }
     }
 
-    private fun onCellClicked(row: Int, col: Int) {
-        val studyId = preferences.getInt(GeneralKeys.SELECTED_FIELD_ID, 0).toString()
-        val plotId = mPlotIds[row]
-        val trait = mTraits[col]
-        val repeatedValues = database.getRepeatedValues(studyId, plotId, trait.id)
+     private fun onCellClicked(row: Int, col: Int) {
+         val studyId = preferences.getInt(GeneralKeys.SELECTED_FIELD_ID, 0).toString()
+         val plotId = mPlotIds[row]
+         val trait = mTraits[col]
+         val repeatedValues = database.getRepeatedValues(studyId, plotId, trait.id)
 
-        try {
-            if (repeatedValues.size <= 1) {
-                navigateFromValueClicked(plotId, col)
-            } else {
-                //show alert dialog with repeated values
-                showRepeatedValuesNavigatorDialog(trait, repeatedValues)
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error occurred while trying to navigate: " + e.printStackTrace())
-            FirebaseCrashlytics.getInstance().recordException(e)
-        }
-    }
+         try {
+             if (repeatedValues.size <= 1) {
+                 navigateFromValueClicked(plotId, col)
+             } else {
+                 // If repeated measures is disabled, automatically navigate to the latest value
+                 if (!trait.repeatedMeasures) {
+                     val latestObs = repeatedValues.maxByOrNull { it.rep.toInt() }
+                     if (latestObs != null) {
+                         val repIndex = repeatedValues.indexOf(latestObs) + 1
+                         navigateFromValueClicked(plotId, col, repIndex)
+                     } else {
+                         navigateFromValueClicked(plotId, col)
+                     }
+                 } else {
+                     //show alert dialog with repeated values
+                     showRepeatedValuesNavigatorDialog(trait, repeatedValues)
+                 }
+             }
+         } catch (e: Exception) {
+             Log.e(TAG, "Error occurred while trying to navigate: " + e.printStackTrace())
+             FirebaseCrashlytics.getInstance().recordException(e)
+         }
+     }
 
     private fun navigateFromValueClicked(plotId: String, traitIndex: Int, rep: Int = 1) {
 

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
@@ -183,6 +183,13 @@ class ObservationDao {
                 traitDbId
             ).maxByOrNull { it.rep.toInt() }?.rep?.toInt() ?: 0) + 1
 
+        /**
+         * Gets the latest observation by rep number for the given study, observation unit, and trait.
+         * Used when repeated measures is disabled to display only the most recent value.
+         */
+        fun getLatestObservation(studyId: String, obsUnit: String, traitDbId: String): ObservationModel? =
+            getAllRepeatedValues(studyId, obsUnit, traitDbId).maxByOrNull { it.rep.toInt() }
+
         //false warning, cursor is closed in toTable
         @SuppressLint("Recycle")
         fun getHostImageObservations(ctx: Context, hostUrl: String, missingPhoto: Bitmap): List<FieldBookImage> = withDatabase { db ->

--- a/app/src/main/java/com/fieldbook/tracker/views/CollectInputView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/CollectInputView.kt
@@ -114,7 +114,7 @@ class CollectInputView(context: Context, attributeSet: AttributeSet) : Constrain
 
         } else {
 
-            text = models.minByOrNull { it.rep.toInt() }?.value ?: ""
+            text = models.maxByOrNull { it.rep.toInt() }?.value ?: ""
             markObservationEdited()
         }
     }


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note

```