### PR TITLE
Fix BrAPI Categorical Sync

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/sync/BrapiSyncViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/sync/BrapiSyncViewModel.kt
@@ -42,6 +42,9 @@ import kotlin.collections.isNotEmpty
 import kotlin.collections.map
 import androidx.core.content.edit
 import com.fieldbook.tracker.database.repository.TraitRepository
+import com.fieldbook.tracker.objects.TraitObject
+import com.fieldbook.tracker.traits.CategoricalTraitLayout
+import com.fieldbook.tracker.utilities.CategoryJsonUtil
 import com.fieldbook.tracker.utilities.export.ValueProcessorFormatAdapter
 import kotlinx.coroutines.withContext
 
@@ -406,6 +409,7 @@ class BrapiSyncViewModel @Inject constructor(
                                 val (inserts, updates, conflicts) = withContext(Dispatchers.IO) {
 
                                     val resolved = resolveObservationStatus(update.data)
+                                    val traitsById = traitRepo.getTraits().associateBy { it.id }
 
                                     Log.d(TAG, "Saving ${resolved.first.size} new observations")
 
@@ -416,6 +420,9 @@ class BrapiSyncViewModel @Inject constructor(
                                             Log.d(TAG, "Saving observation: ${obs.dbId}")
 
                                             obs.internalVariableDbId = obs.variableDbId
+
+                                            // Store categorical BrAPI values using Field Book's internal JSON format.
+                                            obs.value = normalizeDownloadedObservationValue(obs, traitsById)
 
                                             val rep = dataHelper.getNextRep(fieldObject.studyId.toString(), obs.unitDbId, obs.internalVariableDbId).toInt()
 
@@ -436,6 +443,10 @@ class BrapiSyncViewModel @Inject constructor(
                                     }
 
                                     Log.d(TAG, "Updating local database with ${resolved.second.size} updates")
+
+                                    resolved.second.forEach { obs ->
+                                        obs.value = normalizeDownloadedObservationValue(obs, traitsById)
+                                    }
 
                                     dataHelper.updateObservationsByBrapiId(resolved.second)
 
@@ -669,10 +680,48 @@ class BrapiSyncViewModel @Inject constructor(
 
         }.flowOn(Dispatchers.IO)
 
+    private fun processNewObservations(
+        newObs: List<Observation>,
+        localValuesByFieldBookId: Map<String, String>
+    ): Flow<UploadProgressUpdate> =
+        channelFlow {
+
+            val incompatible = AtomicInteger(0)
+            val new = AtomicInteger(0)
+            val edited = AtomicInteger(0)
+
+            brAPIService.awaitCreateObservations(
+                context,
+                newObs,
+                { chunk ->
+
+                    val (incompats, news, edits) = processChunk(
+                        chunk,
+                        newObs,
+                        localValuesByFieldBookId = localValuesByFieldBookId
+                    )
+
+                    incompatible.addAndGet(incompats)
+                    new.addAndGet(news)
+                    edited.addAndGet(edits)
+
+                    trySend(UploadProgressUpdate.InUploadProgress(chunk.size, newObs.size))
+
+                }) { errorCode, failedChunk ->
+
+                //errors coming from brapi api
+                trySend(UploadProgressUpdate.InUploadFailedChunk(errorCode, failedChunk))
+            }
+
+            send(UploadProgressUpdate.Completed(incompatible.get(), new.get(), edited.get()))
+
+        }.flowOn(Dispatchers.IO)
+
     private fun processChunk(
         chunk: List<Observation>,
         referenceObservations: List<Observation>,
-        isNew: Boolean = true
+        isNew: Boolean = true,
+        localValuesByFieldBookId: Map<String, String> = emptyMap()
     ): Triple<Int, Int, Int> {
 
         var incompatible = 0
@@ -703,6 +752,12 @@ class BrapiSyncViewModel @Inject constructor(
             } else if (firstIndex in referenceObservations.indices) {
 
                 val update = referenceObservations[firstIndex]
+                update.fieldBookDbId?.let { fieldBookId ->
+                    localValuesByFieldBookId[fieldBookId]?.let { preservedValue ->
+                        // Keep local DB observation value in Field Book's internal representation.
+                        update.value = preservedValue
+                    }
+                }
                 update.dbId = observation.dbId
                 update.setLastSyncedTime(syncTime)
                 dataHelper.updateObservationsByFieldBookId(listOf(update))
@@ -734,7 +789,10 @@ class BrapiSyncViewModel @Inject constructor(
      * When observation timestamp is greater that synced time, they must be pushed and updated
      * on the brapi endpoint.
      */
-    private fun processEditedObservations(editedObs: List<Observation>): Flow<UploadProgressUpdate> =
+    private fun processEditedObservations(
+        editedObs: List<Observation>,
+        localValuesByFieldBookId: Map<String, String>
+    ): Flow<UploadProgressUpdate> =
         channelFlow {
 
             val incompatible = AtomicInteger(0)
@@ -745,7 +803,12 @@ class BrapiSyncViewModel @Inject constructor(
                 context,
                 editedObs, { chunk ->
 
-                    val (incompats, news, edits) = processChunk(chunk, editedObs, isNew = false)
+                    val (incompats, news, edits) = processChunk(
+                        chunk,
+                        editedObs,
+                        isNew = false,
+                        localValuesByFieldBookId = localValuesByFieldBookId
+                    )
 
                     incompatible.addAndGet(incompats)
                     new.addAndGet(news)
@@ -764,9 +827,13 @@ class BrapiSyncViewModel @Inject constructor(
 
     private suspend fun processObservations(
         observations: List<Observation>,
-        processor: suspend (List<Observation>) -> Flow<UploadProgressUpdate>
+        processor: suspend (List<Observation>, Map<String, String>) -> Flow<UploadProgressUpdate>
     ) {
         Log.d(TAG, "Starting upload observations")
+
+        val localValuesByFieldBookId = observations.mapNotNull { obs ->
+            obs.fieldBookDbId?.let { id -> id to (obs.value ?: "") }
+        }.toMap()
 
         val traits = traitRepo.getTraits().associateBy { it.id }
         observations.forEach { obs ->
@@ -775,7 +842,7 @@ class BrapiSyncViewModel @Inject constructor(
             }
         }
 
-        processor(observations)
+        processor(observations, localValuesByFieldBookId)
             .onCompletion { cause ->
 
                 _uiState.update {
@@ -1115,6 +1182,22 @@ class BrapiSyncViewModel @Inject constructor(
         }
 
     }.flowOn(Dispatchers.IO)
+
+    private fun normalizeDownloadedObservationValue(
+        observation: Observation,
+        traitsById: Map<String, TraitObject>
+    ): String {
+        val rawValue = observation.value ?: return ""
+
+        if (rawValue.isBlank() || rawValue == "NA") return rawValue
+
+        val traitId = observation.internalVariableDbId ?: return rawValue
+        val trait = traitsById[traitId] ?: return rawValue
+
+        if (trait.format !in CategoricalTraitLayout.POSSIBLE_VALUES) return rawValue
+
+        return CategoryJsonUtil.encodeDownloadedBrapiCategoricalValue(rawValue, trait.categories)
+    }
 
     private fun processImageResponse(
         converted: FieldBookImage,

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/sync/BrapiSyncViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/sync/BrapiSyncViewModel.kt
@@ -42,6 +42,7 @@ import kotlin.collections.isNotEmpty
 import kotlin.collections.map
 import androidx.core.content.edit
 import com.fieldbook.tracker.database.repository.TraitRepository
+import com.fieldbook.tracker.utilities.export.ValueProcessorFormatAdapter
 import kotlinx.coroutines.withContext
 
 @HiltViewModel
@@ -49,7 +50,8 @@ class BrapiSyncViewModel @Inject constructor(
     @ApplicationContext private val context: Context,
     private val dataHelper: DataHelper,
     private val preferences: SharedPreferences,
-    private val traitRepo: TraitRepository
+    private val traitRepo: TraitRepository,
+    private val valueProcessorFormatAdapter: ValueProcessorFormatAdapter
 ) : ViewModel() {
 
     private var brAPIService = BrAPIServiceFactory.getBrAPIService(context)
@@ -764,8 +766,14 @@ class BrapiSyncViewModel @Inject constructor(
         observations: List<Observation>,
         processor: suspend (List<Observation>) -> Flow<UploadProgressUpdate>
     ) {
-
         Log.d(TAG, "Starting upload observations")
+
+        val traits = traitRepo.getTraits().associateBy { it.id }
+        observations.forEach { obs ->
+            traits[obs.internalVariableDbId]?.let { trait ->
+                obs.value = valueProcessorFormatAdapter.processValue(obs.value, trait)
+            }
+        }
 
         processor(observations)
             .onCompletion { cause ->

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/sync/BrapiSyncViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/sync/BrapiSyncViewModel.kt
@@ -771,7 +771,7 @@ class BrapiSyncViewModel @Inject constructor(
         val traits = traitRepo.getTraits().associateBy { it.id }
         observations.forEach { obs ->
             traits[obs.internalVariableDbId]?.let { trait ->
-                obs.value = valueProcessorFormatAdapter.processValue(obs.value, trait)
+                obs.value = valueProcessorFormatAdapter.processValue(obs.value, trait, forBrapi = true)
             }
         }
 

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
@@ -271,6 +271,7 @@ class ObservationDao {
                     obs.last_synced_time,
                     obs.collector,
                     obs.rep,
+                    obs.${ObservationVariable.FK} AS internalVariableDbId,
                     study.${Study.PK} AS ${Study.FK},
                     study.study_db_id,
                     vars.external_db_id,
@@ -298,6 +299,7 @@ class ObservationDao {
                         variableName = getStringVal(cursor, "observation_variable_name")
                         rep = getStringVal(cursor, "rep")
                         variableDetails = getStringVal(cursor, "observation_variable_details")
+                        internalVariableDbId = getStringVal(cursor, "internalVariableDbId")
                     }
                     
                     val format = getStringVal(cursor, "observation_variable_field_book_format")

--- a/app/src/main/java/com/fieldbook/tracker/utilities/CategoryJsonUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/CategoryJsonUtil.kt
@@ -39,6 +39,54 @@ class CategoryJsonUtil {
         }
 
         /**
+         * Parses a trait category definition that may be JSON or legacy slash-delimited values.
+         */
+        fun parseTraitCategories(categories: String): ArrayList<BrAPIScaleValidValuesCategories> {
+            if (categories.isBlank()) return arrayListOf()
+
+            return try {
+                decodeCategories(categories)
+            } catch (_: Exception) {
+                ArrayList(
+                    categories.split("/")
+                        .map { it.trim() }
+                        .filter { it.isNotEmpty() }
+                        .map { token ->
+                            BrAPIScaleValidValuesCategories().apply {
+                                label = token
+                                value = token
+                            }
+                        }
+                )
+            }
+        }
+
+        /**
+         * Converts downloaded BrAPI categorical raw values into Field Book internal JSON format.
+         * The stored category value always remains the original BrAPI token; label is resolved
+         * from the trait category definition when available.
+         */
+        fun encodeDownloadedBrapiCategoricalValue(rawValue: String, traitCategories: String): String {
+            if (rawValue.isBlank() || rawValue == "NA") return rawValue
+
+            // Already in internal JSON representation.
+            if (rawValue.trim().startsWith("[") && JsonUtil.isJsonValid(rawValue)) return rawValue
+
+            val categories = parseTraitCategories(traitCategories)
+            val selectedValues = rawValue.split(":").map { it.trim() }.filter { it.isNotEmpty() }
+
+            val mapped = ArrayList(selectedValues.map { selected ->
+                val matched = categories.firstOrNull { it.value == selected || it.label == selected }
+                BrAPIScaleValidValuesCategories().apply {
+                    value = selected
+                    label = matched?.label ?: selected
+                }
+            })
+
+            return if (mapped.isEmpty()) rawValue else encode(mapped)
+        }
+
+        /**
          * Takes an array of BrAPIScaleValidValuesCategories and returns a printable version.
          * JSON is currently stored in the backend to keep record of label/value pairs, the actual exported value
          * is converted using this function to a ":" delimited string. This might lead to data having extra ":" if the user

--- a/app/src/main/java/com/fieldbook/tracker/utilities/CategoryJsonUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/CategoryJsonUtil.kt
@@ -76,6 +76,10 @@ class CategoryJsonUtil {
 
             val rawValue = row["value"] as? String
 
+            val forBrapi = if ("forBrapi" in row.keys) {
+                row["forBrapi"] as? Boolean ?: false
+            } else false
+
             return when(row["observation_variable_field_book_format"]) {
                 in CategoricalTraitLayout.POSSIBLE_VALUES -> {
                     try {
@@ -83,9 +87,11 @@ class CategoryJsonUtil {
                         val showValue = row["categoryDisplayValue"] as? Boolean == true
                         val decoded = decode(rawValue ?: "")
                         if (decoded.size > 1) { // trait has multicat enabled
-                            decoded.joinToString(":") { if (showValue) it.value else it.label }
+                            decoded.joinToString(":") {
+                                if (showValue || forBrapi) it.value else it.label
+                            }
                         } else {
-                            if (showValue) decoded[0].value else decoded[0].label
+                            if (showValue || forBrapi) decoded[0].value else decoded[0].label
                         }
                     } catch (ignore: Exception) {
                         rawValue

--- a/app/src/main/java/com/fieldbook/tracker/utilities/export/ValueProcessorFormatAdapter.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/export/ValueProcessorFormatAdapter.kt
@@ -21,7 +21,7 @@ class ValueProcessorFormatAdapter @Inject constructor(
         private const val TAG = "ValueProcessorFA"
     }
 
-    fun processValue(value: String, trait: TraitObject): String? {
+    fun processValue(value: String, trait: TraitObject, forBrapi: Boolean = false): String? {
         return when {
 
             trait.format in setOf(Formats.DATE.getDatabaseName()) -> {
@@ -31,12 +31,15 @@ class ValueProcessorFormatAdapter @Inject constructor(
                 return (Formats.DATE.getTraitFormatDefinition() as ValuePresenter).represent(context, dateValue, trait)
             }
 
-            trait.format in CategoricalTraitLayout.POSSIBLE_VALUES -> return CategoryJsonUtil.processValue(
-                buildMap {
-                    put("value", value)
-                    put("observation_variable_field_book_format", trait.format)
-                    put("categoryDisplayValue", trait.categoryDisplayValue)
-                })
+            trait.format in CategoricalTraitLayout.POSSIBLE_VALUES -> {
+                return CategoryJsonUtil.processValue(
+                    buildMap {
+                        put("value", value)
+                        put("observation_variable_field_book_format", trait.format)
+                        put("forBrapi", forBrapi)
+                        put("categoryDisplayValue", trait.categoryDisplayValue)
+                    })
+            }
 
             trait.format in Formats.getSpectralFormats().map { it.getDatabaseName() } -> {
                 spectralFileProcessor.processValue(value)


### PR DESCRIPTION
### Description



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note

```