### PR TITLE
epic/271-trait-viewer

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CameraActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CameraActivity.kt
@@ -811,7 +811,7 @@ class CameraActivity : ThemedActivity() {
 
                     // Determine whether to show crop region overlay for video based on saved crop coordinates for this trait
                     val showCropForVideo = try {
-                        val key = GeneralKeys.getCropCoordinatesKey(traitId?.toInt() ?: -1)
+                        val key = GeneralKeys.getCropCoordinatesKey(traitId)
                         val cropCoordinates = prefs.getString(key, "")
                         !cropCoordinates.isNullOrEmpty() && cropCoordinates != CropImageView.DEFAULT_CROP_COORDINATES
                     } catch (_: Exception) {

--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -2428,7 +2428,7 @@ public class CollectActivity extends ThemedActivity
 
                         if (Objects.equals(mediaType, "photo")) {
                             TraitObject trait = getCurrentTrait();
-                            String roiString = preferences.getString(GeneralKeys.getCropCoordinatesKey(Integer.parseInt(trait.getId())), "");
+                            String roiString = preferences.getString(GeneralKeys.getCropCoordinatesKey(trait.getId()), "");
                             if (roiString.isEmpty()) {
 
                                 File f = new File(getContext().getCacheDir(), AbstractCameraTrait.TEMPORARY_IMAGE_NAME);
@@ -3570,7 +3570,7 @@ public class CollectActivity extends ThemedActivity
 
                         //update crop region to full image
                         preferences.edit()
-                            .putString(GeneralKeys.getCropCoordinatesKey(Integer.parseInt(traitId)), "0,0,1,1")
+                            .putString(GeneralKeys.getCropCoordinatesKey(traitId), "0,0,1,1")
                             .apply();
                     }
                 } catch (Exception e) {

--- a/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/ConfigActivity.java
@@ -21,30 +21,28 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.Toolbar;
 import androidx.documentfile.provider.DocumentFile;
-import androidx.preference.PreferenceManager;
 
 import com.fieldbook.tracker.BuildConfig;
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.adapters.ImageListAdapter;
 import com.fieldbook.tracker.database.DataHelper;
 import com.fieldbook.tracker.database.models.ObservationModel;
-import com.fieldbook.tracker.database.models.ObservationUnitModel;
 import com.fieldbook.tracker.fragments.ImportDatabaseFragment;
 import com.fieldbook.tracker.objects.FieldObject;
 import com.fieldbook.tracker.objects.TraitObject;
 import com.fieldbook.tracker.preferences.GeneralKeys;
 import com.fieldbook.tracker.preferences.PreferenceKeys;
 import com.fieldbook.tracker.utilities.AppLanguageUtil;
+import com.fieldbook.tracker.utilities.FieldSwitchImpl;
 import com.fieldbook.tracker.utilities.FuzzySearch;
 import com.fieldbook.tracker.utilities.InsetHandler;
-import com.fieldbook.tracker.utilities.export.ExportUtil;
-import com.fieldbook.tracker.utilities.FieldSwitchImpl;
 import com.fieldbook.tracker.utilities.OldPhotosMigrator;
 import com.fieldbook.tracker.utilities.PersonNameManager;
 import com.fieldbook.tracker.utilities.SoundHelperImpl;
 import com.fieldbook.tracker.utilities.TapTargetUtil;
 import com.fieldbook.tracker.utilities.Utils;
 import com.fieldbook.tracker.utilities.VerifyPersonHelper;
+import com.fieldbook.tracker.utilities.export.ExportUtil;
 import com.getkeepsafe.taptargetview.TapTarget;
 import com.getkeepsafe.taptargetview.TapTargetSequence;
 import com.getkeepsafe.taptargetview.TapTargetView;
@@ -290,6 +288,7 @@ public class ConfigActivity extends ThemedActivity {
                 case 1:
                     intent.setClassName(ConfigActivity.this,
                             TraitActivity.class.getName());
+                    intent.putExtra(TraitActivity.EXTRA_MODE, TraitActivity.MODE_EDITOR);
                     startActivity(intent);
 
                     break;

--- a/app/src/main/java/com/fieldbook/tracker/activities/FieldDetailFragment.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/FieldDetailFragment.kt
@@ -18,6 +18,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.core.content.res.ResourcesCompat
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.Toolbar
 import androidx.cardview.widget.CardView
@@ -35,6 +36,7 @@ import com.fieldbook.tracker.interfaces.FieldSortController
 import com.fieldbook.tracker.interfaces.FieldSyncController
 import com.fieldbook.tracker.objects.FieldObject
 import com.fieldbook.tracker.objects.ImportFormat
+import com.fieldbook.tracker.objects.TraitObject
 import com.fieldbook.tracker.preferences.GeneralKeys
 import com.fieldbook.tracker.preferences.PreferenceKeys
 import com.fieldbook.tracker.traits.formats.Formats
@@ -86,6 +88,7 @@ class FieldDetailFragment : Fragment(), FieldSyncController {
     private lateinit var lastExportTextView: TextView
     private lateinit var lastSyncTextView: TextView
     private lateinit var cardViewCollect: CardView
+    private lateinit var cardViewTraits: CardView
     private lateinit var cardViewExport: CardView
     private lateinit var cardViewSync: CardView
     private lateinit var sourceChip: Chip
@@ -98,6 +101,10 @@ class FieldDetailFragment : Fragment(), FieldSyncController {
     private lateinit var observationCountChip: Chip
     private lateinit var trialNameChip: Chip
     private lateinit var studyGroupNameChip: Chip
+    private lateinit var traitIconsContainer: LinearLayout
+    private lateinit var traitsNoneTextView: TextView
+    private lateinit var traitsExpandCollapseIcon: ImageView
+    private lateinit var traitsExpandedContent: LinearLayout
     private lateinit var detailRecyclerView: RecyclerView
     private var adapter: FieldDetailAdapter? = null
 
@@ -129,6 +136,10 @@ class FieldDetailFragment : Fragment(), FieldSyncController {
         detailRecyclerView = rootView.findViewById(R.id.fieldDetailRecyclerView)
         trialNameChip = rootView.findViewById(R.id.trialNameChip)
         studyGroupNameChip = rootView.findViewById(R.id.studyGroupName)
+        traitIconsContainer = rootView.findViewById(R.id.traitIconsContainer)
+        traitsNoneTextView = rootView.findViewById(R.id.traitsNoneTextView)
+        traitsExpandCollapseIcon = rootView.findViewById(R.id.traitsExpandCollapseIcon)
+        traitsExpandedContent = rootView.findViewById(R.id.traitsExpandedContent)
 
         fieldId = arguments?.getInt(GeneralKeys.FIELD_DETAIL_FIELD_ID)
         loadFieldDetails()
@@ -155,6 +166,7 @@ class FieldDetailFragment : Fragment(), FieldSyncController {
         }
 
         cardViewCollect = rootView.findViewById(R.id.cardViewCollect)
+        cardViewTraits = rootView.findViewById(R.id.cardViewTraits)
         cardViewExport = rootView.findViewById(R.id.cardViewExport)
 
         cardViewCollect.setOnClickListener {
@@ -180,6 +192,25 @@ class FieldDetailFragment : Fragment(), FieldSyncController {
                 }
             } ?: Log.e("FieldDetailFragment", "Field ID is null, cannot export data")
         }
+
+        rootView.findViewById<LinearLayout>(R.id.traitsCardHeader).setOnClickListener {
+            fieldId?.let { id ->
+                val intent = Intent(requireContext(), TraitActivity::class.java).apply {
+                    putExtra(TraitActivity.EXTRA_MODE, TraitActivity.MODE_VIEWER)
+                    putExtra(TraitActivity.EXTRA_STUDY_ID, id)
+                }
+                startActivity(intent)
+            } ?: Log.e("FieldDetailFragment", "Field ID is null, cannot manage traits")
+        }
+
+        val traitsIconsRow = rootView.findViewById<LinearLayout>(R.id.traitsIconsRow)
+        traitsIconsRow.setOnClickListener { toggleTraitsExpanded() }
+
+        val traitsExpanded = preferences.getBoolean(GeneralKeys.FIELD_DETAIL_TRAITS_EXPANDED, false)
+        traitsExpandedContent.visibility = if (traitsExpanded) View.VISIBLE else View.GONE
+        traitsExpandCollapseIcon.setImageResource(
+            if (traitsExpanded) R.drawable.ic_chevron_up else R.drawable.ic_chevron_down
+        )
 
         val dataExpandCollapseIcon: ImageView = rootView.findViewById(R.id.data_expand_collapse_icon)
         val dataCollapsibleContent: LinearLayout = rootView.findViewById(R.id.data_collapsible_content)
@@ -276,13 +307,14 @@ class FieldDetailFragment : Fragment(), FieldSyncController {
         fieldId?.let { id ->
             CoroutineScope(Dispatchers.IO).launch {
                 val field = database.getFieldObject(id)
-                
+                val visibleTraits = database.getVisibleTraitsForStudy(id)
+
                 withContext(Dispatchers.Main) {
                     fieldObject = field  // Store the field object
                     
                     if (field != null) {
-                        updateFieldData(field)
-                        
+                        updateFieldData(field, visibleTraits)
+
                         if (detailRecyclerView.adapter == null) { // initial load
                             detailRecyclerView.layoutManager = LinearLayoutManager(context)
                             val initialItems = createTraitDetailItems(field).toMutableList()
@@ -299,7 +331,7 @@ class FieldDetailFragment : Fragment(), FieldSyncController {
         } ?: Log.e("FieldDetailFragment", "Field ID is null")
     }
 
-    private fun updateFieldData(field: FieldObject) {
+    private fun updateFieldData(field: FieldObject, visibleTraits: List<TraitObject>) {
 
         cardViewSync.visibility = View.GONE
         cardViewSync.setOnClickListener(null)
@@ -372,6 +404,9 @@ class FieldDetailFragment : Fragment(), FieldSyncController {
         }
 
         traitCountChip.text = field.traitCount.toString()
+
+        populateTraitIcons(visibleTraits)
+
         if (field.observationCount.toInt() > 0) {
             observationCountChip.visibility = View.VISIBLE
             observationCountChip.text = field.observationCount.toString()
@@ -385,6 +420,94 @@ class FieldDetailFragment : Fragment(), FieldSyncController {
         if (!groupName.isNullOrEmpty() && groupName != field.trialName) {
             studyGroupNameChip.visibility = View.VISIBLE
             studyGroupNameChip.text = groupName
+        }
+    }
+
+    private fun populateTraitIcons(traits: List<TraitObject>) {
+        val ctx = context ?: return
+        val isExpanded = preferences.getBoolean(GeneralKeys.FIELD_DETAIL_TRAITS_EXPANDED, false)
+
+        if (traits.isEmpty()) {
+            traitIconsContainer.visibility = View.GONE
+            traitsNoneTextView.visibility = View.VISIBLE
+            traitsExpandCollapseIcon.visibility = View.GONE
+            traitsExpandedContent.visibility = View.GONE
+            return
+        }
+
+        traitsNoneTextView.visibility = View.GONE
+        traitsExpandCollapseIcon.visibility = View.VISIBLE
+        traitIconsContainer.visibility = if (isExpanded) View.INVISIBLE else View.VISIBLE
+
+        traitIconsContainer.removeAllViews()
+        val iconSizePx = (24 * ctx.resources.displayMetrics.density).toInt()
+        val marginPx = (4 * ctx.resources.displayMetrics.density).toInt()
+
+        for (trait in traits) {
+            val iconRes = Formats.entries
+                .find { it.getDatabaseName() == trait.format }
+                ?.getIcon() ?: R.drawable.ic_trait_text
+
+            val iv = ImageView(ctx).apply {
+                layoutParams = LinearLayout.LayoutParams(iconSizePx, iconSizePx).also {
+                    it.marginEnd = marginPx
+                }
+                setImageDrawable(ResourcesCompat.getDrawable(resources, iconRes, ctx.theme))
+                contentDescription = trait.alias.takeIf { it.isNotBlank() } ?: trait.name
+            }
+            traitIconsContainer.addView(iv)
+        }
+
+        traitsExpandedContent.removeAllViews()
+        for (trait in traits) {
+            val iconRes = Formats.entries
+                .find { it.getDatabaseName() == trait.format }
+                ?.getIcon() ?: R.drawable.ic_trait_text
+
+            val rowView = LinearLayout(ctx).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = android.view.Gravity.CENTER_VERTICAL
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ).also { it.bottomMargin = marginPx }
+            }
+
+            val iv = ImageView(ctx).apply {
+                layoutParams = LinearLayout.LayoutParams(iconSizePx, iconSizePx).also {
+                    it.marginEnd = marginPx
+                }
+                setImageDrawable(ResourcesCompat.getDrawable(resources, iconRes, ctx.theme))
+            }
+
+            val tv = TextView(ctx).apply {
+                text = trait.alias.takeIf { it.isNotBlank() } ?: trait.name
+                setTextAppearance(R.style.TextViewStyle_Sub)
+                layoutParams = LinearLayout.LayoutParams(
+                    0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f
+                )
+                maxLines = 1
+                ellipsize = android.text.TextUtils.TruncateAt.END
+            }
+
+            rowView.addView(iv)
+            rowView.addView(tv)
+            traitsExpandedContent.addView(rowView)
+        }
+    }
+
+    private fun toggleTraitsExpanded() {
+        val isExpanded = traitsExpandedContent.visibility == View.VISIBLE
+        if (isExpanded) {
+            traitsExpandedContent.visibility = View.GONE
+            traitIconsContainer.visibility = View.VISIBLE
+            traitsExpandCollapseIcon.setImageResource(R.drawable.ic_chevron_down)
+            preferences.edit { putBoolean(GeneralKeys.FIELD_DETAIL_TRAITS_EXPANDED, false) }
+        } else {
+            traitsExpandedContent.visibility = View.VISIBLE
+            traitIconsContainer.visibility = View.INVISIBLE
+            traitsExpandCollapseIcon.setImageResource(R.drawable.ic_chevron_up)
+            preferences.edit { putBoolean(GeneralKeys.FIELD_DETAIL_TRAITS_EXPANDED, true) }
         }
     }
 
@@ -581,8 +704,12 @@ class FieldDetailFragment : Fragment(), FieldSyncController {
 
     fun checkTraitsExist(callback: (Int) -> Unit) {
         CoroutineScope(Dispatchers.IO).launch {
-
-            val traits = database.getVisibleTraits()
+            val currentFieldId = fieldId
+            val traits = if (currentFieldId != null) {
+                database.getVisibleTraitsForStudy(currentFieldId)
+            } else {
+                database.getVisibleTraits()
+            }
             val result = when {
                 traits.isEmpty() -> {
                     withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/fieldbook/tracker/activities/TraitActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/TraitActivity.kt
@@ -6,14 +6,18 @@ import android.view.LayoutInflater
 import android.widget.LinearLayout
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.runtime.remember
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import androidx.preference.PreferenceManager
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.database.DataHelper
@@ -22,6 +26,7 @@ import com.fieldbook.tracker.database.viewmodels.TraitDetailViewModel
 import com.fieldbook.tracker.dialogs.FileExploreDialogFragment
 import com.fieldbook.tracker.dialogs.NewTraitDialog
 import com.fieldbook.tracker.objects.TraitObject
+import com.fieldbook.tracker.preferences.GeneralKeys
 import com.fieldbook.tracker.ui.screens.traits.TraitEditorScreen
 import com.fieldbook.tracker.ui.theme.AppTheme
 import com.fieldbook.tracker.utilities.Utils
@@ -34,8 +39,10 @@ import com.fieldbook.tracker.traits.formats.parameters.DecimalPlacesParameter
 import com.fieldbook.tracker.ui.navigation.controllers.TraitNavController
 import com.fieldbook.tracker.ui.navigation.routes.TraitDetail
 import com.fieldbook.tracker.ui.navigation.routes.TraitEditor
+import com.fieldbook.tracker.ui.navigation.routes.TraitFieldPicker
 import com.fieldbook.tracker.ui.navigation.routes.TraitGraph
 import com.fieldbook.tracker.ui.screens.traits.TraitDetailScreen
+import com.fieldbook.tracker.ui.screens.traits.TraitFieldPickerScreen
 import com.fieldbook.tracker.utilities.SoundHelperImpl
 import com.fieldbook.tracker.utilities.VibrateUtil
 import dagger.hilt.android.AndroidEntryPoint
@@ -59,10 +66,20 @@ class TraitActivity : ThemedActivity() {
 
     companion object {
         private const val TAG = "TraitEditorActivity"
+        const val EXTRA_MODE = "com.fieldbook.tracker.activities.trait.MODE"
+        const val EXTRA_STUDY_ID = "com.fieldbook.tracker.activities.trait.STUDY_ID"
+        const val MODE_EDITOR = "editor"
+        const val MODE_VIEWER = "viewer"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val isViewerMode = intent?.getStringExtra(EXTRA_MODE) == MODE_VIEWER
+        val scopedStudyId = intent?.getIntExtra(EXTRA_STUDY_ID, -1)?.takeIf { it >= 0 }
+            ?: PreferenceManager.getDefaultSharedPreferences(this)
+                .getInt(GeneralKeys.SELECTED_FIELD_ID, -1)
+                .takeIf { it >= 0 }
 
         setupBackCallback()
 
@@ -78,7 +95,11 @@ class TraitActivity : ThemedActivity() {
 
                 NavHost(
                     navController = navController,
-                    startDestination = TraitGraph
+                    startDestination = TraitGraph,
+                    enterTransition = { EnterTransition.None },
+                    exitTransition = { ExitTransition.None },
+                    popEnterTransition = { EnterTransition.None },
+                    popExitTransition = { ExitTransition.None }
                 ) {
                     navigation<TraitGraph>(startDestination = TraitEditor) {
 
@@ -92,12 +113,17 @@ class TraitActivity : ThemedActivity() {
 
                             TraitEditorScreen(
                                 viewModel = editorViewModel,
+                                isViewerMode = isViewerMode,
+                                scopedStudyId = scopedStudyId,
                                 onNavigateBack = { finish() },
                                 onTraitDetail = { traitId ->
                                     traitNav.navigateToTraitDetail(
                                         traitId = traitId,
                                         from = backStackEntry,
                                     )
+                                },
+                                onNavigateToFieldTraitPicker = {
+                                    traitNav.navigateToFieldTraitPicker(backStackEntry)
                                 },
                                 onShowCreateNewTraitDialog = {
                                     showCreateNewTraitDialog(
@@ -111,6 +137,34 @@ class TraitActivity : ThemedActivity() {
                                             editorViewModel.importTraits(it)
                                         }
                                     )
+                                }
+                            )
+                        }
+
+                        composable<TraitFieldPicker> { backStackEntry ->
+                            val parentEntry = remember(backStackEntry) {
+                                navController.getBackStackEntry(TraitGraph)
+                            }
+
+                            val editorViewModel: TraitEditorViewModel = hiltViewModel(parentEntry)
+                            val uiState = editorViewModel.uiState.collectAsStateWithLifecycle().value
+
+                            TraitFieldPickerScreen(
+                                availableTraits = uiState.availableTraits,
+                                onBack = { traitNav.navigateBack() },
+                                onCreateNewTrait = {
+                                    traitNav.navigateBack()
+                                    showCreateNewTraitDialog(
+                                        trait = null,
+                                        onSaved = {
+                                            editorViewModel.loadTraits()
+                                            editorViewModel.loadAvailableTraitsForCurrentStudy()
+                                        },
+                                    )
+                                },
+                                onAddSelected = { selectedIds ->
+                                    editorViewModel.addTraitsToCurrentStudy(selectedIds)
+                                    traitNav.navigateBack()
                                 }
                             )
                         }

--- a/app/src/main/java/com/fieldbook/tracker/activities/TraitActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/TraitActivity.kt
@@ -153,7 +153,6 @@ class TraitActivity : ThemedActivity() {
                                 availableTraits = uiState.availableTraits,
                                 onBack = { traitNav.navigateBack() },
                                 onCreateNewTrait = {
-                                    traitNav.navigateBack()
                                     showCreateNewTraitDialog(
                                         trait = null,
                                         onSaved = {

--- a/app/src/main/java/com/fieldbook/tracker/activities/TraitActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/TraitActivity.kt
@@ -10,8 +10,8 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.runtime.remember
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
@@ -23,14 +23,11 @@ import com.fieldbook.tracker.R
 import com.fieldbook.tracker.database.DataHelper
 import com.fieldbook.tracker.database.repository.TraitRepository
 import com.fieldbook.tracker.database.viewmodels.TraitDetailViewModel
+import com.fieldbook.tracker.database.viewmodels.TraitEditorViewModel
 import com.fieldbook.tracker.dialogs.FileExploreDialogFragment
 import com.fieldbook.tracker.dialogs.NewTraitDialog
 import com.fieldbook.tracker.objects.TraitObject
 import com.fieldbook.tracker.preferences.GeneralKeys
-import com.fieldbook.tracker.ui.screens.traits.TraitEditorScreen
-import com.fieldbook.tracker.ui.theme.AppTheme
-import com.fieldbook.tracker.utilities.Utils
-import com.fieldbook.tracker.database.viewmodels.TraitEditorViewModel
 import com.fieldbook.tracker.traits.formats.Formats
 import com.fieldbook.tracker.traits.formats.NumericFormat
 import com.fieldbook.tracker.traits.formats.TraitFormat
@@ -42,8 +39,11 @@ import com.fieldbook.tracker.ui.navigation.routes.TraitEditor
 import com.fieldbook.tracker.ui.navigation.routes.TraitFieldPicker
 import com.fieldbook.tracker.ui.navigation.routes.TraitGraph
 import com.fieldbook.tracker.ui.screens.traits.TraitDetailScreen
+import com.fieldbook.tracker.ui.screens.traits.TraitEditorScreen
 import com.fieldbook.tracker.ui.screens.traits.TraitFieldPickerScreen
+import com.fieldbook.tracker.ui.theme.AppTheme
 import com.fieldbook.tracker.utilities.SoundHelperImpl
+import com.fieldbook.tracker.utilities.Utils
 import com.fieldbook.tracker.utilities.VibrateUtil
 import dagger.hilt.android.AndroidEntryPoint
 import org.phenoapps.utils.BaseDocumentTreeUtil
@@ -204,7 +204,6 @@ class TraitActivity : ThemedActivity() {
                                 },
                             )
                         }
-
                     }
                 }
             }

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -658,19 +658,31 @@ public class DataHelper {
 
         open();
 
-        String sortColumn = preferences.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position");
+        // Read the field-specific sort preference first, falling back to the global one.
+        // The key "field_default" means "follow the main editor's global sort".
+        String sortColumn = preferences.getString(
+                "field_trait_sort_order_" + studyId, null);
+        if (sortColumn == null) {
+            sortColumn = preferences.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position");
+        }
         return getVisibleTraitsForStudy(studyId, sortColumn);
 
     }
 
     private ArrayList<TraitObject> getVisibleTraitsForStudy(int studyId, String sortColumn) {
-        ArrayList<TraitObject> visibleTraits = ObservationVariableDao.Companion.getAllVisibleTraitObjects(sortColumn);
+        // Resolve "field_default" apply the main editor's global sort preference
+        String effectiveSortColumn = sortColumn;
+        if ("field_default".equals(sortColumn)) {
+            effectiveSortColumn = preferences.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position");
+        }
+
+        ArrayList<TraitObject> visibleTraits = ObservationVariableDao.Companion.getAllVisibleTraitObjects(effectiveSortColumn);
 
         if (studyId < 0) {
             return visibleTraits;
         }
 
-        ArrayList<TraitObject> allTraits = ObservationVariableDao.Companion.getAllTraitObjects(sortColumn);
+        ArrayList<TraitObject> allTraits = ObservationVariableDao.Companion.getAllTraitObjects(effectiveSortColumn);
         java.util.HashSet<String> fallbackIds = new java.util.HashSet<>();
         for (TraitObject trait : allTraits) {
             fallbackIds.add(trait.getId());
@@ -696,8 +708,7 @@ public class DataHelper {
             }
         }
 
-        // For field-specific lists, prefer the field-specific trait order when one exists.
-        if (sortColumn.equals("position")) {
+        if ("position".equals(effectiveSortColumn)) {
             List<String> fieldOrder = fieldTraitConfigDao.getTraitIdsInOrder(studyId);
             if (!fieldOrder.isEmpty()) {
                 java.util.Map<String, Integer> orderMap = new java.util.HashMap<>();
@@ -723,8 +734,8 @@ public class DataHelper {
         }
 
         // For non-position sort orders, apply the requested sort
-        if (!"position".equals(sortColumn)) {
-            if ("visible".equals(sortColumn)) {
+        if (!"position".equals(effectiveSortColumn)) {
+            if ("visible".equals(effectiveSortColumn)) {
                 // Keep visible traits at the top when sorting by visibility.
                 filtered.sort(Comparator.comparing(TraitObject::getVisible).reversed()
                         .thenComparing(t -> {
@@ -732,20 +743,20 @@ public class DataHelper {
                             String name = !t.getAlias().isEmpty() ? t.getAlias() : t.getName();
                             return name.toLowerCase();
                         }));
-            } else if ("observation_variable_name".equals(sortColumn)) {
+            } else if ("observation_variable_name".equals(effectiveSortColumn)) {
                 filtered.sort(Comparator.comparing(t -> {
                     t.getAlias();
                     String name = !t.getAlias().isEmpty() ? t.getAlias() : t.getName();
                     return name.toLowerCase();
                 }));
-            } else if ("observation_variable_field_book_format".equals(sortColumn)) {
+            } else if ("observation_variable_field_book_format".equals(effectiveSortColumn)) {
                 filtered.sort(Comparator.comparing((TraitObject t) -> t.getFormat().toLowerCase())
                         .thenComparing(t -> {
                             t.getAlias();
                             String name = !t.getAlias().isEmpty() ? t.getAlias() : t.getName();
                             return name.toLowerCase();
                         }));
-            } else if ("internal_id_observation_variable".equals(sortColumn)) {
+            } else if ("internal_id_observation_variable".equals(effectiveSortColumn)) {
                 filtered.sort(Comparator.comparingInt(t -> {
                     try {
                         return Integer.parseInt(t.getId());

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -18,31 +18,33 @@ import androidx.preference.PreferenceManager;
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.brapi.model.FieldBookImage;
 import com.fieldbook.tracker.brapi.model.Observation;
+import com.fieldbook.tracker.database.dao.FieldTraitConfigDao;
 import com.fieldbook.tracker.database.dao.GroupDao;
 import com.fieldbook.tracker.database.dao.ObservationDao;
 import com.fieldbook.tracker.database.dao.ObservationUnitAttributeDao;
 import com.fieldbook.tracker.database.dao.ObservationUnitDao;
 import com.fieldbook.tracker.database.dao.ObservationUnitPropertyDao;
 import com.fieldbook.tracker.database.dao.ObservationVariableDao;
+import com.fieldbook.tracker.database.dao.StudyDao;
 import com.fieldbook.tracker.database.dao.spectral.DeviceDao;
 import com.fieldbook.tracker.database.dao.spectral.ProtocolDao;
 import com.fieldbook.tracker.database.dao.spectral.SpectralDao;
-import com.fieldbook.tracker.database.dao.StudyDao;
 import com.fieldbook.tracker.database.dao.spectral.UriDao;
-import com.fieldbook.tracker.database.migrators.ObservationMediaMigratorVersion21;
-import com.fieldbook.tracker.database.views.ObservationVariableAttributeDetailViewCreator;
+import com.fieldbook.tracker.database.migrators.FieldTraitConfigMigratorVersion22;
+import com.fieldbook.tracker.database.models.GroupModel;
 import com.fieldbook.tracker.database.models.ObservationModel;
 import com.fieldbook.tracker.database.models.ObservationUnitModel;
 import com.fieldbook.tracker.database.models.ObservationVariableModel;
-import com.fieldbook.tracker.database.models.GroupModel;
 import com.fieldbook.tracker.database.models.StudyModel;
 import com.fieldbook.tracker.database.repository.SpectralRepository;
+import com.fieldbook.tracker.database.views.ObservationVariableAttributeDetailViewCreator;
 import com.fieldbook.tracker.objects.FieldObject;
 import com.fieldbook.tracker.objects.RangeObject;
 import com.fieldbook.tracker.objects.SearchData;
 import com.fieldbook.tracker.objects.SearchDialogDataModel;
 import com.fieldbook.tracker.objects.TraitObject;
 import com.fieldbook.tracker.preferences.GeneralKeys;
+import com.fieldbook.tracker.preferences.TraitScopePreferences;
 import com.fieldbook.tracker.utilities.GeoJsonUtil;
 import com.fieldbook.tracker.utilities.ZipUtil;
 import com.fieldbook.tracker.utilities.export.SpectralFileProcessor;
@@ -61,10 +63,12 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -77,7 +81,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext;
  */
 public class DataHelper {
 
-    public static final int DATABASE_VERSION = ObservationMediaMigratorVersion21.VERSION;
+    public static final int DATABASE_VERSION = FieldTraitConfigMigratorVersion22.VERSION;
     private static final String DATABASE_NAME = "fieldbook.db";
     public static SQLiteDatabase db;
     private static final String TAG = "Field Book";
@@ -101,6 +105,7 @@ public class DataHelper {
     private SearchQueryBuilder queryBuilder;
 
     private final GroupDao studyGroupDao = new GroupDao(GroupsTable.Type.STUDY);
+    private final FieldTraitConfigDao fieldTraitConfigDao = new FieldTraitConfigDao();
 
     @Inject
     public DataHelper(@ApplicationContext Context context) {
@@ -644,10 +649,114 @@ public class DataHelper {
     public ArrayList<TraitObject> getVisibleTraits() {
 
         open();
+        int selectedStudyId = preferences.getInt(GeneralKeys.SELECTED_FIELD_ID, -1);
+        return getVisibleTraitsForStudy(selectedStudyId);
+
+    }
+
+    public ArrayList<TraitObject> getVisibleTraitsForStudy(int studyId) {
+
+        open();
 
         String sortColumn = preferences.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position");
+        return getVisibleTraitsForStudy(studyId, sortColumn);
 
-        return ObservationVariableDao.Companion.getAllVisibleTraitObjects(sortColumn);
+    }
+
+    private ArrayList<TraitObject> getVisibleTraitsForStudy(int studyId, String sortColumn) {
+        ArrayList<TraitObject> visibleTraits = ObservationVariableDao.Companion.getAllVisibleTraitObjects(sortColumn);
+
+        if (studyId < 0) {
+            return visibleTraits;
+        }
+
+        ArrayList<TraitObject> allTraits = ObservationVariableDao.Companion.getAllTraitObjects(sortColumn);
+        java.util.HashSet<String> fallbackIds = new java.util.HashSet<>();
+        for (TraitObject trait : allTraits) {
+            fallbackIds.add(trait.getId());
+        }
+
+        Set<String> scopedIds = TraitScopePreferences.getOrInitializeStudyTraitIds(preferences, studyId, fallbackIds);
+
+        // If the field has never been customized (no config row), use global visibility as default.
+        // Only use field-specific visibility once the user has explicitly customized this field.
+        List<String> scopedVisibleIds;
+        Set<String> customVisibleIds = TraitScopePreferences.getStudyVisibleTraitIds(preferences, studyId);
+
+        if (customVisibleIds != null) {
+            scopedVisibleIds = new ArrayList<>(customVisibleIds);
+            scopedVisibleIds.removeIf(id -> !scopedIds.contains(id));
+        } else {
+            // Default: use global visible flag
+            scopedVisibleIds = new ArrayList<>();
+            for (TraitObject trait : allTraits) {
+                if (trait.getVisible() && scopedIds.contains(trait.getId())) {
+                    scopedVisibleIds.add(trait.getId());
+                }
+            }
+        }
+
+        // For field-specific lists, prefer the field-specific trait order when one exists.
+        if (sortColumn.equals("position")) {
+            List<String> fieldOrder = fieldTraitConfigDao.getTraitIdsInOrder(studyId);
+            if (!fieldOrder.isEmpty()) {
+                java.util.Map<String, Integer> orderMap = new java.util.HashMap<>();
+                for (int i = 0; i < fieldOrder.size(); i++) {
+                    orderMap.put(fieldOrder.get(i), i);
+                }
+                allTraits.sort(Comparator.comparing(t -> orderMap.getOrDefault(t.getId(), Integer.MAX_VALUE)));
+            }
+        }
+
+        ArrayList<TraitObject> filtered = new ArrayList<>();
+        // Create a map for quick lookup by ID
+        java.util.Map<String, TraitObject> traitMap = new java.util.HashMap<>();
+        for (TraitObject trait : allTraits) {
+            traitMap.put(trait.getId(), trait);
+        }
+
+        for (String traitId : scopedVisibleIds) {
+            TraitObject trait = traitMap.get(traitId);
+            if (trait != null) {
+                filtered.add(trait);
+            }
+        }
+
+        // For non-position sort orders, apply the requested sort
+        if (!"position".equals(sortColumn)) {
+            if ("visible".equals(sortColumn)) {
+                // Keep visible traits at the top when sorting by visibility.
+                filtered.sort(Comparator.comparing(TraitObject::getVisible).reversed()
+                        .thenComparing(t -> {
+                            t.getAlias();
+                            String name = !t.getAlias().isEmpty() ? t.getAlias() : t.getName();
+                            return name.toLowerCase();
+                        }));
+            } else if ("observation_variable_name".equals(sortColumn)) {
+                filtered.sort(Comparator.comparing(t -> {
+                    t.getAlias();
+                    String name = !t.getAlias().isEmpty() ? t.getAlias() : t.getName();
+                    return name.toLowerCase();
+                }));
+            } else if ("observation_variable_field_book_format".equals(sortColumn)) {
+                filtered.sort(Comparator.comparing((TraitObject t) -> t.getFormat().toLowerCase())
+                        .thenComparing(t -> {
+                            t.getAlias();
+                            String name = !t.getAlias().isEmpty() ? t.getAlias() : t.getName();
+                            return name.toLowerCase();
+                        }));
+            } else if ("internal_id_observation_variable".equals(sortColumn)) {
+                filtered.sort(Comparator.comparingInt(t -> {
+                    try {
+                        return Integer.parseInt(t.getId());
+                    } catch (NumberFormatException e) {
+                        return Integer.MAX_VALUE;
+                    }
+                }));
+            }
+        }
+
+        return filtered;
 
     }
 
@@ -694,10 +803,58 @@ public class DataHelper {
 
         List<FieldObject.TraitDetail> traitDetails = getTraitDetailsForStudy(studyId);
 
+        // Filter trait details based on group visibility
+        traitDetails = filterTraitDetailsByGroupVisibility(studyId, traitDetails);
+
         return StudyDao.Companion.getFieldObject(
                 studyId,
                 traitDetails
         );
+    }
+
+    /**
+     * Filters trait details to only include traits that are visible for the given study/field group.
+     * If the field has never been customized, all traits are included.
+     */
+    private List<FieldObject.TraitDetail> filterTraitDetailsByGroupVisibility(Integer studyId, List<FieldObject.TraitDetail> traitDetails) {
+        if (studyId == null || studyId < 0 || traitDetails == null || traitDetails.isEmpty()) {
+            return traitDetails;
+        }
+
+        // If the field has never been customized, return all traits
+        if (!fieldTraitConfigDao.hasFieldTraitConfig(studyId)) {
+            return traitDetails;
+        }
+
+        // Get the visible trait IDs for this field in their custom order
+        List<String> visibleTraitIds = new ArrayList<>();
+        Set<String> customVisibleIds = TraitScopePreferences.getStudyVisibleTraitIds(preferences, studyId);
+        if (customVisibleIds != null) {
+            visibleTraitIds.addAll(customVisibleIds);
+        } else {
+            for (TraitObject trait : ObservationVariableDao.Companion.getAllTraitObjects()) {
+                if (trait.getVisible()) {
+                    visibleTraitIds.add(trait.getId());
+                }
+            }
+        }
+
+        // Map trait details by their ID for quick lookup and ordering
+        java.util.Map<String, FieldObject.TraitDetail> detailMap = new java.util.HashMap<>();
+        for (FieldObject.TraitDetail detail : traitDetails) {
+            detailMap.put(String.valueOf(detail.getTraitId()), detail);
+        }
+
+        // Create the filtered and ordered list based on visibleTraitIds
+        List<FieldObject.TraitDetail> filtered = new ArrayList<>();
+        for (String traitId : visibleTraitIds) {
+            FieldObject.TraitDetail detail = detailMap.get(traitId);
+            if (detail != null) {
+                filtered.add(detail);
+            }
+        }
+
+        return filtered;
     }
 
     public List<FieldObject.TraitDetail> getTraitDetailsForStudy(Integer studyId) {
@@ -1779,6 +1936,11 @@ public class DataHelper {
             if (oldVersion <= 20 && newVersion >= 21) {
 
                 Migrator.Companion.migrateToVersion21(db);
+            }
+
+            if (oldVersion <= 21 && newVersion >= 22) {
+
+                Migrator.Companion.migrateToVersion22(db);
             }
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/database/DbConstants.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/DbConstants.kt
@@ -83,3 +83,13 @@ object ObservationVariableAttributeDetailsView {
     const val ATTACH_AUDIO = "attachAudio"
     const val ALLOW_OTHER = "allowOther"
 }
+
+object FieldTraitConfigTable {
+    const val TABLE_NAME = "field_trait_config"
+    const val ID = "id"
+    const val STUDY_ID = "study_id"
+    const val TRAIT_IDS = "trait_ids"
+    const val CREATED_AT = "created_at"
+    const val UPDATED_AT = "updated_at"
+    const val FK = "field_trait_config_id"
+}

--- a/app/src/main/java/com/fieldbook/tracker/database/Migrator.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/Migrator.kt
@@ -16,6 +16,7 @@ import com.fieldbook.tracker.database.migrators.MulticatToCategoricalVersion20
 import com.fieldbook.tracker.database.migrators.SpectralMigratorVersion16
 import com.fieldbook.tracker.database.migrators.TraitAliasSynonymVersion18
 import com.fieldbook.tracker.database.migrators.StudyConfigurationVersion17
+import com.fieldbook.tracker.database.migrators.FieldTraitConfigMigratorVersion22
 import com.fieldbook.tracker.objects.TraitObject
 
 /**
@@ -472,6 +473,17 @@ class Migrator {
                 }
                 .onSuccess {
                     Log.d(TAG, "Migrated to version 21")
+                }
+        }
+
+        fun migrateToVersion22(db: SQLiteDatabase) {
+
+            FieldTraitConfigMigratorVersion22().migrate(db)
+                .onFailure {
+                    Log.e(TAG, "Failed to migrate to version 22", it)
+                }
+                .onSuccess {
+                    Log.d(TAG, "Migrated to version 22")
                 }
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/FieldTraitConfigDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/FieldTraitConfigDao.kt
@@ -1,0 +1,149 @@
+package com.fieldbook.tracker.database.dao
+
+import android.util.Log
+import androidx.core.content.contentValuesOf
+import com.fieldbook.tracker.database.FieldTraitConfigTable
+import com.fieldbook.tracker.database.withDatabase
+import com.fieldbook.tracker.database.query
+
+/**
+ * DAO for managing field-specific trait configurations (visibility and ordering).
+ *
+ * Each field (study) can have a FieldTraitConfig row that stores:
+ * - trait_ids: comma-separated trait IDs that are visible in this field, in the desired order
+ */
+class FieldTraitConfigDao {
+
+    companion object {
+        private const val TAG = "FieldTraitConfigDao"
+    }
+
+    /**
+     * Get the field-specific trait configuration for a study.
+     * Returns null if the field has never been customized.
+     */
+    fun getFieldTraitConfig(studyId: Int): FieldTraitConfig? = withDatabase { db ->
+        if (studyId < 0) return@withDatabase null
+
+        db.query(
+            FieldTraitConfigTable.TABLE_NAME,
+            select = arrayOf(
+                FieldTraitConfigTable.ID,
+                FieldTraitConfigTable.TRAIT_IDS
+            ),
+            where = "${FieldTraitConfigTable.STUDY_ID} = ?",
+            whereArgs = arrayOf(studyId.toString())
+        ).use { cursor ->
+            if (cursor.moveToFirst()) {
+                val id = cursor.getInt(cursor.getColumnIndexOrThrow(FieldTraitConfigTable.ID))
+                val traitIds = cursor.getString(cursor.getColumnIndexOrThrow(FieldTraitConfigTable.TRAIT_IDS)) ?: ""
+                FieldTraitConfig(id, studyId, traitIds)
+            } else {
+                null
+            }
+        }
+    }
+
+    /**
+     * Check if a field has been customized (has any trait configuration).
+     * Returns true only if a config row exists for this study.
+     */
+    fun hasFieldTraitConfig(studyId: Int): Boolean {
+        if (studyId < 0) return false
+        return getFieldTraitConfig(studyId) != null
+    }
+
+    /**
+     * Get the trait IDs for a field in their custom order.
+     * Returns empty list if field has no custom configuration.
+     */
+    fun getTraitIdsInOrder(studyId: Int): List<String> {
+        val config = getFieldTraitConfig(studyId) ?: return emptyList()
+        return config.getTraitIds()
+    }
+
+    /**
+     * Initialize or update field trait configuration.
+     * This creates the row if it doesn't exist, or updates it if it does.
+     */
+    fun setTraitConfiguration(studyId: Int, traitIdsInOrder: List<String>) {
+        if (studyId < 0) {
+            return
+        }
+
+        val traitIdsStr = traitIdsInOrder.joinToString(",")
+
+        Log.d(TAG, "setTraitConfiguration: studyId=$studyId, ${traitIdsInOrder.size} traits in order")
+
+        withDatabase { db ->
+            val values = contentValuesOf(
+                FieldTraitConfigTable.STUDY_ID to studyId,
+                FieldTraitConfigTable.TRAIT_IDS to traitIdsStr,
+                FieldTraitConfigTable.UPDATED_AT to System.currentTimeMillis().toString()
+            )
+
+            // Try to update first, if no rows affected, insert
+            val updated = db.update(
+                FieldTraitConfigTable.TABLE_NAME,
+                values,
+                "${FieldTraitConfigTable.STUDY_ID} = ?",
+                arrayOf(studyId.toString())
+            )
+
+            if (updated == 0) {
+                // If no existing row, insert a new one
+                values.put(FieldTraitConfigTable.CREATED_AT, System.currentTimeMillis().toString())
+                db.insert(FieldTraitConfigTable.TABLE_NAME, null, values)
+            }
+        }
+    }
+
+    /**
+     * Delete the field trait configuration for a study.
+     * This resets the field to use global defaults.
+     */
+    fun deleteFieldTraitConfig(studyId: Int) {
+        if (studyId < 0) return
+
+        withDatabase { db ->
+            val deleted = db.delete(
+                FieldTraitConfigTable.TABLE_NAME,
+                "${FieldTraitConfigTable.STUDY_ID} = ?",
+                arrayOf(studyId.toString())
+            )
+            Log.d(TAG, "deleteFieldTraitConfig: deleted $deleted row(s) for studyId=$studyId")
+        }
+    }
+
+    /**
+     * Clear all field trait configurations (used during reset/cleanup).
+     */
+    fun deleteAllConfigs() {
+        withDatabase { db ->
+            val deleted = db.delete(FieldTraitConfigTable.TABLE_NAME, null, null)
+            Log.d(TAG, "deleteAllConfigs: deleted $deleted row(s)")
+        }
+    }
+}
+
+/**
+ * Data class representing a field's trait configuration.
+ */
+data class FieldTraitConfig(
+    val id: Int,
+    val studyId: Int,
+    val traitIds: String  // comma-separated visible trait IDs in order
+) {
+    fun getTraitIds(): List<String> = traitIds.parseIds()
+}
+
+/**
+ * Parse comma-separated list of IDs, filtering out empty strings.
+ */
+internal fun String.parseIds(): List<String> {
+    return if (isBlank()) {
+        emptyList()
+    } else {
+        split(",").filter { it.isNotBlank() }
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/StudyDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/StudyDao.kt
@@ -339,7 +339,7 @@ class StudyDao {
                 val traitDetails = mutableListOf<FieldObject.TraitDetail>()
 
                 val cursor = db.rawQuery("""
-                    SELECT ov.observation_variable_name, ov.observation_variable_field_book_format, COUNT(*) as count, GROUP_CONCAT(o.value, '|') as observations,
+                    SELECT ov.internal_id_observation_variable, ov.observation_variable_name, ov.observation_variable_field_book_format, COUNT(*) as count, GROUP_CONCAT(o.value, '|') as observations,
                     COUNT(DISTINCT observation_unit_id) AS distinct_obs_units,
                     (SELECT COUNT(*) FROM observation_units WHERE study_id = ?) AS total_obs_units,
                     (SELECT v.observation_variable_attribute_value 
@@ -355,6 +355,7 @@ class StudyDao {
 
                 if (cursor.moveToFirst()) {
                     do {
+                        val traitId = cursor.getString(cursor.getColumnIndexOrThrow("internal_id_observation_variable"))
                         val traitName = cursor.getString(cursor.getColumnIndexOrThrow("observation_variable_name"))
                         val format = cursor.getString(cursor.getColumnIndexOrThrow("observation_variable_field_book_format"))
                         val count = cursor.getInt(cursor.getColumnIndexOrThrow("count"))
@@ -373,7 +374,7 @@ class StudyDao {
                         val completeness = distinctObsUnits.toFloat() / totalObsUnits.toFloat()
                         val categories = cursor.getString(cursor.getColumnIndexOrThrow("categories"))
 
-                        traitDetails.add(FieldObject.TraitDetail(traitName, format, categories, count, observations, completeness))
+                        traitDetails.add(FieldObject.TraitDetail(traitId, traitName, format, categories, count, observations, completeness))
                     } while (cursor.moveToNext())
                 }
 

--- a/app/src/main/java/com/fieldbook/tracker/database/migrators/FieldTraitConfigMigratorVersion22.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/migrators/FieldTraitConfigMigratorVersion22.kt
@@ -1,0 +1,48 @@
+package com.fieldbook.tracker.database.migrators
+
+import android.database.sqlite.SQLiteDatabase
+import android.util.Log
+import com.fieldbook.tracker.database.FieldTraitConfigTable
+import com.fieldbook.tracker.database.Migrator
+
+/**
+ * New field trait config table for organizing trait lists per field.
+ */
+class FieldTraitConfigMigratorVersion22 : FieldBookMigrator {
+
+    companion object {
+        private const val TAG = "FieldTraitConfigMigratorVersion22"
+        const val VERSION = 22
+    }
+
+    override fun migrate(db: SQLiteDatabase): Result<Any> = runCatching {
+
+        Log.d(TAG, "Starting migration to version 22 - Adding field_trait_config table")
+
+        createFieldTraitConfigTable(db)
+
+        createIndexes(db)
+
+        Log.d(TAG, "Completed migration to version 22")
+
+    }
+
+    private fun createFieldTraitConfigTable(db: SQLiteDatabase) {
+        val query = ("""
+            CREATE TABLE IF NOT EXISTS ${FieldTraitConfigTable.TABLE_NAME} (
+                ${FieldTraitConfigTable.ID} INTEGER PRIMARY KEY AUTOINCREMENT,
+                ${FieldTraitConfigTable.STUDY_ID} INTEGER NOT NULL UNIQUE,
+                ${FieldTraitConfigTable.TRAIT_IDS} TEXT,
+                ${FieldTraitConfigTable.CREATED_AT} TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                ${FieldTraitConfigTable.UPDATED_AT} TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY(${FieldTraitConfigTable.STUDY_ID}) REFERENCES ${Migrator.Study.tableName}(${Migrator.Study.PK}) ON DELETE CASCADE
+            )
+        """).trimIndent()
+
+        db.execSQL(query)
+    }
+
+    private fun createIndexes(db: SQLiteDatabase) {
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS idx_field_trait_config_study_id ON ${FieldTraitConfigTable.TABLE_NAME}(${FieldTraitConfigTable.STUDY_ID})")
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/database/repository/TraitRepository.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/repository/TraitRepository.kt
@@ -9,6 +9,7 @@ import com.fieldbook.tracker.R
 import com.fieldbook.tracker.application.IoDispatcher
 import com.fieldbook.tracker.database.DataHelper
 import com.fieldbook.tracker.database.dao.FieldTraitConfigDao
+import com.fieldbook.tracker.database.dao.ObservationVariableDao
 import com.fieldbook.tracker.database.models.ObservationModel
 import com.fieldbook.tracker.enums.FileFormat
 import com.fieldbook.tracker.objects.TraitImportFile
@@ -93,9 +94,12 @@ class TraitRepository @Inject constructor(
                     trait.clone().apply { visible = id in scopedVisibleIds }
                 }
 
-            // For field-specific lists, prefer the field-specific trait order when one exists.
-            // Fall back to the Editor screen's current order when no field order is set.
-            if (sortOrder == "position") {
+            if (sortOrder == "field_default") {
+                val globalSort = prefs.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position") ?: "position"
+                val globallySorted = ObservationVariableDao.getAllTraitObjects(globalSort)
+                val idToGlobalIndex = globallySorted.mapIndexed { idx, t -> t.id to idx }.toMap()
+                filtered = filtered.sortedWith(compareBy { idToGlobalIndex[it.id] ?: Int.MAX_VALUE })
+            } else if (sortOrder == "position") {
                 val fieldOrder = if (hasFieldConfig) fieldTraitConfigDao.getTraitIdsInOrder(studyId) else emptyList()
                 if (fieldOrder.isNotEmpty()) {
                     val orderMap = fieldOrder.mapIndexed { index, id -> id to index }.toMap()

--- a/app/src/main/java/com/fieldbook/tracker/database/repository/TraitRepository.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/repository/TraitRepository.kt
@@ -8,13 +8,14 @@ import androidx.core.content.edit
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.application.IoDispatcher
 import com.fieldbook.tracker.database.DataHelper
+import com.fieldbook.tracker.database.dao.FieldTraitConfigDao
 import com.fieldbook.tracker.database.models.ObservationModel
-import com.fieldbook.tracker.database.models.TraitAttributes
 import com.fieldbook.tracker.enums.FileFormat
 import com.fieldbook.tracker.objects.TraitImportFile
 import com.fieldbook.tracker.objects.TraitObject
 import com.fieldbook.tracker.objects.toTraitJson
 import com.fieldbook.tracker.preferences.GeneralKeys
+import com.fieldbook.tracker.preferences.TraitScopePreferences
 import com.fieldbook.tracker.utilities.CSVReader
 import com.fieldbook.tracker.utilities.FileUtil
 import com.fieldbook.tracker.utilities.FileUtils.copyToDirectory
@@ -25,7 +26,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonPrimitive
 import org.phenoapps.utils.BaseDocumentTreeUtil
 import java.io.InputStreamReader
 import java.util.ArrayList
@@ -47,12 +47,230 @@ class TraitRepository @Inject constructor(
         prettyPrint = false
     }
 
+    private val fieldTraitConfigDao = FieldTraitConfigDao()
+
     val valueFormatter: ValueProcessorFormatAdapter
         get() = database.valueFormatter
 
-    suspend fun getTraits(): List<TraitObject> = withContext(ioDispatcher) {
+    suspend fun getTraits(
+        studyId: Int? = null,
+        usePerFieldList: Boolean = false,
+        sortOrder: String = "position",
+    ): List<TraitObject> =
+        withContext(ioDispatcher) {
+            val allTraits = database.getAllTraitObjects()
+
+            if (!usePerFieldList || studyId == null || studyId < 0) {
+                return@withContext allTraits
+            }
+
+            // Ensure field-specific configuration is initialized on first access
+            ensureStudyVisibilityInitialized(studyId)
+
+            val scopedIds = TraitScopePreferences.getOrInitializeStudyTraitIds(
+                preferences = prefs,
+                studyId = studyId,
+                fallbackTraitIds = allTraits.map { it.id }.toSet(),
+            )
+
+            // Since we ensured initialization above, hasFieldConfig should be true
+            // if the study is valid.
+            val hasFieldConfig = fieldTraitConfigDao.hasFieldTraitConfig(studyId)
+            
+            // Per-field visibility is stored in preferences
+            val customVisibleIds = TraitScopePreferences.getStudyVisibleTraitIds(prefs, studyId)
+            
+            val scopedVisibleIds: Set<String> = if (customVisibleIds != null) {
+                customVisibleIds.intersect(scopedIds)
+            } else {
+                allTraits.filter { it.visible && it.id in scopedIds }.map { it.id }.toSet()
+            }
+
+            Log.d(TAG, "getTraits: studyId=$studyId hasFieldConfig=$hasFieldConfig scopedVisibleCount=${scopedVisibleIds.size}")
+
+            var filtered = allTraits
+                .filter { it.id in scopedIds }
+                .map { trait ->
+                    trait.clone().apply { visible = id in scopedVisibleIds }
+                }
+
+            // For field-specific lists, prefer the field-specific trait order when one exists.
+            // Fall back to observation_variables position (global order) when no field order is set.
+            if (sortOrder == "position") {
+                val fieldOrder = if (hasFieldConfig) fieldTraitConfigDao.getTraitIdsInOrder(studyId) else emptyList()
+                filtered = if (fieldOrder.isNotEmpty()) {
+                    val orderMap = fieldOrder.mapIndexed { index, id -> id to index }.toMap()
+                    filtered.sortedWith(compareBy { orderMap[it.id] ?: Int.MAX_VALUE })
+                } else {
+                    filtered.sortedWith(
+                        compareBy<TraitObject> { it.realPosition }
+                            .thenBy { it.id.toIntOrNull() ?: Int.MAX_VALUE }
+                    )
+                }
+            } else if (sortOrder == "visible") {
+                // Keep visible traits at the top when sorting by visibility.
+                filtered = filtered.sortedWith(
+                    compareByDescending<TraitObject> { it.visible }
+                        .thenBy { it.alias.ifBlank { it.name }.lowercase() }
+                )
+            } else if (sortOrder == "observation_variable_name") {
+                filtered = filtered.sortedBy { it.alias.ifBlank { it.name }.lowercase() }
+            } else if (sortOrder == "observation_variable_field_book_format") {
+                filtered = filtered.sortedWith(
+                    compareBy<TraitObject> { it.format.lowercase() }
+                        .thenBy { it.alias.ifBlank { it.name }.lowercase() }
+                )
+            } else if (sortOrder == "internal_id_observation_variable") {
+                filtered = filtered.sortedWith(
+                    compareBy<TraitObject> { it.id.toIntOrNull() ?: Int.MAX_VALUE }
+                        .thenBy { it.alias.ifBlank { it.name }.lowercase() }
+                )
+            }
+
+            filtered
+        }
+
+    suspend fun getUnscopedTraits(): List<TraitObject> = withContext(ioDispatcher) {
         database.getAllTraitObjects()
     }
+
+    suspend fun addTraitsToStudy(studyId: Int, traitIds: Set<String>) = withContext(ioDispatcher) {
+        TraitScopePreferences.addStudyTraitIds(prefs, studyId, traitIds)
+        // Ensure field is initialized before adding new traits as visible
+        ensureStudyVisibilityInitialized(studyId)
+
+        val allTraitsInGlobalOrder = database.getAllTraitObjects()
+        val orderedNewIds = allTraitsInGlobalOrder
+            .map { it.id }
+            .filter { it in traitIds }
+
+        // Update ordering
+        val currentOrder = fieldTraitConfigDao.getTraitIdsInOrder(studyId).toMutableList()
+        orderedNewIds.forEach { newId ->
+            if (newId !in currentOrder) currentOrder.add(newId)
+        }
+        fieldTraitConfigDao.setTraitConfiguration(studyId, currentOrder)
+
+        // Update visibility (default to visible for new additions)
+        val currentVisible = TraitScopePreferences.getStudyVisibleTraitIds(prefs, studyId)?.toMutableSet()
+            ?: allTraitsInGlobalOrder.filter { it.visible }.map { it.id }.toSet().toMutableSet()
+        currentVisible.addAll(traitIds)
+        TraitScopePreferences.setStudyVisibleTraitIds(prefs, studyId, currentVisible)
+    }
+
+    suspend fun removeTraitsFromStudy(studyId: Int, traitIds: Set<String>) = withContext(ioDispatcher) {
+        if (studyId < 0 || traitIds.isEmpty()) return@withContext
+
+        val allTraitIds = database.getAllTraitObjects().map { it.id }.toSet()
+        val currentScoped = TraitScopePreferences.getOrInitializeStudyTraitIds(
+            preferences = prefs,
+            studyId = studyId,
+            fallbackTraitIds = allTraitIds,
+        )
+
+        val updatedScoped = currentScoped - traitIds
+        TraitScopePreferences.setStudyTraitIds(prefs, studyId, updatedScoped)
+
+        ensureStudyVisibilityInitialized(studyId)
+        
+        // Update ordering
+        val updatedOrder = fieldTraitConfigDao.getTraitIdsInOrder(studyId).filterNot { it in traitIds }
+        fieldTraitConfigDao.setTraitConfiguration(studyId, updatedOrder)
+
+        // Update visibility
+        TraitScopePreferences.getStudyVisibleTraitIds(prefs, studyId)?.let { currentVisible ->
+            val updatedVisible = currentVisible - traitIds
+            TraitScopePreferences.setStudyVisibleTraitIds(prefs, studyId, updatedVisible)
+        }
+    }
+
+    suspend fun syncStudyWithMainList(studyId: Int) = withContext(ioDispatcher) {
+        if (studyId < 0) return@withContext
+
+        val allTraitsInGlobalOrder = database.getAllTraitObjects()
+        val allIds = allTraitsInGlobalOrder.map { it.id }
+        val globalVisible = allTraitsInGlobalOrder.filter { it.visible }.map { it.id }.toSet()
+
+        TraitScopePreferences.setStudyTraitIds(prefs, studyId, allIds.toSet())
+        TraitScopePreferences.setStudyVisibleTraitIds(prefs, studyId, globalVisible)
+
+        fieldTraitConfigDao.setTraitConfiguration(
+            studyId = studyId,
+            traitIdsInOrder = allIds,
+        )
+    }
+
+    /**
+     * Ensures that the field-specific trait configuration is initialized.
+     * Creates config based on the current global visibility state if not already done.
+     * This is a no-op if the field already has a custom configuration.
+     */
+    private fun ensureStudyVisibilityInitialized(studyId: Int) {
+        if (studyId < 0) return
+        if (fieldTraitConfigDao.hasFieldTraitConfig(studyId)) return
+
+        val allTraitsInGlobalOrder = database.getAllTraitObjects()
+        val fallbackIds = allTraitsInGlobalOrder.map { it.id }.toSet()
+        val scopedIds = TraitScopePreferences.getOrInitializeStudyTraitIds(
+            preferences = prefs,
+            studyId = studyId,
+            fallbackTraitIds = fallbackIds,
+        )
+        
+        // Initialize order with ALL scoped traits
+        val scopedOrder = allTraitsInGlobalOrder
+            .filter { it.id in scopedIds }
+            .map { it.id }
+
+        Log.d(TAG, "ensureStudyVisibilityInitialized: initializing studyId=$studyId with ${scopedOrder.size} scoped traits in order")
+        fieldTraitConfigDao.setTraitConfiguration(
+            studyId = studyId,
+            traitIdsInOrder = scopedOrder,
+        )
+
+        // Initialize visibility if not already present
+        if (TraitScopePreferences.getStudyVisibleTraitIds(prefs, studyId) == null) {
+            val scopedVisibleIds = allTraitsInGlobalOrder
+                .filter { it.visible && it.id in scopedIds }
+                .map { it.id }
+                .toSet()
+            TraitScopePreferences.setStudyVisibleTraitIds(prefs, studyId, scopedVisibleIds)
+        }
+    }
+
+    suspend fun updateStudyTraitVisibility(studyId: Int, traitId: String, isVisible: Boolean) =
+        withContext(ioDispatcher) {
+            // Initialize field-specific visibility on first edit (lazy initialization)
+            ensureStudyVisibilityInitialized(studyId)
+            
+            val currentVisible = TraitScopePreferences.getStudyVisibleTraitIds(prefs, studyId)?.toMutableSet()
+                ?: mutableSetOf()
+
+            if (isVisible) {
+                currentVisible.add(traitId)
+            } else {
+                currentVisible.remove(traitId)
+            }
+            
+            TraitScopePreferences.setStudyVisibleTraitIds(prefs, studyId, currentVisible)
+        }
+
+    suspend fun updateAllStudyTraitVisibility(studyId: Int, traitIds: Set<String>, isVisible: Boolean) =
+        withContext(ioDispatcher) {
+            // Initialize field-specific visibility on first edit (lazy initialization)
+            ensureStudyVisibilityInitialized(studyId)
+
+            val currentVisible = TraitScopePreferences.getStudyVisibleTraitIds(prefs, studyId)?.toMutableSet()
+                ?: mutableSetOf()
+
+            if (isVisible) {
+                currentVisible.addAll(traitIds)
+            } else {
+                currentVisible.removeAll(traitIds)
+            }
+
+            TraitScopePreferences.setStudyVisibleTraitIds(prefs, studyId, currentVisible)
+        }
 
     suspend fun getTraitById(id: String): TraitObject? = withContext(ioDispatcher) {
         database.getTraitById(id)
@@ -77,7 +295,7 @@ class TraitRepository @Inject constructor(
         // clear crop coordinates
         prefs.edit {
             traits.forEach { trait ->
-                remove(GeneralKeys.getCropCoordinatesKey(trait.id.toInt()))
+                remove(GeneralKeys.getCropCoordinatesKey(trait.id))
             }
         }
     }
@@ -87,7 +305,7 @@ class TraitRepository @Inject constructor(
 
         // clear crop coordinates
         prefs.edit {
-            remove(GeneralKeys.getCropCoordinatesKey(traitId.toInt()))
+            remove(GeneralKeys.getCropCoordinatesKey(traitId))
         }
     }
 
@@ -118,6 +336,27 @@ class TraitRepository @Inject constructor(
             database.updateTraitPosition(trait.id, index + 1)
         }
     }
+
+    /**
+     * Update field-specific trait order. This creates a field-specific trait list
+     * in the field_trait_config table to remember the custom ordering for this field.
+     */
+    suspend fun updateStudyTraitOrder(studyId: Int, orderedTraitIds: List<String>) =
+        withContext(ioDispatcher) {
+            ensureStudyVisibilityInitialized(studyId)
+            fieldTraitConfigDao.setTraitConfiguration(
+                studyId = studyId,
+                traitIdsInOrder = orderedTraitIds,
+            )
+        }
+
+    /**
+     * Check if a field has a custom trait list (field-specific ordering)
+     */
+    suspend fun hasFieldSpecificTraitList(studyId: Int): Boolean =
+        withContext(ioDispatcher) {
+            fieldTraitConfigDao.getTraitIdsInOrder(studyId).isNotEmpty()
+        }
 
     // returns -1 if insertion failed, else returns rowId if successful
     suspend fun insertTrait(trait: TraitObject): Long = withContext(ioDispatcher) {

--- a/app/src/main/java/com/fieldbook/tracker/database/repository/TraitRepository.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/repository/TraitRepository.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import org.phenoapps.utils.BaseDocumentTreeUtil
 import java.io.InputStreamReader
-import java.util.ArrayList
 import java.util.UUID
 import javax.inject.Inject
 
@@ -95,18 +94,15 @@ class TraitRepository @Inject constructor(
                 }
 
             // For field-specific lists, prefer the field-specific trait order when one exists.
-            // Fall back to observation_variables position (global order) when no field order is set.
+            // Fall back to the Editor screen's current order when no field order is set.
             if (sortOrder == "position") {
                 val fieldOrder = if (hasFieldConfig) fieldTraitConfigDao.getTraitIdsInOrder(studyId) else emptyList()
-                filtered = if (fieldOrder.isNotEmpty()) {
+                if (fieldOrder.isNotEmpty()) {
                     val orderMap = fieldOrder.mapIndexed { index, id -> id to index }.toMap()
-                    filtered.sortedWith(compareBy { orderMap[it.id] ?: Int.MAX_VALUE })
-                } else {
-                    filtered.sortedWith(
-                        compareBy<TraitObject> { it.realPosition }
-                            .thenBy { it.id.toIntOrNull() ?: Int.MAX_VALUE }
-                    )
+                    filtered = filtered.sortedWith(compareBy { orderMap[it.id] ?: Int.MAX_VALUE })
                 }
+                // If fieldOrder is empty, we keep the order of 'filtered', which matches 'allTraits'.
+                // 'allTraits' is already sorted according to the Editor's current sort preference.
             } else if (sortOrder == "visible") {
                 // Keep visible traits at the top when sorting by visibility.
                 filtered = filtered.sortedWith(

--- a/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitEditorViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitEditorViewModel.kt
@@ -8,10 +8,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.activities.CollectActivity
+import com.fieldbook.tracker.database.repository.TraitRepository
 import com.fieldbook.tracker.objects.TraitObject
 import com.fieldbook.tracker.preferences.GeneralKeys
 import com.fieldbook.tracker.preferences.PreferenceKeys
-import com.fieldbook.tracker.database.repository.TraitRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -91,7 +91,10 @@ class TraitEditorViewModel @Inject constructor(
         }
         _uiState.update { it.copy(sortOrder = sortOrder) }
 
-        loadTraits(showLoading = false)
+        viewModelScope.launch {
+            loadTraitsInternal(showLoading = false)
+            _events.emit(TraitEditorEvent.ScrollToTop)
+        }
     }
 
     // IN-MEMORY UPDATES (does not fetch from db)
@@ -161,35 +164,40 @@ class TraitEditorViewModel @Inject constructor(
 
     // DB RELATED
 
-    fun loadTraits(showLoading: Boolean = true) {
+    private suspend fun loadTraitsInternal(showLoading: Boolean = true) {
         if (!isScopeConfigured) return
 
+        if (showLoading) {
+            _uiState.update { it.copy(isLoading = true) }
+        }
+
+        runCatching {
+            repo.getTraits(
+                studyId = scopedStudyId,
+                usePerFieldList = usePerFieldTraitList,
+                sortOrder = if (_uiState.value.sortOrder == "position")
+                    prefs.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position") ?: "position"
+                else _uiState.value.sortOrder
+            )
+        }
+            .onSuccess { traits ->
+                _uiState.update {
+                    it.copy(traits = traits, isLoading = false)
+                }
+                lastCommittedSortedTraitIds = traits.map { it.id }
+            }
+            .onFailure { e ->
+                _uiState.update {
+                    it.copy(isLoading = false)
+                }
+                Log.e(TAG, "Error loading traits", e)
+                _events.emit(TraitEditorEvent.ShowToast(R.string.error_loading_traits))
+            }
+    }
+
+    fun loadTraits(showLoading: Boolean = true) {
         viewModelScope.launch {
-            if (showLoading) {
-                _uiState.update { it.copy(isLoading = true) }
-            }
-
-            runCatching {
-                repo.getTraits(
-                    studyId = scopedStudyId,
-                    usePerFieldList = usePerFieldTraitList,
-                    sortOrder = _uiState.value.sortOrder,
-                )
-            }
-                .onSuccess { traits ->
-                    _uiState.update {
-                        it.copy(traits = traits, isLoading = false)
-                    }
-                    lastCommittedSortedTraitIds = traits.map { it.id }
-
-                }
-                .onFailure { e ->
-                    _uiState.update {
-                        it.copy(isLoading = false)
-                    }
-                    Log.e(TAG, "Error loading traits", e)
-                    _events.emit(TraitEditorEvent.ShowToast(R.string.error_loading_traits))
-                }
+            loadTraitsInternal(showLoading)
         }
     }
 
@@ -215,7 +223,10 @@ class TraitEditorViewModel @Inject constructor(
         }
         _uiState.update { it.copy(sortOrder = sortOrder) }
 
-        loadTraits(showLoading = false)
+        viewModelScope.launch {
+            loadTraitsInternal(showLoading = false)
+            _events.emit(TraitEditorEvent.ScrollToTop)
+        }
     }
 
     fun loadAvailableTraitsForCurrentStudy() {
@@ -744,6 +755,7 @@ sealed class TraitEditorEvent {
     data class RequestStoragePermissionForExport(val source: DialogTriggerSource) : TraitEditorEvent()
     object OpenFileExplorer : TraitEditorEvent()
     object OpenCloudFilePicker : TraitEditorEvent()
+    object ScrollToTop : TraitEditorEvent()
 }
 
 // only one dialog can be active at a time

--- a/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitEditorViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitEditorViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.activities.CollectActivity
 import com.fieldbook.tracker.database.repository.TraitRepository
+import com.fieldbook.tracker.database.viewmodels.TraitEditorViewModel.Companion.SORT_FIELD_DEFAULT
 import com.fieldbook.tracker.objects.TraitObject
 import com.fieldbook.tracker.preferences.GeneralKeys
 import com.fieldbook.tracker.preferences.PreferenceKeys
@@ -42,6 +43,9 @@ class TraitEditorViewModel @Inject constructor(
     companion object {
         private const val TAG = "TraitEditorViewModel"
         private const val FIELD_TRAIT_SORT_ORDER_PREFIX = "field_trait_sort_order_"
+
+        /** Sort key meaning "follow the main editor's global sort preference" (viewer-only). */
+        const val SORT_FIELD_DEFAULT = "field_default"
     }
 
     private val _uiState = MutableStateFlow(TraitEditorUiState())
@@ -80,6 +84,24 @@ class TraitEditorViewModel @Inject constructor(
         prefs.getString(PreferenceKeys.BRAPI_DISPLAY_NAME, default) ?: default
 
     fun previouslyExported() = prefs.getBoolean(GeneralKeys.TRAITS_EXPORTED, false)
+
+    /**
+     * Resolves the effective sort-order to pass to the repository.
+     *
+     * In viewer mode the preference lives under a field-specific key; otherwise the global key.
+     * The special key [SORT_FIELD_DEFAULT] is passed through to the repo, which will
+     * apply the global sort preference to the scoped traits.
+     * "position" in viewer mode means "use the field-specific DB order" (custom reorder).
+     */
+    private fun resolveSortOrder(): String {
+        if (isViewerMode && scopedStudyId != null) {
+            return prefs.getString(
+                "$FIELD_TRAIT_SORT_ORDER_PREFIX${scopedStudyId}",
+                SORT_FIELD_DEFAULT
+            ) ?: SORT_FIELD_DEFAULT
+        }
+        return prefs.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position") ?: "position"
+    }
 
     fun updateSortOrder(sortOrder: String) {
         if (!isViewerMode) {
@@ -175,9 +197,7 @@ class TraitEditorViewModel @Inject constructor(
             repo.getTraits(
                 studyId = scopedStudyId,
                 usePerFieldList = usePerFieldTraitList,
-                sortOrder = if (_uiState.value.sortOrder == "position")
-                    prefs.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position") ?: "position"
-                else _uiState.value.sortOrder
+                sortOrder = resolveSortOrder()
             )
         }
             .onSuccess { traits ->
@@ -216,8 +236,8 @@ class TraitEditorViewModel @Inject constructor(
         val sortOrder = if (isViewerMode && scopedStudyId != null) {
             prefs.getString(
                 "$FIELD_TRAIT_SORT_ORDER_PREFIX${scopedStudyId}",
-                prefs.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position") ?: "position"
-            ) ?: "position"
+                SORT_FIELD_DEFAULT
+            ) ?: SORT_FIELD_DEFAULT
         } else {
             prefs.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position") ?: "position"
         }
@@ -377,7 +397,7 @@ class TraitEditorViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 if (useScopedVisibility) {
-                    repo.updateStudyTraitVisibility(scopedStudy!!, traitId, isVisible)
+                    repo.updateStudyTraitVisibility(scopedStudy, traitId, isVisible)
                     // Create/update field-specific trait list when visibility changes
                     val currentTraits = _uiState.value.traits
                     repo.updateStudyTraitOrder(scopedStudy, currentTraits.map { it.id })
@@ -410,7 +430,7 @@ class TraitEditorViewModel @Inject constructor(
             runCatching {
                 if (useScopedVisibility) {
                     repo.updateAllStudyTraitVisibility(
-                        studyId = scopedStudy!!,
+                        studyId = scopedStudy,
                         traitIds = oldList.map { it.id }.toSet(),
                         isVisible = newVisibility,
                     )
@@ -455,7 +475,7 @@ class TraitEditorViewModel @Inject constructor(
             runCatching {
                 if (useScopedVisibility) {
                     repo.updateAllStudyTraitVisibility(
-                        studyId = scopedStudy!!,
+                        studyId = scopedStudy,
                         traitIds = selectedIds,
                         isVisible = newVisibility,
                     )
@@ -530,6 +550,23 @@ class TraitEditorViewModel @Inject constructor(
      * That is, if previously dragging and currently not dragging anymore
      */
     fun onDragStateChanged(isCurrentlyDragging: Boolean) {
+        // Detect drag start: previously not dragging, now dragging
+        if (!wasPreviouslyDragging && isCurrentlyDragging) {
+            // If a custom sort order is active, reset to default "position" to allow manual reordering
+            if (_uiState.value.sortOrder != "position") {
+                // Update the correct preference key (field-specific in viewer mode, global otherwise)
+                if (isViewerMode) {
+                    scopedStudyId?.let { studyId ->
+                        prefs.edit { putString("$FIELD_TRAIT_SORT_ORDER_PREFIX$studyId", "position") }
+                    }
+                } else {
+                    prefs.edit { putString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position") }
+                }
+                _uiState.update { it.copy(sortOrder = "position") }
+            }
+        }
+
+        // Detect drag end: previously dragging, now stopped
         if (wasPreviouslyDragging && !isCurrentlyDragging) { // drag ended
             commitTraitOrder()
         }
@@ -548,7 +585,7 @@ class TraitEditorViewModel @Inject constructor(
 
                 if (useScopedOrder) {
                     // Create/update field-specific trait list with new order
-                    repo.updateStudyTraitOrder(scopedStudy!!, finalList.map { it.id })
+                    repo.updateStudyTraitOrder(scopedStudy, finalList.map { it.id })
                 } else {
                     // Update global trait positions
                     repo.updateTraitOrder(finalList)

--- a/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitEditorViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitEditorViewModel.kt
@@ -41,6 +41,7 @@ class TraitEditorViewModel @Inject constructor(
 
     companion object {
         private const val TAG = "TraitEditorViewModel"
+        private const val FIELD_TRAIT_SORT_ORDER_PREFIX = "field_trait_sort_order_"
     }
 
     private val _uiState = MutableStateFlow(TraitEditorUiState())
@@ -50,14 +51,17 @@ class TraitEditorViewModel @Inject constructor(
     val events = _events.asSharedFlow()
 
     // to manage db updates on reorder
-    private var lastCommittedSortedList: List<TraitObject> = emptyList()
+    private var lastCommittedSortedTraitIds: List<String> = emptyList()
     private var wasPreviouslyDragging = false
+    private var scopedStudyId: Int? = null
+    private var usePerFieldTraitList: Boolean = false
+    private var isViewerMode: Boolean = false
+    private var isScopeConfigured: Boolean = false
 
     init {
         val sortOrder =
             prefs.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position") ?: "position"
-        _uiState.update { it.copy(sortOrder = sortOrder) }
-        loadTraits()
+        _uiState.update { it.copy(sortOrder = sortOrder, isLoading = true) }
     }
 
     private fun notifyCollectReload() {
@@ -78,10 +82,16 @@ class TraitEditorViewModel @Inject constructor(
     fun previouslyExported() = prefs.getBoolean(GeneralKeys.TRAITS_EXPORTED, false)
 
     fun updateSortOrder(sortOrder: String) {
-        prefs.edit { putString(GeneralKeys.TRAITS_LIST_SORT_ORDER, sortOrder) }
+        if (!isViewerMode) {
+            prefs.edit { putString(GeneralKeys.TRAITS_LIST_SORT_ORDER, sortOrder) }
+        } else {
+            scopedStudyId?.let { studyId ->
+                prefs.edit { putString("$FIELD_TRAIT_SORT_ORDER_PREFIX$studyId", sortOrder) }
+            }
+        }
         _uiState.update { it.copy(sortOrder = sortOrder) }
 
-        loadTraits()
+        loadTraits(showLoading = false)
     }
 
     // IN-MEMORY UPDATES (does not fetch from db)
@@ -89,16 +99,31 @@ class TraitEditorViewModel @Inject constructor(
     fun addTraitObject(newTrait: TraitObject) {
         _uiState.update { state ->
             state.copy(
-                traits = state.traits + newTrait
+                traits = state.traits + newTrait,
+                selectedTraitIds = state.selectedTraitIds - newTrait.id
             )
         }
     }
 
     fun removeTraitObject(id: String) {
+        val newList = _uiState.value.traits.filterNot { it.id == id }
         _uiState.update { state ->
             state.copy(
-                traits = state.traits.filterNot { it.id == id }
+                traits = newList,
+                selectedTraitIds = state.selectedTraitIds - id
             )
+        }
+        lastCommittedSortedTraitIds = newList.map { it.id }
+
+        // Perform background reorder if in global mode to ensure positions are gapless
+        if (!isViewerMode) {
+            viewModelScope.launch {
+                runCatching {
+                    repo.updateTraitOrder(newList)
+                }.onFailure { e ->
+                    Log.e(TAG, "Soft reorder failed after trait deletion", e)
+                }
+            }
         }
     }
 
@@ -112,18 +137,50 @@ class TraitEditorViewModel @Inject constructor(
         }
     }
 
+    fun toggleTraitSelection(id: String) {
+        _uiState.update { state ->
+            val newSelection = if (id in state.selectedTraitIds) {
+                state.selectedTraitIds - id
+            } else {
+                state.selectedTraitIds + id
+            }
+            state.copy(selectedTraitIds = newSelection)
+        }
+    }
+
+    fun clearSelection() {
+        _uiState.update { it.copy(selectedTraitIds = emptySet()) }
+    }
+
+    fun selectAll() {
+        _uiState.update { state ->
+            state.copy(selectedTraitIds = state.traits.map { it.id }.toSet())
+        }
+    }
+
 
     // DB RELATED
 
-    fun loadTraits() {
-        viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true)
+    fun loadTraits(showLoading: Boolean = true) {
+        if (!isScopeConfigured) return
 
-            runCatching { repo.getTraits() }
+        viewModelScope.launch {
+            if (showLoading) {
+                _uiState.update { it.copy(isLoading = true) }
+            }
+
+            runCatching {
+                repo.getTraits(
+                    studyId = scopedStudyId,
+                    usePerFieldList = usePerFieldTraitList,
+                    sortOrder = _uiState.value.sortOrder,
+                )
+            }
                 .onSuccess { traits ->
                     _uiState.update {
                         it.copy(traits = traits, isLoading = false)
                     }
+                    lastCommittedSortedTraitIds = traits.map { it.id }
 
                 }
                 .onFailure { e ->
@@ -133,6 +190,151 @@ class TraitEditorViewModel @Inject constructor(
                     Log.e(TAG, "Error loading traits", e)
                     _events.emit(TraitEditorEvent.ShowToast(R.string.error_loading_traits))
                 }
+        }
+    }
+
+    fun configureTraitScope(studyId: Int?, enablePerFieldScope: Boolean, isViewer: Boolean) {
+        val normalizedStudyId = studyId?.takeIf { it >= 0 }
+        if (scopedStudyId == normalizedStudyId && usePerFieldTraitList == enablePerFieldScope && isViewerMode == isViewer && isScopeConfigured) {
+            return
+        }
+
+        isViewerMode = isViewer
+        scopedStudyId = normalizedStudyId
+        usePerFieldTraitList = enablePerFieldScope
+        isScopeConfigured = true
+
+        // Field-specific list defaults to the same sort mode as the main list.
+        val sortOrder = if (isViewerMode && scopedStudyId != null) {
+            prefs.getString(
+                "$FIELD_TRAIT_SORT_ORDER_PREFIX${scopedStudyId}",
+                prefs.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position") ?: "position"
+            ) ?: "position"
+        } else {
+            prefs.getString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position") ?: "position"
+        }
+        _uiState.update { it.copy(sortOrder = sortOrder) }
+
+        loadTraits(showLoading = false)
+    }
+
+    fun loadAvailableTraitsForCurrentStudy() {
+        scopedStudyId ?: return
+        if (!usePerFieldTraitList) return
+
+        viewModelScope.launch {
+            runCatching {
+                val allTraits = repo.getUnscopedTraits()
+                val currentIds = uiState.value.traits.map { it.id }.toSet()
+                allTraits.filterNot { it.id in currentIds }
+            }.onSuccess { available ->
+                _uiState.update { it.copy(availableTraits = available) }
+            }.onFailure { e ->
+                Log.e(TAG, "Error loading available traits", e)
+                _events.emit(TraitEditorEvent.ShowToast(R.string.error_loading_traits))
+            }
+        }
+    }
+
+    fun addTraitsToCurrentStudy(traitIds: Set<String>) {
+        val currentStudyId = scopedStudyId ?: return
+        if (!usePerFieldTraitList || traitIds.isEmpty()) return
+
+        viewModelScope.launch {
+            runCatching {
+                repo.addTraitsToStudy(currentStudyId, traitIds)
+            }.onSuccess {
+                loadTraits()
+                loadAvailableTraitsForCurrentStudy()
+                _events.emit(
+                    TraitEditorEvent.ShowMessageWithArgs(
+                        R.string.traits_viewer_added_count,
+                        listOf(traitIds.size)
+                    )
+                )
+            }.onFailure { e ->
+                Log.e(TAG, "Error assigning traits to study", e)
+                _events.emit(TraitEditorEvent.ShowToast(R.string.error_importing_traits))
+            }
+        }
+    }
+
+    fun requestRemoveTraitFromCurrentStudy(trait: TraitObject) {
+        val traitName = trait.alias.ifBlank { trait.name }
+        showDialog(TraitActivityDialog.RemoveFromField(setOf(trait.id), traitName))
+    }
+
+    fun requestRemoveSelectedTraitsFromCurrentStudy() {
+        val selectedIds = _uiState.value.selectedTraitIds
+        if (selectedIds.isEmpty()) return
+        
+        val message = if (selectedIds.size == 1) {
+            val trait = _uiState.value.traits.find { it.id == selectedIds.first() }
+            trait?.alias?.ifBlank { trait.name } ?: ""
+        } else {
+            selectedIds.size.toString()
+        }
+        
+        showDialog(TraitActivityDialog.RemoveFromField(selectedIds, message))
+    }
+
+    fun removeTraitFromCurrentStudy(traitIds: Set<String>) {
+        val currentStudyId = scopedStudyId ?: return
+        if (!usePerFieldTraitList || traitIds.isEmpty()) return
+
+        hideDialog()
+
+        val oldList = _uiState.value.traits
+        
+        // Optimistic local removal
+        val newList = _uiState.value.traits.filterNot { it.id in traitIds }
+        _uiState.update { state ->
+            state.copy(
+                traits = newList,
+                selectedTraitIds = state.selectedTraitIds - traitIds
+            )
+        }
+        lastCommittedSortedTraitIds = newList.map { it.id }
+
+        viewModelScope.launch {
+            runCatching {
+                repo.removeTraitsFromStudy(currentStudyId, traitIds)
+            }.onSuccess {
+                loadAvailableTraitsForCurrentStudy()
+                _events.emit(TraitEditorEvent.ShowToast(R.string.traits_viewer_removed_trait))
+            }.onFailure { e ->
+                // Rollback (simplified, just reload quietly)
+                loadTraits(showLoading = false)
+                Log.e(TAG, "Error removing traits from study", e)
+                _events.emit(TraitEditorEvent.ShowToast(R.string.error_updating_trait_visibility))
+            }
+        }
+    }
+
+    private fun rollbackRemovedTrait(trait: TraitObject, index: Int) {
+        _uiState.update { state ->
+            val updated = state.traits.toMutableList()
+            val safeIndex = index.coerceIn(0, updated.size)
+            updated.add(safeIndex, trait)
+            state.copy(traits = updated)
+        }
+    }
+
+    fun syncCurrentStudyWithMainList() {
+        val currentStudyId = scopedStudyId ?: return
+        if (!usePerFieldTraitList) return
+
+        viewModelScope.launch {
+            runCatching {
+                repo.syncStudyWithMainList(currentStudyId)
+            }.onSuccess {
+                loadTraits()
+                loadAvailableTraitsForCurrentStudy()
+                _events.emit(TraitEditorEvent.ShowToast(R.string.traits_viewer_synced_with_main_list))
+            }.onFailure { e ->
+                Log.e(TAG, "Error syncing field trait list with main list", e)
+                _events.emit(TraitEditorEvent.ShowToast(R.string.error_loading_traits))
+            }
         }
     }
 
@@ -155,12 +357,23 @@ class TraitEditorViewModel @Inject constructor(
 
     fun updateTraitVisibility(traitId: String, isVisible: Boolean) {
         val trait = uiState.value.traits.find { it.id == traitId } ?: return
+        val scopedStudy = scopedStudyId
+        val useScopedVisibility = usePerFieldTraitList && scopedStudy != null
 
         val updatedTrait = trait.clone().apply { visible = isVisible }
         updateTraitInList(updatedTrait)
 
         viewModelScope.launch {
-            runCatching { repo.updateVisibility(traitId, isVisible) }
+            runCatching {
+                if (useScopedVisibility) {
+                    repo.updateStudyTraitVisibility(scopedStudy!!, traitId, isVisible)
+                    // Create/update field-specific trait list when visibility changes
+                    val currentTraits = _uiState.value.traits
+                    repo.updateStudyTraitOrder(scopedStudy, currentTraits.map { it.id })
+                } else {
+                    repo.updateVisibility(traitId, isVisible)
+                }
+            }
                 .onSuccess { notifyCollectReload() }
                 .onFailure { e -> // rollback
                     updateTraitInList(trait)
@@ -173,6 +386,8 @@ class TraitEditorViewModel @Inject constructor(
 
     fun toggleAllTraitsVisibility() {
         val oldList = _uiState.value.traits
+        val scopedStudy = scopedStudyId
+        val useScopedVisibility = usePerFieldTraitList && scopedStudy != null
 
         val newVisibility = !oldList.all { it.visible }
 
@@ -182,8 +397,18 @@ class TraitEditorViewModel @Inject constructor(
 
         viewModelScope.launch {
             runCatching {
-                oldList.forEach {
-                    repo.updateVisibility(it.id, newVisibility)
+                if (useScopedVisibility) {
+                    repo.updateAllStudyTraitVisibility(
+                        studyId = scopedStudy!!,
+                        traitIds = oldList.map { it.id }.toSet(),
+                        isVisible = newVisibility,
+                    )
+                    // Create/update field-specific trait list when toggling all
+                    repo.updateStudyTraitOrder(scopedStudy, updatedList.map { it.id })
+                } else {
+                    oldList.forEach {
+                        repo.updateVisibility(it.id, newVisibility)
+                    }
                 }
             }
                 .onSuccess { notifyCollectReload() }
@@ -192,6 +417,54 @@ class TraitEditorViewModel @Inject constructor(
                 Log.e(TAG, "Error toggling visibility for all traits", e)
                 _events.emit(TraitEditorEvent.ShowToast(R.string.error_toggling_all_traits_visibility))
             }
+        }
+    }
+
+    fun toggleVisibilityForSelectedTraits() {
+        val selectedIds = _uiState.value.selectedTraitIds
+        if (selectedIds.isEmpty()) return
+
+        val currentTraits = _uiState.value.traits.filter { it.id in selectedIds }
+        val allVisible = currentTraits.all { it.visible }
+        val newVisibility = !allVisible
+
+        val scopedStudy = scopedStudyId
+        val useScopedVisibility = usePerFieldTraitList && scopedStudy != null
+
+        // Update in-memory state for immediate feedback
+        _uiState.update { state ->
+            val updatedTraits = state.traits.map {
+                if (it.id in selectedIds) it.clone().apply { visible = newVisibility }
+                else it
+            }
+            state.copy(traits = updatedTraits)
+        }
+
+        viewModelScope.launch {
+            runCatching {
+                if (useScopedVisibility) {
+                    repo.updateAllStudyTraitVisibility(
+                        studyId = scopedStudy!!,
+                        traitIds = selectedIds,
+                        isVisible = newVisibility,
+                    )
+                    // Update field order as well if needed (optional, keeping it simple for now)
+                    val updatedTraits = _uiState.value.traits
+                    repo.updateStudyTraitOrder(scopedStudy, updatedTraits.map { it.id })
+                } else {
+                    selectedIds.forEach {
+                        repo.updateVisibility(it, newVisibility)
+                    }
+                }
+            }
+                .onSuccess { 
+                    notifyCollectReload()
+                }
+                .onFailure { e ->
+                    loadTraits() // Rollback by reloading
+                    Log.e(TAG, "Error toggling visibility for selected traits", e)
+                    _events.emit(TraitEditorEvent.ShowToast(R.string.error_toggling_all_traits_visibility))
+                }
         }
     }
 
@@ -254,21 +527,39 @@ class TraitEditorViewModel @Inject constructor(
 
     fun commitTraitOrder() {
         val finalList = _uiState.value.traits
-        if (finalList == lastCommittedSortedList) return
+        val finalIds = finalList.map { it.id }
+        if (finalIds == lastCommittedSortedTraitIds) return
 
         viewModelScope.launch {
             runCatching {
-                repo.updateTraitOrder(finalList)
+                val scopedStudy = scopedStudyId
+                val useScopedOrder = usePerFieldTraitList && scopedStudy != null
+
+                if (useScopedOrder) {
+                    // Create/update field-specific trait list with new order
+                    repo.updateStudyTraitOrder(scopedStudy!!, finalList.map { it.id })
+                } else {
+                    // Update global trait positions
+                    repo.updateTraitOrder(finalList)
+                }
                 notifyCollectReload()
 
-                lastCommittedSortedList = finalList
+                lastCommittedSortedTraitIds = finalIds
 
-                // update pref and state
-                prefs.edit {
-                    putString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position")
+                // Keep global sort preference untouched in field-specific viewer mode.
+                if (!isViewerMode) {
+                    prefs.edit {
+                        putString(GeneralKeys.TRAITS_LIST_SORT_ORDER, "position")
+                    }
+                } else {
+                    scopedStudyId?.let { studyId ->
+                        prefs.edit { putString("$FIELD_TRAIT_SORT_ORDER_PREFIX$studyId", "position") }
+                    }
                 }
 
                 _uiState.update { it.copy(sortOrder = "position") }
+                // Reload quietly to guarantee UI reflects persisted DB-backed field order.
+                loadTraits(showLoading = false)
             }.onFailure { e ->
                 Log.e(TAG, "Failed to save trait order", e)
                 _events.emit(TraitEditorEvent.ShowToast(R.string.error_saving_trait_order))
@@ -435,10 +726,13 @@ enum class DialogTriggerSource { IMPORT_WORKFLOW, TOOLBAR }
 data class TraitEditorUiState(
     val activeDialog: TraitActivityDialog = TraitActivityDialog.None,
     val traits: List<TraitObject> = emptyList(),
-    val isLoading: Boolean = false,
+    val availableTraits: List<TraitObject> = emptyList(),
+    val selectedTraitIds: Set<String> = emptySet(),
+    val isLoading: Boolean = true,
     val sortOrder: String = "position",
 ) {
     val hasTraits: Boolean get() = traits.isNotEmpty()
+    val isSelectionMode: Boolean get() = selectedTraitIds.isNotEmpty()
 }
 
 sealed class TraitEditorEvent {
@@ -461,5 +755,6 @@ sealed class TraitActivityDialog {
     object ExportCheck : TraitActivityDialog()
     data class Export(val source: DialogTriggerSource) : TraitActivityDialog()
     data class DeleteAll(val source: DialogTriggerSource) : TraitActivityDialog()
+    data class RemoveFromField(val traitIds: Set<String>, val message: String) : TraitActivityDialog()
     object SortTraits : TraitActivityDialog()
 }

--- a/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitEditorViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitEditorViewModel.kt
@@ -290,12 +290,12 @@ class TraitEditorViewModel @Inject constructor(
         }
     }
 
-    fun requestRemoveTraitFromCurrentStudy(trait: TraitObject) {
+    fun requestRemoveTrait(trait: TraitObject) {
         val traitName = trait.alias.ifBlank { trait.name }
         showDialog(TraitActivityDialog.RemoveFromField(setOf(trait.id), traitName))
     }
 
-    fun requestRemoveSelectedTraitsFromCurrentStudy() {
+    fun requestRemoveSelectedTraits() {
         val selectedIds = _uiState.value.selectedTraitIds
         if (selectedIds.isEmpty()) return
         
@@ -309,14 +309,11 @@ class TraitEditorViewModel @Inject constructor(
         showDialog(TraitActivityDialog.RemoveFromField(selectedIds, message))
     }
 
-    fun removeTraitFromCurrentStudy(traitIds: Set<String>) {
-        val currentStudyId = scopedStudyId ?: return
-        if (!usePerFieldTraitList || traitIds.isEmpty()) return
+    fun removeTraits(traitIds: Set<String>) {
+        if (traitIds.isEmpty()) return
 
         hideDialog()
 
-        val oldList = _uiState.value.traits
-        
         // Optimistic local removal
         val newList = _uiState.value.traits.filterNot { it.id in traitIds }
         _uiState.update { state ->
@@ -329,15 +326,25 @@ class TraitEditorViewModel @Inject constructor(
 
         viewModelScope.launch {
             runCatching {
-                repo.removeTraitsFromStudy(currentStudyId, traitIds)
+                if (isViewerMode && usePerFieldTraitList) {
+                    val currentStudyId = scopedStudyId ?: return@runCatching
+                    repo.removeTraitsFromStudy(currentStudyId, traitIds)
+                } else {
+                    traitIds.forEach { repo.deleteTrait(it) }
+                    repo.updateTraitOrder(newList)
+                }
             }.onSuccess {
-                loadAvailableTraitsForCurrentStudy()
-                _events.emit(TraitEditorEvent.ShowToast(R.string.traits_viewer_removed_trait))
+                if (isViewerMode) {
+                    loadAvailableTraitsForCurrentStudy()
+                    _events.emit(TraitEditorEvent.ShowToast(R.string.traits_viewer_removed_trait))
+                }
+                notifyCollectReload()
             }.onFailure { e ->
                 // Rollback (simplified, just reload quietly)
                 loadTraits(showLoading = false)
-                Log.e(TAG, "Error removing traits from study", e)
-                _events.emit(TraitEditorEvent.ShowToast(R.string.error_updating_trait_visibility))
+                Log.e(TAG, "Error removing traits", e)
+                val errorMsg = if (isViewerMode) R.string.error_updating_trait_visibility else R.string.error_deleting_traits
+                _events.emit(TraitEditorEvent.ShowToast(errorMsg))
             }
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/fragments/CropImageFragment.kt
+++ b/app/src/main/java/com/fieldbook/tracker/fragments/CropImageFragment.kt
@@ -60,7 +60,7 @@ class CropImageFragment: Fragment(R.layout.crop_image_fragment), CoroutineScope 
             override fun onCropImageSaved(rectCoordinates: String) {
 
                 //save the coordinate text to preferences, make the key relative to the input trait id
-                prefs.edit { putString(GeneralKeys.getCropCoordinatesKey(traitId), rectCoordinates) }
+                prefs.edit { putString(GeneralKeys.getCropCoordinatesKey(traitId.toString()), rectCoordinates) }
 
                 launch(Dispatchers.IO) {
 
@@ -89,7 +89,7 @@ class CropImageFragment: Fragment(R.layout.crop_image_fragment), CoroutineScope 
 
             override fun getCropCoordinates(): String {
 
-                return prefs.getString(GeneralKeys.getCropCoordinatesKey(traitId), "") ?: ""
+                return prefs.getString(GeneralKeys.getCropCoordinatesKey(traitId.toString()), "") ?: ""
             }
 
             override fun getImageUri() = imageUri

--- a/app/src/main/java/com/fieldbook/tracker/objects/FieldObject.java
+++ b/app/src/main/java/com/fieldbook/tracker/objects/FieldObject.java
@@ -45,23 +45,24 @@ public class FieldObject {
     }
 
     public static class TraitDetail {
+        private final String traitId;
         private final String traitName;
         private final String format;
         private String categories;
         private final int count;
         private final List<String> observations;
-        private final float completeness;  // Add this line
+        private final float completeness;
 
-        public TraitDetail(String traitName, String format, String categories, int count, List<String> observations, float completeness) {
+        public TraitDetail(String id, String traitName, String format, String categories, int count, List<String> observations, float completeness) {
+            this.traitId = id;
             this.traitName = traitName;
             this.format = format;
             this.categories = categories;
             this.count = count;
             this.observations = observations;
-            this.completeness = completeness;  // Add this line
+            this.completeness = completeness;
         }
 
-        // Getters
         public String getTraitName() { return traitName; }
         public String getFormat() { return format; }
         public String getCategories() {
@@ -69,7 +70,8 @@ public class FieldObject {
         }
         public int getCount() { return count; }
         public List<String> getObservations() { return observations; }
-        public float getCompleteness() { return completeness; }  // Add this line
+        public float getCompleteness() { return completeness; }
+        public String getTraitId() { return traitId; }
     }
 
     private List<TraitDetail> traitDetails;

--- a/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/GeneralKeys.java
@@ -145,6 +145,7 @@ public class GeneralKeys {
     // Field and trait detail
     public static final String FIELD_DETAIL_OVERVIEW_COLLAPSED = "FIELD_DETAIL_OVERVIEW_COLLAPSED";
     public static final String FIELD_DETAIL_DATA_COLLAPSED = "FIELD_DETAIL_DATA_COLLAPSED";
+    public static final String FIELD_DETAIL_TRAITS_EXPANDED = "FIELD_DETAIL_TRAITS_EXPANDED";
     public static final String FIELD_DETAIL_FIELD_ID = "FIELD_DETAIL_FIELD_ID";
     public static final String TRAIT_DETAIL_OVERVIEW_COLLAPSED = "TRAIT_DETAIL_OVERVIEW_COLLAPSED";
     public static final String TRAIT_DETAIL_OPTIONS_COLLAPSED = "TRAIT_DETAIL_OPTIONS_COLLAPSED";
@@ -224,7 +225,7 @@ public class GeneralKeys {
      * @return key used in preferences to obtain the (tl, tr, br, bl) coordinates used for cropping images
      */
     @NotNull
-    public static String getCropCoordinatesKey(int traitId) {
+    public static String getCropCoordinatesKey(String traitId) {
         return "com.fieldbook.tracker.crop_coordinates." + traitId;
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/preferences/TraitScopePreferences.kt
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/TraitScopePreferences.kt
@@ -1,0 +1,62 @@
+package com.fieldbook.tracker.preferences
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+
+object TraitScopePreferences {
+
+    private const val STUDY_TRAIT_IDS_PREFIX = "study_trait_ids_"
+    private const val STUDY_TRAIT_VISIBILITY_PREFIX = "study_trait_visibility_"
+
+    @JvmStatic
+    fun getStudyTraitIds(preferences: SharedPreferences, studyId: Int): Set<String> {
+        if (studyId < 0) return emptySet()
+        return preferences.getStringSet("$STUDY_TRAIT_IDS_PREFIX$studyId", emptySet()) ?: emptySet()
+    }
+
+    @JvmStatic
+    fun getStudyVisibleTraitIds(preferences: SharedPreferences, studyId: Int): Set<String>? {
+        if (studyId < 0) return null
+        return preferences.getStringSet("$STUDY_TRAIT_VISIBILITY_PREFIX$studyId", null)
+    }
+
+    @JvmStatic
+    fun setStudyVisibleTraitIds(preferences: SharedPreferences, studyId: Int, traitIds: Set<String>) {
+        if (studyId < 0) return
+        preferences.edit { putStringSet("$STUDY_TRAIT_VISIBILITY_PREFIX$studyId", traitIds) }
+    }
+
+    @JvmStatic
+    fun getOrInitializeStudyTraitIds(
+        preferences: SharedPreferences,
+        studyId: Int,
+        fallbackTraitIds: Set<String>,
+    ): Set<String> {
+        if (studyId < 0) return emptySet()
+
+        val existing = getStudyTraitIds(preferences, studyId)
+        if (existing.isNotEmpty()) return existing
+
+        if (fallbackTraitIds.isEmpty()) return emptySet()
+
+        preferences.edit { putStringSet("$STUDY_TRAIT_IDS_PREFIX$studyId", fallbackTraitIds) }
+        return fallbackTraitIds
+    }
+
+    @JvmStatic
+    fun addStudyTraitIds(preferences: SharedPreferences, studyId: Int, traitIds: Set<String>) {
+        if (studyId < 0 || traitIds.isEmpty()) return
+
+        val merged = getStudyTraitIds(preferences, studyId).toMutableSet().apply {
+            addAll(traitIds)
+        }
+
+        preferences.edit { putStringSet("$STUDY_TRAIT_IDS_PREFIX$studyId", merged) }
+    }
+
+    @JvmStatic
+    fun setStudyTraitIds(preferences: SharedPreferences, studyId: Int, traitIds: Set<String>) {
+        if (studyId < 0) return
+        preferences.edit { putStringSet("$STUDY_TRAIT_IDS_PREFIX$studyId", traitIds) }
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/preferences/TraitScopePreferences.kt
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/TraitScopePreferences.kt
@@ -7,6 +7,7 @@ object TraitScopePreferences {
 
     private const val STUDY_TRAIT_IDS_PREFIX = "study_trait_ids_"
     private const val STUDY_TRAIT_VISIBILITY_PREFIX = "study_trait_visibility_"
+    private const val STUDY_TRAIT_INITIALIZED_PREFIX = "study_trait_initialized_"
 
     @JvmStatic
     fun getStudyTraitIds(preferences: SharedPreferences, studyId: Int): Set<String> {
@@ -26,6 +27,23 @@ object TraitScopePreferences {
         preferences.edit { putStringSet("$STUDY_TRAIT_VISIBILITY_PREFIX$studyId", traitIds) }
     }
 
+    /**
+     * Returns true if a study's trait scope has been explicitly initialized
+     * (even if the resulting set is empty due to all traits being removed).
+     */
+    @JvmStatic
+    fun isStudyTraitScopeInitialized(preferences: SharedPreferences, studyId: Int): Boolean {
+        if (studyId < 0) return false
+        return preferences.getBoolean("$STUDY_TRAIT_INITIALIZED_PREFIX$studyId", false)
+    }
+
+    /**
+     * Returns the scoped trait IDs for a study, initializing them from [fallbackTraitIds]
+     * only if the scope has never been initialized before.
+     *
+     * If the scope was previously initialized and the set is empty (e.g. all traits
+     * were removed), the empty set is returned as-is — it will NOT be repopulated.
+     */
     @JvmStatic
     fun getOrInitializeStudyTraitIds(
         preferences: SharedPreferences,
@@ -34,12 +52,18 @@ object TraitScopePreferences {
     ): Set<String> {
         if (studyId < 0) return emptySet()
 
-        val existing = getStudyTraitIds(preferences, studyId)
-        if (existing.isNotEmpty()) return existing
+        // If already initialized (even to empty), respect the current value
+        if (isStudyTraitScopeInitialized(preferences, studyId)) {
+            return getStudyTraitIds(preferences, studyId)
+        }
 
+        // First-time initialization: populate from fallback
         if (fallbackTraitIds.isEmpty()) return emptySet()
 
-        preferences.edit { putStringSet("$STUDY_TRAIT_IDS_PREFIX$studyId", fallbackTraitIds) }
+        preferences.edit {
+            putStringSet("$STUDY_TRAIT_IDS_PREFIX$studyId", fallbackTraitIds)
+            putBoolean("$STUDY_TRAIT_INITIALIZED_PREFIX$studyId", true)
+        }
         return fallbackTraitIds
     }
 
@@ -51,12 +75,18 @@ object TraitScopePreferences {
             addAll(traitIds)
         }
 
-        preferences.edit { putStringSet("$STUDY_TRAIT_IDS_PREFIX$studyId", merged) }
+        preferences.edit {
+            putStringSet("$STUDY_TRAIT_IDS_PREFIX$studyId", merged)
+            putBoolean("$STUDY_TRAIT_INITIALIZED_PREFIX$studyId", true)
+        }
     }
 
     @JvmStatic
     fun setStudyTraitIds(preferences: SharedPreferences, studyId: Int, traitIds: Set<String>) {
         if (studyId < 0) return
-        preferences.edit { putStringSet("$STUDY_TRAIT_IDS_PREFIX$studyId", traitIds) }
+        preferences.edit {
+            putStringSet("$STUDY_TRAIT_IDS_PREFIX$studyId", traitIds)
+            putBoolean("$STUDY_TRAIT_INITIALIZED_PREFIX$studyId", true)
+        }
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/traits/AbstractCameraTrait.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/AbstractCameraTrait.kt
@@ -193,7 +193,7 @@ abstract class AbstractCameraTrait :
 
     protected fun isCropRequired() = (currentTrait?.saveImage ?: true) && (currentTrait?.cropImage ?: false)
 
-    protected fun isCropExist() = (preferences.getString(GeneralKeys.getCropCoordinatesKey(currentTrait?.id?.toInt() ?: -1), "") ?: "").isNotEmpty()
+    protected fun isCropExist() = (preferences.getString(GeneralKeys.getCropCoordinatesKey(currentTrait?.id), "") ?: "").isNotEmpty()
 
     protected fun requestCropDefinition(traitId: String, imageUri: Uri) {
 
@@ -719,7 +719,7 @@ abstract class AbstractCameraTrait :
                 if (isCropExist()) {
 
                     //get bitmap from uri, create new bitmap from preference roi and update uri to database
-                    val cropRect = preferences.getString(GeneralKeys.getCropCoordinatesKey(currentTrait.id.toInt()), "") ?: ""
+                    val cropRect = preferences.getString(GeneralKeys.getCropCoordinatesKey(currentTrait.id), "") ?: ""
 
                     withContext(Dispatchers.IO) {
 

--- a/app/src/main/java/com/fieldbook/tracker/traits/VideoTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/VideoTraitLayout.kt
@@ -235,7 +235,7 @@ class VideoTraitLayout : PhotoTraitLayout {
                     val cropRequired = isCropRequired() && isCropExist()
 
                     if (cropRequired) {
-                        val cropRect = preferences.getString(GeneralKeys.getCropCoordinatesKey(currentTrait.id.toInt()), "") ?: ""
+                        val cropRect = preferences.getString(GeneralKeys.getCropCoordinatesKey(currentTrait.id), "") ?: ""
                         val rect = CropImageView.parseRectCoordinates(cropRect)
 
                         if (rect != null) {
@@ -303,7 +303,7 @@ class VideoTraitLayout : PhotoTraitLayout {
                     val cropRequired = isCropRequired() && isCropExist()
 
                     if (cropRequired) {
-                        val cropRect = preferences.getString(GeneralKeys.getCropCoordinatesKey(currentTrait.id.toInt()), "") ?: ""
+                        val cropRect = preferences.getString(GeneralKeys.getCropCoordinatesKey(currentTrait.id), "") ?: ""
                         val rect = CropImageView.parseRectCoordinates(cropRect)
 
                         if (rect != null) {

--- a/app/src/main/java/com/fieldbook/tracker/ui/navigation/controllers/TraitNavController.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/navigation/controllers/TraitNavController.kt
@@ -3,6 +3,7 @@ package com.fieldbook.tracker.ui.navigation.controllers
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import com.fieldbook.tracker.ui.navigation.routes.TraitDetail
+import com.fieldbook.tracker.ui.navigation.routes.TraitFieldPicker
 
 class TraitNavController(
     navController: NavHostController,
@@ -10,6 +11,10 @@ class TraitNavController(
 
     fun navigateToTraitDetail(traitId: String, from: NavBackStackEntry) {
         navigateIfResumed(from, TraitDetail(traitId))
+    }
+
+    fun navigateToFieldTraitPicker(from: NavBackStackEntry) {
+        navigateIfResumed(from, TraitFieldPicker)
     }
 
     fun navigateBack() = back()

--- a/app/src/main/java/com/fieldbook/tracker/ui/navigation/routes/TraitRoutes.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/navigation/routes/TraitRoutes.kt
@@ -9,4 +9,7 @@ object TraitGraph
 object TraitEditor
 
 @Serializable
+object TraitFieldPicker
+
+@Serializable
 data class TraitDetail(val traitId: String)

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitEditorScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitEditorScreen.kt
@@ -273,6 +273,7 @@ fun TraitEditorScreen(
         TraitActivityDialog.SortTraits -> {
             SortOptionsDialog(
                 currentSortOrder = uiState.sortOrder,
+                isViewerMode = isViewerMode,
                 onCancel = { viewModel.hideDialog() },
                 onSortSelected = { sortOrder ->
                     viewModel.updateSortOrder(sortOrder)

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitEditorScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitEditorScreen.kt
@@ -108,9 +108,9 @@ fun TraitEditorScreen(
                 isTutorialEnabled = viewModel.isTutorialEnabled(),
                 isSelectionMode = uiState.isSelectionMode,
                 selectedCount = uiState.selectedTraitIds.size,
-                onBack = { 
+                onBack = {
                     if (uiState.isSelectionMode) viewModel.clearSelection()
-                    else onNavigateBack() 
+                    else onNavigateBack()
                 },
                 onToggleAllTraits = { viewModel.toggleAllTraitsVisibility() },
                 onSyncWithMainList = { viewModel.syncCurrentStudyWithMainList() },
@@ -118,7 +118,7 @@ fun TraitEditorScreen(
                 onRequestExportPermission = { viewModel.requestExportPermission(DialogTriggerSource.TOOLBAR) },
                 onClearSelection = { viewModel.clearSelection() },
                 onSelectAll = { viewModel.selectAll() },
-                onRemoveSelected = { viewModel.requestRemoveSelectedTraitsFromCurrentStudy() },
+                onRemoveSelected = { viewModel.requestRemoveSelectedTraits() },
                 onToggleVisibilitySelected = { viewModel.toggleVisibilityForSelectedTraits() }
             )
         },
@@ -162,8 +162,8 @@ fun TraitEditorScreen(
                         traits = uiState.traits,
                         selectedTraitIds = uiState.selectedTraitIds,
                         showVisibilityControls = isViewerMode,
-                        showRemoveAction = isViewerMode && !uiState.isSelectionMode,
-                        allowReorder = isViewerMode && !uiState.isSelectionMode,
+                        showRemoveAction = !uiState.isSelectionMode,
+                        allowReorder = !uiState.isSelectionMode,
                         onTraitClick = { traitId ->
                             if (uiState.isSelectionMode) viewModel.toggleTraitSelection(traitId)
                             else onTraitDetail(traitId)
@@ -175,7 +175,7 @@ fun TraitEditorScreen(
                             viewModel.updateTraitVisibility(trait.id, isVisible)
                         },
                         onRemoveTrait = { trait ->
-                            viewModel.requestRemoveTraitFromCurrentStudy(trait)
+                            viewModel.requestRemoveTrait(trait)
                         },
                         onMoveItem = { from, to ->
                             viewModel.moveTraitItem(from, to)
@@ -265,8 +265,9 @@ fun TraitEditorScreen(
         is TraitActivityDialog.RemoveFromField -> {
             RemoveTraitFromFieldDialog(
                 traitName = dialog.message,
+                isViewerMode = isViewerMode,
                 onCancel = { viewModel.hideDialog() },
-                onRemove = { viewModel.removeTraitFromCurrentStudy(dialog.traitIds) },
+                onRemove = { viewModel.removeTraits(dialog.traitIds) },
             )
         }
 
@@ -335,7 +336,10 @@ fun TraitEditorScreen(
 
                 TraitEditorEvent.NavigateToBrapi -> {
                     if (!Utils.isConnected(context)) {
-                        Utils.makeToast(context, resources.getString(R.string.opening_brapi_no_network_error))
+                        Utils.makeToast(
+                            context,
+                            resources.getString(R.string.opening_brapi_no_network_error)
+                        )
                         return@collect
                     }
 

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitEditorScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitEditorScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -66,6 +64,8 @@ fun TraitEditorScreen(
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val isPerFieldTraitListEnabled = true
+
+    val listState = androidx.compose.foundation.lazy.rememberLazyListState()
 
     LaunchedEffect(isViewerMode, scopedStudyId, isPerFieldTraitListEnabled) {
         val studyScope = if (isViewerMode) scopedStudyId else null
@@ -183,6 +183,7 @@ fun TraitEditorScreen(
                         onDragStateChanged = { dragging ->
                             viewModel.onDragStateChanged(dragging)
                         },
+                        lazyListState = listState,
                         modifier = Modifier.fillMaxSize()
                     )
                 }
@@ -355,6 +356,10 @@ fun TraitEditorScreen(
                 is TraitEditorEvent.ShareFile -> {
                     val doc = DocumentFile.fromSingleUri(context, event.fileUri)
                     FileUtil.shareFile(context, prefs, doc)
+                }
+
+                TraitEditorEvent.ScrollToTop -> {
+                    listState.animateScrollToItem(0)
                 }
             }
         }

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitEditorScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitEditorScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -39,6 +41,7 @@ import com.fieldbook.tracker.ui.screens.traits.dialogs.CreateTraitsDialog
 import com.fieldbook.tracker.ui.screens.traits.dialogs.DeleteAllTraitsDialog
 import com.fieldbook.tracker.ui.screens.traits.dialogs.ExportCheckDialog
 import com.fieldbook.tracker.ui.screens.traits.dialogs.ExportDialog
+import com.fieldbook.tracker.ui.screens.traits.dialogs.RemoveTraitFromFieldDialog
 import com.fieldbook.tracker.ui.screens.traits.dialogs.SortOptionsDialog
 import com.fieldbook.tracker.ui.screens.traits.dialogs.TraitImportDialog
 import com.fieldbook.tracker.ui.screens.traits.lists.TraitList
@@ -49,8 +52,11 @@ import com.fieldbook.tracker.utilities.Utils
 @Composable
 fun TraitEditorScreen(
     viewModel: TraitEditorViewModel,
+    isViewerMode: Boolean,
+    scopedStudyId: Int?,
     onNavigateBack: () -> Unit,
     onTraitDetail: (String) -> Unit,
+    onNavigateToFieldTraitPicker: () -> Unit,
     onShowCreateNewTraitDialog: () -> Unit,
     onShowLocalFilePicker: () -> Unit,
 ) {
@@ -59,6 +65,12 @@ fun TraitEditorScreen(
     val prefs = PreferenceManager.getDefaultSharedPreferences(context)
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val isPerFieldTraitListEnabled = true
+
+    LaunchedEffect(isViewerMode, scopedStudyId, isPerFieldTraitListEnabled) {
+        val studyScope = if (isViewerMode) scopedStudyId else null
+        viewModel.configureTraitScope(studyScope, isPerFieldTraitListEnabled, isViewerMode)
+    }
 
     val permissionCallback = remember { mutableStateOf<(() -> Unit)?>(null) }
 
@@ -92,19 +104,43 @@ fun TraitEditorScreen(
         topBar = {
             TraitEditorToolbar(
                 hasTraits = uiState.hasTraits,
+                isViewerMode = isViewerMode,
                 isTutorialEnabled = viewModel.isTutorialEnabled(),
-                onBack = onNavigateBack,
+                isSelectionMode = uiState.isSelectionMode,
+                selectedCount = uiState.selectedTraitIds.size,
+                onBack = { 
+                    if (uiState.isSelectionMode) viewModel.clearSelection()
+                    else onNavigateBack() 
+                },
                 onToggleAllTraits = { viewModel.toggleAllTraitsVisibility() },
+                onSyncWithMainList = { viewModel.syncCurrentStudyWithMainList() },
                 onShowDialog = { dialog -> viewModel.showDialog(dialog) },
                 onRequestExportPermission = { viewModel.requestExportPermission(DialogTriggerSource.TOOLBAR) },
+                onClearSelection = { viewModel.clearSelection() },
+                onSelectAll = { viewModel.selectAll() },
+                onRemoveSelected = { viewModel.requestRemoveSelectedTraitsFromCurrentStudy() },
+                onToggleVisibilitySelected = { viewModel.toggleVisibilityForSelectedTraits() }
             )
         },
         floatingActionButton = {
-            CircularBorderedFab(
-                onClick = { viewModel.showDialog(TraitActivityDialog.NewTrait) },
-                icon = Icons.Filled.Add,
-                contentDescription = stringResource(R.string.traits_new_dialog_title)
-            )
+            if (!isViewerMode || (isPerFieldTraitListEnabled && scopedStudyId != null)) {
+                CircularBorderedFab(
+                    onClick = {
+                        if (isViewerMode && isPerFieldTraitListEnabled && scopedStudyId != null) {
+                            viewModel.loadAvailableTraitsForCurrentStudy()
+                            onNavigateToFieldTraitPicker()
+                        } else {
+                            viewModel.showDialog(TraitActivityDialog.NewTrait)
+                        }
+                    },
+                    icon = Icons.Filled.Add,
+                    contentDescription = if (isViewerMode) {
+                        stringResource(R.string.traits_viewer_add_to_field)
+                    } else {
+                        stringResource(R.string.traits_new_dialog_title)
+                    }
+                )
+            }
         }
     ) { paddingValues ->
 
@@ -124,9 +160,22 @@ fun TraitEditorScreen(
                 else -> {
                     TraitList(
                         traits = uiState.traits,
-                        onTraitClick = onTraitDetail,
+                        selectedTraitIds = uiState.selectedTraitIds,
+                        showVisibilityControls = isViewerMode,
+                        showRemoveAction = isViewerMode && !uiState.isSelectionMode,
+                        allowReorder = isViewerMode && !uiState.isSelectionMode,
+                        onTraitClick = { traitId ->
+                            if (uiState.isSelectionMode) viewModel.toggleTraitSelection(traitId)
+                            else onTraitDetail(traitId)
+                        },
+                        onTraitLongClick = { traitId ->
+                            if (!uiState.isSelectionMode) viewModel.toggleTraitSelection(traitId)
+                        },
                         onToggleVisibility = { trait, isVisible ->
                             viewModel.updateTraitVisibility(trait.id, isVisible)
+                        },
+                        onRemoveTrait = { trait ->
+                            viewModel.requestRemoveTraitFromCurrentStudy(trait)
                         },
                         onMoveItem = { from, to ->
                             viewModel.moveTraitItem(from, to)
@@ -209,6 +258,14 @@ fun TraitEditorScreen(
             DeleteAllTraitsDialog(
                 onCancel = { viewModel.handleDeleteDialogAction(dialog.source) },
                 onDelete = { viewModel.handleDeleteDialogAction(dialog.source, true) },
+            )
+        }
+
+        is TraitActivityDialog.RemoveFromField -> {
+            RemoveTraitFromFieldDialog(
+                traitName = dialog.message,
+                onCancel = { viewModel.hideDialog() },
+                onRemove = { viewModel.removeTraitFromCurrentStudy(dialog.traitIds) },
             )
         }
 

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitFieldPickerScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitFieldPickerScreen.kt
@@ -106,13 +106,6 @@ fun TraitFieldPickerScreen(
                                 },
                                 displayMode = ActionDisplayMode.ALWAYS,
                                 contentDescription = stringResource(R.string.fields_select_all)
-                            ),
-                            TopAppBarAction(
-                                title = stringResource(R.string.traits_viewer_create_new_trait),
-                                icon = Icons.Default.Add,
-                                onClick = { onCreateNewTrait() },
-                                displayMode = ActionDisplayMode.ALWAYS,
-                                contentDescription = stringResource(R.string.traits_viewer_create_new_trait)
                             )
                         )
                     } else {
@@ -125,6 +118,13 @@ fun TraitFieldPickerScreen(
                                 },
                                 displayMode = ActionDisplayMode.IF_ROOM,
                                 contentDescription = stringResource(R.string.fields_select_all)
+                            ),
+                            TopAppBarAction(
+                                title = stringResource(R.string.traits_viewer_create_new_trait),
+                                icon = Icons.Default.Add,
+                                onClick = { onCreateNewTrait() },
+                                displayMode = ActionDisplayMode.ALWAYS,
+                                contentDescription = stringResource(R.string.traits_viewer_create_new_trait)
                             )
                         )
                     }

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitFieldPickerScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitFieldPickerScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -183,7 +184,7 @@ fun TraitFieldPickerScreen(
             Surface(
                 tonalElevation = 3.dp,
                 shadowElevation = 8.dp,
-                color = AppTheme.colors.background
+                color = AppTheme.colors.primary
             ) {
                 Row(
                     modifier = Modifier
@@ -199,12 +200,14 @@ fun TraitFieldPickerScreen(
                         modifier = Modifier.fillMaxWidth(),
                         contentPadding = PaddingValues(vertical = 12.dp),
                         colors = ButtonDefaults.outlinedButtonColors(
-                            contentColor = AppTheme.colors.primary
+                            contentColor = AppTheme.colors.primary,
+                            containerColor = AppTheme.colors.background
                         )
                     ) {
                         Text(
                             text = stringResource(R.string.traits_viewer_add_selected),
-                            style = MaterialTheme.typography.labelLarge
+                            style = MaterialTheme.typography.labelLarge,
+                            color = Color.Black
                         )
                     }
                 }

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitFieldPickerScreen.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/TraitFieldPickerScreen.kt
@@ -1,0 +1,325 @@
+package com.fieldbook.tracker.ui.screens.traits
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SelectAll
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateSetOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.fieldbook.tracker.R
+import com.fieldbook.tracker.objects.TraitObject
+import com.fieldbook.tracker.traits.formats.Formats
+import com.fieldbook.tracker.ui.components.appBar.ActionDisplayMode
+import com.fieldbook.tracker.ui.components.appBar.AppBar
+import com.fieldbook.tracker.ui.components.appBar.TopAppBarAction
+import com.fieldbook.tracker.ui.theme.AppTheme
+
+@Composable
+fun TraitFieldPickerScreen(
+    availableTraits: List<TraitObject>,
+    onBack: () -> Unit,
+    onCreateNewTrait: () -> Unit,
+    onAddSelected: (Set<String>) -> Unit,
+) {
+    val selectedTraitIds = remember { mutableStateSetOf<String>() }
+    var searchQuery by remember { mutableStateOf("") }
+
+    val filteredTraits = remember(availableTraits, searchQuery) {
+        if (searchQuery.isBlank()) availableTraits
+        else availableTraits.filter {
+            it.name.contains(searchQuery, ignoreCase = true) ||
+                    it.alias.contains(searchQuery, ignoreCase = true)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            Column(modifier = Modifier.background(AppTheme.colors.background)) {
+                AppBar(
+                    title = if (selectedTraitIds.isEmpty()) {
+                        stringResource(R.string.traits_viewer_create_new_trait)
+                    } else {
+                        stringResource(R.string.selected_count, selectedTraitIds.size)
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                painter = painterResource(R.drawable.arrow_left),
+                                contentDescription = stringResource(R.string.appbar_back),
+                                tint = AppTheme.colors.text.tertiary
+                            )
+                        }
+                    },
+                    actions = if (selectedTraitIds.isNotEmpty()) {
+                        listOf(
+                            TopAppBarAction(
+                                title = stringResource(R.string.fields_select_all),
+                                icon = Icons.Default.SelectAll,
+                                onClick = { 
+                                    if (selectedTraitIds.size == filteredTraits.size) {
+                                        selectedTraitIds.clear()
+                                    } else {
+                                        selectedTraitIds.addAll(filteredTraits.map { it.id })
+                                    }
+                                },
+                                displayMode = ActionDisplayMode.ALWAYS,
+                                contentDescription = stringResource(R.string.fields_select_all)
+                            ),
+                            TopAppBarAction(
+                                title = stringResource(R.string.traits_viewer_create_new_trait),
+                                icon = Icons.Default.Add,
+                                onClick = { onCreateNewTrait() },
+                                displayMode = ActionDisplayMode.ALWAYS,
+                                contentDescription = stringResource(R.string.traits_viewer_create_new_trait)
+                            )
+                        )
+                    } else {
+                        listOf(
+                            TopAppBarAction(
+                                title = stringResource(R.string.fields_select_all),
+                                icon = Icons.Default.SelectAll,
+                                onClick = { 
+                                    selectedTraitIds.addAll(filteredTraits.map { it.id })
+                                },
+                                displayMode = ActionDisplayMode.IF_ROOM,
+                                contentDescription = stringResource(R.string.fields_select_all)
+                            )
+                        )
+                    }
+                )
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    OutlinedTextField(
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        placeholder = { 
+                            Text(
+                                text = stringResource(R.string.main_toolbar_search),
+                                color = AppTheme.colors.text.secondary.copy(alpha = 0.6f)
+                            ) 
+                        },
+                        leadingIcon = { 
+                            Icon(
+                                imageVector = Icons.Default.Search, 
+                                contentDescription = null,
+                                tint = AppTheme.colors.text.secondary
+                            ) 
+                        },
+                        trailingIcon = if (searchQuery.isNotEmpty()) {
+                            {
+                                IconButton(onClick = { searchQuery = "" }) {
+                                    Icon(
+                                        imageVector = Icons.Default.Clear, 
+                                        contentDescription = null,
+                                        tint = AppTheme.colors.text.secondary
+                                    )
+                                }
+                            }
+                        } else null,
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedContainerColor = AppTheme.colors.background,
+                            unfocusedContainerColor = AppTheme.colors.background,
+                            disabledContainerColor = AppTheme.colors.background,
+                            focusedBorderColor = AppTheme.colors.primary,
+                            unfocusedBorderColor = AppTheme.colors.surface.border,
+                            cursorColor = AppTheme.colors.primary,
+                            focusedTextColor = AppTheme.colors.text.primary,
+                            unfocusedTextColor = AppTheme.colors.text.primary,
+                        ),
+                        shape = MaterialTheme.shapes.medium,
+                        singleLine = true
+                    )
+                }
+            }
+        },
+        bottomBar = {
+            Surface(
+                tonalElevation = 3.dp,
+                shadowElevation = 8.dp,
+                color = AppTheme.colors.background
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .windowInsetsPadding(WindowInsets.navigationBars)
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    OutlinedButton(
+                        onClick = {
+                            onAddSelected(selectedTraitIds.toSet())
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        contentPadding = PaddingValues(vertical = 12.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = AppTheme.colors.primary
+                        )
+                    ) {
+                        Text(
+                            text = stringResource(R.string.traits_viewer_add_selected),
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
+                }
+            }
+        }
+    ) { paddingValues ->
+        if (availableTraits.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_file_generic),
+                    contentDescription = null,
+                    modifier = Modifier.size(64.dp),
+                    tint = AppTheme.colors.text.secondary.copy(alpha = 0.4f)
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = stringResource(R.string.traits_viewer_no_available_traits),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = AppTheme.colors.text.secondary,
+                    fontWeight = FontWeight.Medium
+                )
+            }
+        } else if (filteredTraits.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = stringResource(R.string.search_results_missing),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = AppTheme.colors.text.secondary
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(filteredTraits, key = { it.id }) { trait ->
+                    val isSelected = trait.id in selectedTraitIds
+                    
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                if (isSelected) selectedTraitIds.remove(trait.id)
+                                else selectedTraitIds.add(trait.id)
+                            },
+                        shape = MaterialTheme.shapes.medium,
+                        color = if (isSelected) AppTheme.colors.interactive.selectedItemBackground else AppTheme.colors.background,
+                        border = androidx.compose.foundation.BorderStroke(
+                            1.dp, 
+                            if (isSelected) AppTheme.colors.primary else AppTheme.colors.surface.border
+                        ),
+                        tonalElevation = if (isSelected) 2.dp else 0.dp
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Checkbox(
+                                checked = isSelected,
+                                onCheckedChange = { checked ->
+                                    if (checked) selectedTraitIds.add(trait.id)
+                                    else selectedTraitIds.remove(trait.id)
+                                },
+                                colors = CheckboxDefaults.colors(
+                                    checkedColor = AppTheme.colors.primary,
+                                    uncheckedColor = AppTheme.colors.text.secondary
+                                )
+                            )
+
+                            Spacer(modifier = Modifier.width(12.dp))
+
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = trait.alias.takeIf { it.isNotBlank() } ?: trait.name,
+                                    style = MaterialTheme.typography.titleMedium,
+                                    color = AppTheme.colors.text.primary,
+                                    fontWeight = FontWeight.SemiBold
+                                )
+
+                                val formatLabel = Formats.entries
+                                    .find { it.getDatabaseName() == trait.format }
+                                    ?.name
+                                    ?.replace('_', ' ')
+                                    ?.lowercase()
+                                    ?.replaceFirstChar { it.uppercase() }
+                                    ?: trait.format
+
+                                Text(
+                                    text = formatLabel,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = AppTheme.colors.text.secondary
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/dialogs/RemoveTraitFromFieldDialog.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/dialogs/RemoveTraitFromFieldDialog.kt
@@ -1,0 +1,45 @@
+package com.fieldbook.tracker.ui.screens.traits.dialogs
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.fieldbook.tracker.R
+import com.fieldbook.tracker.ui.dialogs.builder.AppAlertDialog
+import com.fieldbook.tracker.ui.theme.AppTheme
+
+@Composable
+fun RemoveTraitFromFieldDialog(
+    traitName: String,
+    onCancel: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    AppAlertDialog(
+        title = stringResource(R.string.traits_viewer_remove_from_field_title),
+        content = {
+            Column {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.traits_viewer_remove_from_field_message, traitName),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+        },
+        positiveButtonText = stringResource(R.string.dialog_remove),
+        positiveTextColor = AppTheme.colors.status.error,
+        onPositive = onRemove,
+        negativeButtonText = stringResource(R.string.dialog_cancel),
+        onNegative = onCancel,
+    )
+}
+

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/dialogs/RemoveTraitFromFieldDialog.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/dialogs/RemoveTraitFromFieldDialog.kt
@@ -17,11 +17,16 @@ import com.fieldbook.tracker.ui.theme.AppTheme
 @Composable
 fun RemoveTraitFromFieldDialog(
     traitName: String,
+    isViewerMode: Boolean,
     onCancel: () -> Unit,
     onRemove: () -> Unit,
 ) {
+    val title = if (isViewerMode) R.string.traits_viewer_remove_from_field_title else R.string.traits_options_delete_title
+    val message = if (isViewerMode) R.string.traits_viewer_remove_from_field_message else R.string.traits_warning_delete
+    val confirmText = if (isViewerMode) R.string.dialog_remove else R.string.dialog_delete
+
     AppAlertDialog(
-        title = stringResource(R.string.traits_viewer_remove_from_field_title),
+        title = stringResource(title),
         content = {
             Column {
                 Row(
@@ -29,13 +34,13 @@ fun RemoveTraitFromFieldDialog(
                     modifier = Modifier.padding(bottom = 16.dp)
                 ) {
                     Text(
-                        text = stringResource(R.string.traits_viewer_remove_from_field_message, traitName),
+                        text = if (isViewerMode) stringResource(message, traitName) else stringResource(message),
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }
             }
         },
-        positiveButtonText = stringResource(R.string.dialog_remove),
+        positiveButtonText = stringResource(confirmText),
         positiveTextColor = AppTheme.colors.status.error,
         onPositive = onRemove,
         negativeButtonText = stringResource(R.string.dialog_cancel),

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/dialogs/SortOptionsDialog.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/dialogs/SortOptionsDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.fieldbook.tracker.R
+import com.fieldbook.tracker.database.viewmodels.TraitEditorViewModel.Companion.SORT_FIELD_DEFAULT
 import com.fieldbook.tracker.ui.dialogs.DialogOption
 import com.fieldbook.tracker.ui.dialogs.OptionsDialog
 import com.fieldbook.tracker.ui.theme.AppTheme
@@ -15,16 +16,26 @@ import com.fieldbook.tracker.ui.theme.AppTheme
 @Composable
 fun SortOptionsDialog(
     currentSortOrder: String,
+    isViewerMode: Boolean = false,
     onCancel: () -> Unit,
     onSortSelected: (String) -> Unit,
 ) {
-    val sortOptions = listOf(
-        "position" to stringResource(R.string.traits_sort_default),
+    // In viewer mode, "Default" maps to SORT_FIELD_DEFAULT ("follow main editor's sort").
+    // In editor mode, "Default" maps to "position" (DB order).
+    val defaultKey = if (isViewerMode) SORT_FIELD_DEFAULT else "position"
+
+    val sortOptions = mutableListOf(
+        defaultKey to stringResource(R.string.traits_sort_default),
         "observation_variable_name" to stringResource(R.string.traits_sort_name),
         "observation_variable_field_book_format" to stringResource(R.string.traits_sort_format),
         "internal_id_observation_variable" to stringResource(R.string.traits_sort_import_order),
-        "visible" to stringResource(R.string.traits_sort_visibility)
     )
+
+    if (isViewerMode) {
+        sortOptions.add(
+            "visible" to stringResource(R.string.traits_sort_visibility)
+        )
+    }
 
     var selectedOption by remember(currentSortOrder) { mutableStateOf(currentSortOrder) }
 

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/listItems/TraitListItem.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/listItems/TraitListItem.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -43,7 +42,6 @@ import sh.calvin.reorderable.ReorderableCollectionItemScope
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TraitListItem(
-    position: Int,
     trait: TraitObject,
     isSelected: Boolean = false,
     showVisibilityCheckbox: Boolean,
@@ -115,18 +113,6 @@ fun TraitListItem(
                 .fillMaxWidth()
                 .padding(horizontal = 12.dp, vertical = 10.dp)
         ) {
-            Text(
-                text = "$position",
-                modifier = Modifier.width(16.dp),
-                style = AppTheme.typography.subheadingStyle,
-                color = if (isSelected) AppTheme.colors.primary else AppTheme.colors.text.secondary,
-                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-
-            Spacer(modifier = Modifier.width(4.dp))
-
             if (showVisibilityCheckbox) {
                 // visibility checkbox
                 Checkbox(
@@ -225,7 +211,6 @@ private fun TraitListItemPreview() {
 
     AppTheme {
         TraitListItem(
-            position = 1,
             trait = traitObject,
             showVisibilityCheckbox = true,
             showRemoveAction = true,

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/listItems/TraitListItem.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/listItems/TraitListItem.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.rounded.DragHandle
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
@@ -105,7 +104,7 @@ fun TraitListItem(
         shape = RoundedCornerShape(12.dp),
         color = if (isSelected) AppTheme.colors.interactive.selectedItemBackground else AppTheme.colors.background,
         border = androidx.compose.foundation.BorderStroke(
-            if (isSelected) 1.dp else 0.dp,
+            1.dp,
             if (isSelected) AppTheme.colors.primary else AppTheme.colors.surface.border
         ),
         shadowElevation = 0.dp

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/listItems/TraitListItem.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/listItems/TraitListItem.kt
@@ -1,30 +1,36 @@
 package com.fieldbook.tracker.ui.screens.traits.listItems
 
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.rounded.DragHandle
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -38,9 +44,17 @@ import sh.calvin.reorderable.ReorderableCollectionItemScope
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TraitListItem(
+    position: Int,
     trait: TraitObject,
+    isSelected: Boolean = false,
+    showVisibilityCheckbox: Boolean,
+    showRemoveAction: Boolean,
+    showDragHandle: Boolean,
     onClick: () -> Unit,
+    onLongClick: () -> Unit = {},
     onToggleVisibility: (Boolean) -> Unit,
+    onRemove: () -> Unit,
+    isDragging: Boolean = false,
     isAnyItemDragging: Boolean = false, // used disable interactions when something is being dragged
     reorderableScope: ReorderableCollectionItemScope? = null,
     modifier: Modifier = Modifier,
@@ -49,22 +63,24 @@ fun TraitListItem(
 
     val interactionSource = remember { MutableInteractionSource() }
 
-    Box (
+    val elevation by animateDpAsState(if (isDragging) 6.dp else 0.dp, label = "elevation")
+    val scale by animateFloatAsState(if (isDragging) 1.02f else 1f, label = "scale")
+
+    Surface(
         modifier = modifier
             .fillMaxWidth()
-            .background(
-                color = AppTheme.colors.background,
-                shape = RoundedCornerShape(5.dp)
-            )
-            .border(
-                width = 1.dp,
-                color = AppTheme.colors.surface.border,
-                shape = RoundedCornerShape(5.dp)
-            )
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+                alpha = if (isDragging) 0.95f else 1f
+                shadowElevation = elevation.toPx()
+                shape = RoundedCornerShape(12.dp)
+                clip = true
+            }
             .then(
-                if (reorderableScope != null) {
+                if (reorderableScope != null && !showDragHandle) {
                     with(reorderableScope) {
-                        Modifier.longPressDraggableHandle( // reorder only on long press
+                        Modifier.longPressDraggableHandle( // reorder only on long press if no handle
                             onDragStarted = {
                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                             },
@@ -76,30 +92,57 @@ fun TraitListItem(
                     }
                 } else Modifier
             )
-            .clickable(
+            .combinedClickable(
                 onClick = onClick,
+                onLongClick = {
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                    onLongClick()
+                },
                 interactionSource = interactionSource,
+                indication = androidx.compose.material3.ripple(),
                 enabled = !isAnyItemDragging
-            )
+            ),
+        shape = RoundedCornerShape(12.dp),
+        color = if (isSelected) AppTheme.colors.interactive.selectedItemBackground else AppTheme.colors.background,
+        border = androidx.compose.foundation.BorderStroke(
+            if (isSelected) 1.dp else 0.dp,
+            if (isSelected) AppTheme.colors.primary else AppTheme.colors.surface.border
+        ),
+        shadowElevation = 0.dp
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 10.dp)
         ) {
-            
-            // visibility checkbox
-            Checkbox(
-                checked = trait.visible,
-                onCheckedChange = if (isAnyItemDragging) { _ -> } else onToggleVisibility,
-                enabled = !isAnyItemDragging,
-                colors = CheckboxDefaults.colors(
-                    checkedColor = AppTheme.colors.accent,
-                    uncheckedColor = AppTheme.colors.accent,
-                    checkmarkColor = AppTheme.colors.background,
-                )
+            Text(
+                text = "$position",
+                modifier = Modifier.width(16.dp),
+                style = AppTheme.typography.subheadingStyle,
+                color = if (isSelected) AppTheme.colors.primary else AppTheme.colors.text.secondary,
+                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
 
-            Spacer(modifier = Modifier.width(5.dp))
+            Spacer(modifier = Modifier.width(4.dp))
+
+            if (showVisibilityCheckbox) {
+                // visibility checkbox
+                Checkbox(
+                    checked = trait.visible,
+                    onCheckedChange = { onToggleVisibility(it) },
+                    enabled = !isAnyItemDragging,
+                    colors = CheckboxDefaults.colors(
+                        checkedColor = AppTheme.colors.accent,
+                        uncheckedColor = AppTheme.colors.accent,
+                        checkmarkColor = AppTheme.colors.background,
+                    )
+                )
+
+                Spacer(modifier = Modifier.width(2.dp))
+            }
 
             // format icon
             val formatEnum = Formats.entries.find { it.getDatabaseName() == trait.format }
@@ -111,26 +154,62 @@ fun TraitListItem(
 
             Spacer(modifier = Modifier.width(15.dp))
 
-            // trait alias
-            Text(
-                text = trait.alias,
-                style = AppTheme.typography.bodyStyle,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = trait.alias,
+                    style = AppTheme.typography.bodyStyle,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
 
-            // drag button
-            IconButton(
-                onClick = { },
-                enabled = !isAnyItemDragging
-            ) {
-                Icon(
-                    Icons.Rounded.DragHandle,
-                    contentDescription = null,
-                    tint = AppTheme.colors.surface.iconTint
+                Text(
+                    text = trait.format,
+                    style = AppTheme.typography.subheadingStyle,
+                    color = AppTheme.colors.text.secondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
+
+            if (showDragHandle) {
+                // drag button
+                IconButton(
+                    onClick = { },
+                    enabled = !isAnyItemDragging,
+                    modifier = if (reorderableScope != null) {
+                        with(reorderableScope) {
+                            Modifier.longPressDraggableHandle(
+                                onDragStarted = {
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                },
+                                onDragStopped = {
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                },
+                                interactionSource = interactionSource
+                            )
+                        }
+                    } else Modifier
+                ) {
+                    Icon(
+                        Icons.Rounded.DragHandle,
+                        contentDescription = null,
+                        tint = if (isDragging) AppTheme.colors.primary else AppTheme.colors.surface.iconTint
+                    )
+                }
+            }
+
+//            if (showRemoveAction) {
+//                IconButton(
+//                    onClick = onRemove,
+//                    enabled = !isAnyItemDragging
+//                ) {
+//                    Icon(
+//                        imageVector = Icons.Filled.Close,
+//                        contentDescription = null,
+//                        tint = AppTheme.colors.surface.iconTint
+//                    )
+//                }
+//            }
         }
     }
 }
@@ -147,9 +226,14 @@ private fun TraitListItemPreview() {
 
     AppTheme {
         TraitListItem(
+            position = 1,
             trait = traitObject,
+            showVisibilityCheckbox = true,
+            showRemoveAction = true,
+            showDragHandle = true,
             onClick = { },
             onToggleVisibility = { },
+            onRemove = { },
         )
     }
 }

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/lists/TraitList.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/lists/TraitList.kt
@@ -31,9 +31,9 @@ fun TraitList(
     onRemoveTrait: (TraitObject) -> Unit,
     onMoveItem: (Int, Int) -> Unit,
     onDragStateChanged: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    lazyListState: androidx.compose.foundation.lazy.LazyListState = rememberLazyListState()
 ) {
-    val lazyListState = rememberLazyListState()
     val state = rememberReorderableLazyListState(lazyListState) { from, to ->
         onMoveItem(from.index, to.index)
     }

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/lists/TraitList.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/lists/TraitList.kt
@@ -59,7 +59,6 @@ fun TraitList(
             if (allowReorder) {
                 ReorderableItem(state, key = trait.id) { isDragging ->
                     TraitListItem(
-                        position = index + 1,
                         trait = trait,
                         isSelected = isSelected,
                         showVisibilityCheckbox = showVisibilityControls,
@@ -76,7 +75,6 @@ fun TraitList(
                 }
             } else {
                 TraitListItem(
-                    position = index + 1,
                     trait = trait,
                     isSelected = isSelected,
                     showVisibilityCheckbox = showVisibilityControls,

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/lists/TraitList.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/lists/TraitList.kt
@@ -1,5 +1,6 @@
 package com.fieldbook.tracker.ui.screens.traits.lists
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -20,8 +21,14 @@ import sh.calvin.reorderable.rememberReorderableLazyListState
 @Composable
 fun TraitList(
     traits: List<TraitObject>,
+    selectedTraitIds: Set<String> = emptySet(),
+    showVisibilityControls: Boolean,
+    showRemoveAction: Boolean,
+    allowReorder: Boolean,
     onTraitClick: (String) -> Unit,
+    onTraitLongClick: (String) -> Unit = {},
     onToggleVisibility: (TraitObject, Boolean) -> Unit,
+    onRemoveTrait: (TraitObject) -> Unit,
     onMoveItem: (Int, Int) -> Unit,
     onDragStateChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier
@@ -31,27 +38,56 @@ fun TraitList(
         onMoveItem(from.index, to.index)
     }
 
+    // Track drag lifecycle once at list-level so commit is always triggered when dragging ends.
+    LaunchedEffect(state.isAnyItemDragging) {
+        onDragStateChanged(state.isAnyItemDragging)
+    }
+
     LazyColumn(
         state = lazyListState,
-        modifier = modifier,
-        contentPadding = PaddingValues(4.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        modifier = modifier.animateContentSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         items(
             count = traits.size,
             key = { index -> traits[index].id }
         ) { index ->
             val trait = traits[index]
-            ReorderableItem(state, key = trait.id) { isDragging ->
-                LaunchedEffect(isDragging) {
-                    onDragStateChanged(isDragging)
+            val isSelected = trait.id in selectedTraitIds
+            
+            if (allowReorder) {
+                ReorderableItem(state, key = trait.id) { isDragging ->
+                    TraitListItem(
+                        position = index + 1,
+                        trait = trait,
+                        isSelected = isSelected,
+                        showVisibilityCheckbox = showVisibilityControls,
+                        showRemoveAction = showRemoveAction,
+                        showDragHandle = true,
+                        onClick = { onTraitClick(trait.id) },
+                        onLongClick = { onTraitLongClick(trait.id) },
+                        onToggleVisibility = { isVisible -> onToggleVisibility(trait, isVisible) },
+                        onRemove = { onRemoveTrait(trait) },
+                        isDragging = isDragging,
+                        reorderableScope = this@ReorderableItem,
+                        isAnyItemDragging = state.isAnyItemDragging,
+                    )
                 }
+            } else {
                 TraitListItem(
+                    position = index + 1,
                     trait = trait,
+                    isSelected = isSelected,
+                    showVisibilityCheckbox = showVisibilityControls,
+                    showRemoveAction = showRemoveAction,
+                    showDragHandle = false,
                     onClick = { onTraitClick(trait.id) },
+                    onLongClick = { onTraitLongClick(trait.id) },
                     onToggleVisibility = { isVisible -> onToggleVisibility(trait, isVisible) },
-                    reorderableScope = this@ReorderableItem,
-                    isAnyItemDragging = state.isAnyItemDragging,
+                    onRemove = { onRemoveTrait(trait) },
+                    reorderableScope = null,
+                    isAnyItemDragging = false,
                 )
             }
         }
@@ -80,8 +116,12 @@ private fun TraitListPreview() {
         Box(modifier = Modifier.fillMaxHeight()) {
             TraitList(
                 traits = traitList,
+                showVisibilityControls = true,
+                showRemoveAction = true,
+                allowReorder = true,
                 onTraitClick = { },
                 onToggleVisibility = { _, _ -> },
+                onRemoveTrait = { },
                 onMoveItem = { _, _ -> },
                 onDragStateChanged = { },
                 modifier = Modifier,

--- a/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/toolbars/TraitEditorToolbar.kt
+++ b/app/src/main/java/com/fieldbook/tracker/ui/screens/traits/toolbars/TraitEditorToolbar.kt
@@ -1,8 +1,11 @@
 package com.fieldbook.tracker.ui.screens.traits.toolbars
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.FileDownload
+import androidx.compose.material.icons.filled.SelectAll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
@@ -20,13 +23,57 @@ import com.fieldbook.tracker.ui.theme.AppTheme
 @Composable
 fun TraitEditorToolbar(
     hasTraits: Boolean,
+    isViewerMode: Boolean,
     isTutorialEnabled: Boolean,
+    isSelectionMode: Boolean = false,
+    selectedCount: Int = 0,
     onBack: () -> Unit,
     onToggleAllTraits: () -> Unit,
+    onSyncWithMainList: () -> Unit,
     onShowDialog: (TraitActivityDialog) -> Unit,
-    onRequestExportPermission: () -> Unit
+    onRequestExportPermission: () -> Unit,
+    onClearSelection: () -> Unit = {},
+    onSelectAll: () -> Unit = {},
+    onRemoveSelected: () -> Unit = {},
+    onToggleVisibilitySelected: () -> Unit = {}
 ) {
-
+    if (isSelectionMode) {
+        AppBar(
+            title = stringResource(R.string.selected_count, selectedCount),
+            navigationIcon = {
+                IconButton(onClick = onClearSelection) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.dialog_cancel)
+                    )
+                }
+            },
+            actions = listOf(
+                TopAppBarAction(
+                    title = stringResource(R.string.fields_select_all),
+                    icon = Icons.Default.SelectAll,
+                    onClick = onSelectAll,
+                    displayMode = ActionDisplayMode.ALWAYS,
+                    contentDescription = stringResource(R.string.fields_select_all)
+                ),
+                TopAppBarAction(
+                    title = stringResource(R.string.traits_sort_visibility),
+                    icon = Icons.Default.Check,
+                    onClick = onToggleVisibilitySelected,
+                    displayMode = ActionDisplayMode.ALWAYS,
+                    contentDescription = stringResource(R.string.traits_sort_visibility)
+                ),
+                TopAppBarAction(
+                    title = stringResource(R.string.dialog_delete),
+                    icon = Icons.Default.Delete,
+                    onClick = onRemoveSelected,
+                    displayMode = ActionDisplayMode.ALWAYS,
+                    contentDescription = stringResource(R.string.dialog_delete)
+                )
+            )
+        )
+        return
+    }
 
     val appBarActions = buildList {
         // if (isTutorialEnabled) {
@@ -44,24 +91,51 @@ fun TraitEditorToolbar(
         // }
 
         if (hasTraits) {
-            addAll(
-                listOf(
+            if (isViewerMode) {
+                add(
                     TopAppBarAction(
                         title = stringResource(R.string.traits_sort_visibility),
                         contentDescription = stringResource(R.string.traits_sort_visibility),
                         icon = R.drawable.ic_tb_toggle_all,
                         displayMode = ActionDisplayMode.ALWAYS,
                         onClick = onToggleAllTraits
-                    ),
+                    )
+                )
+            }
+
+            add(
+                TopAppBarAction(
+                    title = stringResource(R.string.traits_toolbar_sort),
+                    contentDescription = stringResource(R.string.traits_toolbar_sort),
+                    icon = R.drawable.ic_sort,
+                    displayMode = ActionDisplayMode.ALWAYS,
+                    onClick = {
+                        onShowDialog(TraitActivityDialog.SortTraits)
+                    }
+                )
+            )
+
+            if (isViewerMode) {
+                add(
                     TopAppBarAction(
-                        title = stringResource(R.string.traits_toolbar_sort),
-                        contentDescription = stringResource(R.string.traits_toolbar_sort),
-                        icon = R.drawable.ic_sort,
-                        displayMode = ActionDisplayMode.ALWAYS,
-                        onClick = {
-                            onShowDialog(TraitActivityDialog.SortTraits)
-                        }
-                    ),
+                        title = stringResource(R.string.traits_toolbar_sync_with_main_list),
+                        contentDescription = stringResource(R.string.traits_toolbar_sync_with_main_list),
+                        icon = R.drawable.ic_field_sync,
+                        displayMode = ActionDisplayMode.IF_ROOM,
+                        onClick = onSyncWithMainList
+                    )
+                )
+                add(
+                    TopAppBarAction(
+                        title = stringResource(R.string.traits_dialog_export),
+                        contentDescription = stringResource(R.string.traits_dialog_export),
+                        icon = Icons.Filled.FileDownload,
+                        displayMode = ActionDisplayMode.IF_ROOM,
+                        onClick = onRequestExportPermission
+                    )
+                )
+            } else {
+                add(
                     TopAppBarAction(
                         title = stringResource(R.string.traits_toolbar_delete_all),
                         contentDescription = stringResource(R.string.traits_toolbar_delete_all),
@@ -70,22 +144,24 @@ fun TraitEditorToolbar(
                         onClick = {
                             onShowDialog(TraitActivityDialog.DeleteAll(DialogTriggerSource.TOOLBAR))
                         }
-                    ),
+                    )
+                )
+                add(
                     TopAppBarAction(
                         title = stringResource(R.string.traits_dialog_export),
                         contentDescription = stringResource(R.string.traits_dialog_export),
                         icon = Icons.Filled.FileDownload,
                         displayMode = ActionDisplayMode.IF_ROOM,
                         onClick = onRequestExportPermission
-                    ),
+                    )
                 )
-            )
+            }
         }
     }
 
 
     AppBar(
-        title = stringResource(R.string.settings_traits),
+        title = if (isViewerMode) stringResource(R.string.field_detail_manage_traits) else stringResource(R.string.settings_traits),
         navigationIcon = {
             IconButton(onClick = onBack) {
                 Icon(
@@ -104,9 +180,11 @@ private fun TraitEditorToolbarPreview() {
     AppTheme {
         TraitEditorToolbar(
             hasTraits = true,
+            isViewerMode = false,
             isTutorialEnabled = true,
             onBack = { },
             onToggleAllTraits = { },
+            onSyncWithMainList = { },
             onShowDialog = { },
             onRequestExportPermission = { },
         )

--- a/app/src/main/java/com/fieldbook/tracker/utilities/CameraXFacade.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/CameraXFacade.kt
@@ -221,8 +221,7 @@ class CameraXFacade @Inject constructor(@param:ActivityContext private val conte
         }
 
         //parse crop from prefs
-        val cropCoordinates = (context as? ThemedActivity)?.prefs?.getString(GeneralKeys.getCropCoordinatesKey(
-            traitId?.toInt() ?: -1), "")
+        val cropCoordinates = (context as? ThemedActivity)?.prefs?.getString(GeneralKeys.getCropCoordinatesKey(traitId), "")
 
         // If crop coordinates are valid, add a drawable to the PreviewView overlay that dims outside the crop rect
         if (showCropRegion && !cropCoordinates.isNullOrEmpty() && cropCoordinates != CropImageView.DEFAULT_CROP_COORDINATES && previewView != null) {
@@ -322,8 +321,7 @@ class CameraXFacade @Inject constructor(@param:ActivityContext private val conte
             Log.w(TAG, "Error removing previous crop drawable: ${e.message}")
         }
 
-        val cropCoordinates = (context as? ThemedActivity)?.prefs?.getString(GeneralKeys.getCropCoordinatesKey(
-            traitId?.toInt() ?: -1), "")
+        val cropCoordinates = (context as? ThemedActivity)?.prefs?.getString(GeneralKeys.getCropCoordinatesKey(traitId), "")
 
         if (showCropRegion && !cropCoordinates.isNullOrEmpty() && cropCoordinates != CropImageView.DEFAULT_CROP_COORDINATES && previewView != null) {
             val rect = CropImageView.parseRectCoordinates(cropCoordinates)

--- a/app/src/main/java/com/fieldbook/tracker/utilities/export/ExportUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/export/ExportUtil.kt
@@ -259,19 +259,6 @@ class ExportUtil @Inject constructor(
             BaseDocumentTreeUtil.getDirectory(context as Activity, R.string.dir_field_export)
 
             exportTrait.clear()
-            if (isActiveTraitsChecked) {
-                val traits = database.allTraitObjects
-                for (t in traits) {
-                    if (t.visible) {
-                        exportTrait.add(t)
-                    }
-                }
-            }
-
-            if (isAllTraitsChecked) {
-                exportTrait.addAll(database.allTraitObjects)
-            }
-
             checkDbBool = checkDB.isChecked
             checkTableBool = checkTable.isChecked
             exportFileString = fileName.text.toString()
@@ -346,6 +333,14 @@ class ExportUtil @Inject constructor(
             Log.d(TAG, "Export task started for fieldId: $fieldId")
             val bundleChecked = preferences.getBoolean(GeneralKeys.DIALOG_EXPORT_BUNDLE_CHECKED, false)
             val fo = database.getFieldObject(fieldId)
+
+            val isActiveTraitsChecked = preferences.getBoolean(GeneralKeys.EXPORT_TRAITS_ACTIVE, false)
+            exportTrait = if (isActiveTraitsChecked) {
+                database.getVisibleTraitsForStudy(fieldId)
+            } else {
+                database.allTraitObjects
+            }
+
             var fieldFileString = exportFileString
             if (multipleFields) { fieldFileString = "${timeStamp.format(Calendar.getInstance().time)}_${fo.name}" }
 
@@ -473,15 +468,15 @@ class ExportUtil @Inject constructor(
     }
 
     private fun countMediaFiles(fields: List<FieldObject>, useActiveTraits: Boolean): Int {
-        val traits = database.allTraitObjects
-        val traitNames = if (useActiveTraits) {
-            traits.filter { it.visible }.map { FileUtil.sanitizeFileName(it.name) }
-        } else {
-            traits.map { FileUtil.sanitizeFileName(it.name) }
-        }
-
         var count = 0
         for (field in fields) {
+            val traits = if (useActiveTraits) {
+                database.getVisibleTraitsForStudy(field.studyId)
+            } else {
+                database.allTraitObjects
+            }
+            val traitNames = traits.map { FileUtil.sanitizeFileName(it.name) }
+
             val mediaDir = BaseDocumentTreeUtil.getFile(context, R.string.dir_plot_data, field.name)
             if (mediaDir != null && mediaDir.exists() && mediaDir.isDirectory) {
                 mediaDir.listFiles().forEach { traitDir ->

--- a/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/TraitBoxView.kt
@@ -267,7 +267,10 @@ class TraitBoxView : ConstraintLayout {
                 R.string.edit_traits
             ) {
                     _: DialogInterface, _: Int ->
-                    val intent = Intent(context, TraitActivity::class.java)
+                    val intent = Intent(context, TraitActivity::class.java).apply {
+                        putExtra(TraitActivity.EXTRA_MODE, TraitActivity.MODE_VIEWER)
+                        putExtra(TraitActivity.EXTRA_STUDY_ID, studyId)
+                    }
                     startActivity(context, intent, null)
             }
         val dialog = builder.create()

--- a/app/src/main/res/layout/fragment_field_detail.xml
+++ b/app/src/main/res/layout/fragment_field_detail.xml
@@ -282,6 +282,120 @@
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cardViewTraits"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            app:cardElevation="4dp"
+            app:strokeColor="@android:color/transparent"
+            app:cardBackgroundColor="@color/main_color_background">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingTop="12dp"
+                android:paddingBottom="8dp">
+
+                <!-- Tappable header row — navigates to TraitActivity -->
+                <LinearLayout
+                    android:id="@+id/traitsCardHeader"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <ImageView
+                        android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        android:layout_margin="8dp"
+                        android:src="@drawable/ic_ruler" />
+
+                    <TextView
+                        style="@style/TextViewStyle.Bold.Title"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginEnd="8dp"
+                        android:text="@string/field_detail_manage_traits" />
+
+                    <ImageView
+                        android:layout_width="30dp"
+                        android:layout_height="30dp"
+                        android:src="@drawable/ic_chevron_right" />
+
+                </LinearLayout>
+
+                <!-- Summary / expanded toggle row -->
+                <LinearLayout
+                    android:id="@+id/traitsIconsRow"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingStart="8dp"
+                    android:paddingEnd="8dp"
+                    android:paddingTop="4dp"
+                    android:paddingBottom="4dp"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:foreground="?attr/selectableItemBackground">
+
+                    <!-- Expand/collapse arrow — left of the icon list -->
+                    <ImageView
+                        android:id="@+id/traitsExpandCollapseIcon"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_marginEnd="6dp"
+                        android:src="@drawable/ic_chevron_down"
+                        android:visibility="gone" />
+
+                    <!-- Centered scrollable format-icon row (hidden when expanded) -->
+                    <HorizontalScrollView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:scrollbars="none">
+
+                        <LinearLayout
+                            android:id="@+id/traitIconsContainer"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            android:gravity="center" />
+
+                    </HorizontalScrollView>
+
+                    <TextView
+                        android:id="@+id/traitsNoneTextView"
+                        style="@style/TextViewStyle.Sub"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:gravity="center"
+                        android:visibility="gone"
+                        android:text="@string/field_detail_traits_none" />
+
+                </LinearLayout>
+
+                <!-- Expanded: trait list with icon + name -->
+                <LinearLayout
+                    android:id="@+id/traitsExpandedContent"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingStart="46dp"
+                    android:paddingEnd="8dp"
+                    android:paddingBottom="4dp"
+                    android:visibility="gone" />
+
+            </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
         <!-- Export Card -->
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/cardViewExport"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1986,4 +1986,18 @@
     <string name="view_trait_innospectra_na">N/A</string>
     <string name="unknown">Unknown</string>
 
+    <string name="field_detail_manage_traits">Traits</string>
+    <string name="field_detail_traits_none">No traits</string>
+    <string name="traits_viewer_add_to_field">Add Traits to Field</string>
+    <string name="traits_viewer_no_available_traits">No additional traits are available to add.</string>
+    <string name="traits_viewer_add_selected">Add Selected</string>
+    <string name="traits_viewer_create_new_trait">Create New Trait</string>
+    <string name="traits_viewer_added_count">Added %1$d trait(s) to this field</string>
+    <string name="traits_viewer_removed_trait">Removed trait from this field</string>
+    <string name="traits_viewer_synced_with_main_list">Synced field traits with main list</string>
+    <string name="traits_toolbar_sync_with_main_list">Sync with main list</string>
+    <string name="traits_viewer_remove_from_field_title">Remove Trait</string>
+    <string name="traits_viewer_remove_from_field_message">Remove %1$s from this field list?</string>
+    <string name="dialog_remove">Remove</string>
+    <string name="search_hint">search</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1991,7 +1991,7 @@
     <string name="traits_viewer_add_to_field">Add Traits to Field</string>
     <string name="traits_viewer_no_available_traits">No additional traits are available to add.</string>
     <string name="traits_viewer_add_selected">Add Selected</string>
-    <string name="traits_viewer_create_new_trait">Create New Trait</string>
+    <string name="traits_viewer_create_new_trait">Trait Picker</string>
     <string name="traits_viewer_added_count">Added %1$d trait(s) to this field</string>
     <string name="traits_viewer_removed_trait">Removed trait from this field</string>
     <string name="traits_viewer_synced_with_main_list">Synced field traits with main list</string>


### PR DESCRIPTION
field dependent trait lists

closes #271 



### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [x] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note

```