### PR TITLE
Add OAuth Redirect dialog: default (main) vs experimental app scheme.

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiAuthActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiAuthActivity.java
@@ -146,10 +146,15 @@ public class BrapiAuthActivity extends ThemedActivity {
             String clientId = sharedPreferences.getString(PreferenceKeys.BRAPI_OIDC_CLIENT_ID, "fieldbook");
             String scope = sharedPreferences.getString(PreferenceKeys.BRAPI_OIDC_SCOPE, "");
 
-            // Authorization code flow works better with custom URL scheme fieldbook://app/auth
-            // https://github.com/openid/AppAuth-Android/issues?q=is%3Aissue+intent+null
-            Uri redirectURI = flow.equals(getString(R.string.preferences_brapi_oidc_flow_oauth_implicit)) ?
-                    Uri.parse("https://phenoapps.org/field-book") : Uri.parse("fieldbook://app/auth");
+            Uri redirectURI;
+            if (isExperimentalOAuthRedirect(sharedPreferences)) {
+                redirectURI = Uri.parse("fieldbook://app/auth");
+            } else {
+                // Authorization code flow works better with custom URL scheme fieldbook://app/auth
+                // https://github.com/openid/AppAuth-Android/issues?q=is%3Aissue+intent+null
+                redirectURI = flow.equals(getString(R.string.preferences_brapi_oidc_flow_oauth_implicit)) ?
+                        Uri.parse("https://phenoapps.org/field-book") : Uri.parse("fieldbook://app/auth");
+            }
 
             authUtil.getAuthServiceConfiguration((authorizationServiceConfiguration, ex) -> {
 
@@ -218,6 +223,10 @@ public class BrapiAuthActivity extends ThemedActivity {
         authService.performAuthorizationRequest(
                 authRequest,
                 PendingIntent.getActivity(context, 0, responseIntent, PendingIntent.FLAG_MUTABLE));
+    }
+
+    private static boolean isExperimentalOAuthRedirect(SharedPreferences sharedPreferences) {
+        return "experimental".equals(sharedPreferences.getString(PreferenceKeys.BRAPI_OAUTH_REDIRECT, "default"));
     }
 
     public void authorizeBrAPI_OLD(SharedPreferences sharedPreferences, Context context) {

--- a/app/src/main/java/com/fieldbook/tracker/preferences/BrapiPreferencesFragment.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/BrapiPreferencesFragment.java
@@ -87,6 +87,8 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat implement
     private static final int REQUEST_BARCODE_SCAN_BRAPI_CONFIG = 97;
     private static final int AUTH_REQUEST_CODE = 123;
     private static final String DIALOG_FRAGMENT_TAG = "com.tracker.fieldbook.preferences.BRAPI_DIALOG_FRAGMENT";
+    private static final String OAUTH_REDIRECT_DEFAULT = "default";
+    private static final String OAUTH_REDIRECT_EXPERIMENTAL = "experimental";
 
     private Context context;
     private PreferenceCategory brapiServerPrefCategory;
@@ -159,6 +161,8 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat implement
             });
             updatePreferencesVisibility(brapiEnabledPref.isChecked());
         }
+
+        setupOAuthRedirectPreference();
 
         setupToolbar();
         setHasOptionsMenu(true);
@@ -292,11 +296,53 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat implement
             .show();
     }
 
+    private void setupOAuthRedirectPreference() {
+        Preference oauthRedirectPref = findPreference(PreferenceKeys.BRAPI_OAUTH_REDIRECT);
+        if (oauthRedirectPref != null) {
+            updateOAuthRedirectSummary(oauthRedirectPref);
+            oauthRedirectPref.setOnPreferenceClickListener(preference -> {
+                showOAuthRedirectDialog();
+                return true;
+            });
+        }
+    }
+
+    private void updateOAuthRedirectSummary(Preference oauthRedirectPref) {
+        String mode = preferences.getString(PreferenceKeys.BRAPI_OAUTH_REDIRECT, OAUTH_REDIRECT_DEFAULT);
+        oauthRedirectPref.setSummary(OAUTH_REDIRECT_EXPERIMENTAL.equals(mode)
+                ? getString(R.string.preferences_brapi_oauth_redirect_experimental)
+                : getString(R.string.preferences_brapi_oauth_redirect_default));
+    }
+
+    private void showOAuthRedirectDialog() {
+        String[] options = {
+                getString(R.string.preferences_brapi_oauth_redirect_default),
+                getString(R.string.preferences_brapi_oauth_redirect_experimental)
+        };
+        String current = preferences.getString(PreferenceKeys.BRAPI_OAUTH_REDIRECT, OAUTH_REDIRECT_DEFAULT);
+        int selected = OAUTH_REDIRECT_EXPERIMENTAL.equals(current) ? 1 : 0;
+
+        new AlertDialog.Builder(context, R.style.AppAlertDialog)
+                .setTitle(R.string.preferences_brapi_oauth_redirect_title)
+                .setSingleChoiceItems(options, selected, (dialog, which) -> {
+                    String value = which == 1 ? OAUTH_REDIRECT_EXPERIMENTAL : OAUTH_REDIRECT_DEFAULT;
+                    preferences.edit().putString(PreferenceKeys.BRAPI_OAUTH_REDIRECT, value).apply();
+                    Preference oauthRedirectPref = findPreference(PreferenceKeys.BRAPI_OAUTH_REDIRECT);
+                    if (oauthRedirectPref != null) {
+                        updateOAuthRedirectSummary(oauthRedirectPref);
+                    }
+                    dialog.dismiss();
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
     private void updatePreferencesVisibility(boolean isChecked) {
         PreferenceScreen preferenceScreen = getPreferenceScreen();
         for (int i = 0; i < preferenceScreen.getPreferenceCount(); i++) {
             Preference preferenceItem = preferenceScreen.getPreference(i);
-            if (preferenceItem.getKey().equals(PreferenceKeys.BRAPI_ENABLED)) { // Skip the checkbox preference itself
+            if (preferenceItem.getKey().equals(PreferenceKeys.BRAPI_ENABLED)
+                    || preferenceItem.getKey().equals(PreferenceKeys.BRAPI_OAUTH_REDIRECT)) {
                 continue;
             }
             preferenceItem.setVisible(isChecked);

--- a/app/src/main/java/com/fieldbook/tracker/preferences/PreferenceKeys.kt
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/PreferenceKeys.kt
@@ -99,6 +99,7 @@ class PreferenceKeys {
 
         // BrAPI
         const val BRAPI_ENABLED = "BRAPI_ENABLED"
+        const val BRAPI_OAUTH_REDIRECT = "BRAPI_OAUTH_REDIRECT"
         const val BRAPI_BASE_URL = "BRAPI_BASE_URL"
         const val BRAPI_OIDC_URL = "BRAPI_OIDC_URL"
         const val BRAPI_OIDC_FLOW = "BRAPI_OIDC_FLOW"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1249,6 +1249,9 @@
 
     <string name="preferences_brapi_enable_title">Enable BrAPI</string>
     <string name="preferences_brapi_enable_summary">The Breeding API allows simple data transfer to compatible databases.</string>
+    <string name="preferences_brapi_oauth_redirect_title">OAuth Redirect</string>
+    <string name="preferences_brapi_oauth_redirect_default">Default</string>
+    <string name="preferences_brapi_oauth_redirect_experimental">Experimental (phenoapps.org independent)</string>
     <string name="preferences_brapi_server_title">Server</string>
     <string name="preferences_brapi_barcode_config_title">Auto-configure</string>
     <string name="preferences_brapi_barcode_config_summary">Manage settings with QR codes</string>

--- a/app/src/main/res/xml/preferences_brapi.xml
+++ b/app/src/main/res/xml/preferences_brapi.xml
@@ -9,6 +9,12 @@
         android:summary="@string/preferences_brapi_enable_summary"
         android:title="@string/preferences_brapi_enable_title" />
 
+    <Preference
+        android:icon="@drawable/ic_pref_brapi_version"
+        android:key="BRAPI_OAUTH_REDIRECT"
+        android:summary="@string/preferences_brapi_oauth_redirect_default"
+        android:title="@string/preferences_brapi_oauth_redirect_title" />
+
     <PreferenceCategory
         android:key="brapi_server"
         android:title="@string/preferences_brapi_server_title"


### PR DESCRIPTION
### Description

BrAPI OAuth login can fail when **phenoapps.org** is unreachable — even if the BrAPI/OIDC server in settings is on a local network and working fine.

That mattered in practice on restricted or flaky networks (e.g. only local net available, or TLS/connectivity issues to phenoapps.org such as `PR_END_OF_FILE_ERROR`, which some users see in Russia).

**What was going wrong**

For implicit OAuth, Field Book used redirect URI `https://phenoapps.org/field-book`. After you signed in, the browser/identity provider sent the callback through PhenoApps’ site, and `BrapiAuthActivity` listened for that HTTPS URL. Login could therefore depend on reaching phenoapps.org, which has nothing to do with the BrAPI server you configured.

**What this PR adds**

A new **OAuth Redirect** option in Breeding API settings (below **Enable BrAPI**):

| Mode | Behavior |
|------|----------|
| **Default** | Unchanged from current releases — implicit → `https://phenoapps.org/field-book`, authorization code → `fieldbook://app/auth` |
| **Experimental (phenoapps.org independent)** | Always uses `fieldbook://app/auth` for OAuth (implicit and authorization code). The callback stays in the app instead of going through phenoapps.org |

Default is selected on install/upgrade, so existing behavior is preserved unless you opt in.

### Change Type

- [x] **`CHANGE`** (fix or feature that alters existing functionality)

### Release Note

```release-note
Breeding API settings now include an OAuth Redirect option. Default behavior is unchanged. Experimental (phenoapps.org independent) always returns OAuth to the app at fieldbook://app/auth, which can fix login when phenoapps.org is unreachable but your configured BrAPI server is not. **Experimental implicit-flow deployments may need fieldbook://app/auth added to their OIDC client redirect URIs.**
```

| | |
|---|---|
| **France VPN · Default · BrAPI**<br>`test-server.brapi.org` OK<br><br><img width="220" alt="France VPN, default, BrAPI OK" src="https://github.com/user-attachments/assets/4e320730-5515-40f0-b482-aaaf1469ea63" /> | **France VPN · Default · Auth**<br>OAuth OK<br><br><img width="220" alt="France VPN, default, auth OK" src="https://github.com/user-attachments/assets/8316ca8b-0515-4062-a24e-b79c70c3428e" /> |
| **Russia · no VPN · Default**<br>Fails via **phenoapps.org**<br><br><img width="220" alt="Russia, default, failure" src="https://github.com/user-attachments/assets/a2252507-0484-4cae-a982-a7e0174827ce" /> | **Russia · no VPN · Experimental**<br>Local server via `fieldbook://app/auth`<br><br><img width="220" alt="Russia, experimental, works" src="https://github.com/user-attachments/assets/5506dd9c-71e3-4e36-b9fe-d4cc5a42eb70" /> |
