### PR TITLE
fix jpeg saving

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -2351,10 +2351,11 @@ public class CollectActivity extends ThemedActivity
                     if (currentTrait != null) {
                         BaseTraitLayout traitPhoto = traitLayouts.getTraitLayout(currentTrait.getFormat());
                         if (traitPhoto instanceof PhotoTraitLayout) {
-                            ((PhotoTraitLayout) traitPhoto).makeImage(currentTrait);
+                            boolean saved = ((PhotoTraitLayout) traitPhoto).makeImage(currentTrait);
+                            triggerTts(saved ? success : fail);
+                        } else {
+                            triggerTts(success);
                         }
-
-                        triggerTts(success);
                     }
 
                 } else triggerTts(fail);

--- a/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.kt
@@ -2,11 +2,13 @@ package com.fieldbook.tracker.traits
 
 import android.app.Activity
 import android.app.AlertDialog
+import android.content.ClipData
 import android.content.Context
 import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import android.provider.MediaStore
+import android.util.Log
 import android.util.AttributeSet
 import android.util.Size
 import androidx.annotation.OptIn
@@ -338,6 +340,11 @@ open class PhotoTraitLayout : CameraTrait {
 
         val file = File(context.cacheDir, TEMPORARY_IMAGE_NAME)
 
+        if (!file.exists() || file.length() == 0L) {
+            Log.e(TAG, "makeImage: temp file is missing or empty — camera may not have written to the output URI")
+            return
+        }
+
         file.inputStream().use { stream ->
 
             val data = stream.readBytes()
@@ -370,6 +377,10 @@ open class PhotoTraitLayout : CameraTrait {
         // Ensure that there's a camera activity to handle the intent
         if (takePictureIntent.resolveActivity(context.packageManager) != null) {
             takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
+            // Required on Android 7.0+ so the camera app can write to the FileProvider URI.
+            // Without this the camera silently fails to save and returns RESULT_OK with an empty file.
+            takePictureIntent.clipData = ClipData.newRawUri("", uri)
+            takePictureIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
             (context as Activity).startActivityForResult(
                 takePictureIntent,
                 PICTURE_REQUEST_CODE

--- a/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PhotoTraitLayout.kt
@@ -336,13 +336,13 @@ open class PhotoTraitLayout : CameraTrait {
         bindCameraForInformation()
     }
 
-    fun makeImage(currentTrait: TraitObject) {
+    fun makeImage(currentTrait: TraitObject): Boolean {
 
         val file = File(context.cacheDir, TEMPORARY_IMAGE_NAME)
 
         if (!file.exists() || file.length() == 0L) {
             Log.e(TAG, "makeImage: temp file is missing or empty — camera may not have written to the output URI")
-            return
+            return false
         }
 
         file.inputStream().use { stream ->
@@ -357,6 +357,8 @@ open class PhotoTraitLayout : CameraTrait {
                 SaveState.SINGLE_SHOT
             )
         }
+
+        return true
     }
 
     /**
@@ -367,6 +369,7 @@ open class PhotoTraitLayout : CameraTrait {
 
         val file = File(context.cacheDir, TEMPORARY_IMAGE_NAME)
 
+        file.delete()
         file.createNewFile()
 
         val uri =

--- a/app/src/main/java/com/fieldbook/tracker/utilities/CameraXFacade.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/CameraXFacade.kt
@@ -279,6 +279,7 @@ class CameraXFacade @Inject constructor(@param:ActivityContext private val conte
             onBind.invoke(camera, executor, imageCapture)
         } catch (e: Exception) {
             Log.e(TAG, "bindPreview: failed to bind camera lifecycle", e)
+            throw e
         }
     }
 
@@ -372,15 +373,20 @@ class CameraXFacade @Inject constructor(@param:ActivityContext private val conte
 
         val useCaseGroup = useCaseGroupBuilder.build()
 
-        val camera = cameraXInstance.get().bindToLifecycle(
-            context as LifecycleOwner,
-            currentSelector,
-            useCaseGroup
-        )
+        try {
+            val camera = cameraXInstance.get().bindToLifecycle(
+                context as LifecycleOwner,
+                currentSelector,
+                useCaseGroup
+            )
 
-        Log.d(TAG, "Camera lifecycle bound for video: ${camera.cameraInfo}")
+            Log.d(TAG, "Camera lifecycle bound for video: ${camera.cameraInfo}")
 
-        onBind.invoke(camera, executor, videoCapture)
+            onBind.invoke(camera, executor, videoCapture)
+        } catch (e: Exception) {
+            Log.e(TAG, "bindPreviewForVideo: failed to bind camera lifecycle", e)
+            throw e
+        }
     }
 
     // Drawable that dims the area outside of a normalized crop rect (values 0..1)

--- a/app/src/main/java/com/fieldbook/tracker/utilities/CameraXFacade.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/CameraXFacade.kt
@@ -267,15 +267,19 @@ class CameraXFacade @Inject constructor(@param:ActivityContext private val conte
 
         val useCaseGroup = useCaseGroupBuilder.build()
 
-        val camera = cameraXInstance.get().bindToLifecycle(
-            context as LifecycleOwner,
-            currentSelector,
-            useCaseGroup
-        )
+        try {
+            val camera = cameraXInstance.get().bindToLifecycle(
+                context as LifecycleOwner,
+                currentSelector,
+                useCaseGroup
+            )
 
-        Log.d(TAG, "Camera lifecycle bound: ${camera.cameraInfo}")
+            Log.d(TAG, "Camera lifecycle bound: ${camera.cameraInfo}")
 
-        onBind.invoke(camera, executor, imageCapture)
+            onBind.invoke(camera, executor, imageCapture)
+        } catch (e: Exception) {
+            Log.e(TAG, "bindPreview: failed to bind camera lifecycle", e)
+        }
     }
 
     @OptIn(ExperimentalGetImage::class)

--- a/app/src/main/java/com/fieldbook/tracker/utilities/ExifUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/ExifUtil.kt
@@ -48,8 +48,11 @@ class ExifUtil {
                 exif.saveAttributes()
 
                 // Write the corrected file back, truncating any previous content
-                context.contentResolver.openOutputStream(uri, "wt")?.use { output ->
-                    tempFile.inputStream().use { input -> input.copyTo(output) }
+                val out = context.contentResolver.openOutputStream(uri, "wt")
+                if (out != null) {
+                    out.use { output -> tempFile.inputStream().use { input -> input.copyTo(output) } }
+                } else {
+                    Log.e(PhotoTraitLayout.TAG, "saveStringToExif: openOutputStream returned null, EXIF not written back")
                 }
 
             } catch (e: Exception) {

--- a/app/src/main/java/com/fieldbook/tracker/utilities/ExifUtil.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/ExifUtil.kt
@@ -13,6 +13,8 @@ import com.fieldbook.tracker.traits.PhotoTraitLayout
 import com.google.common.reflect.TypeToken
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import java.io.File
+import java.io.FileOutputStream
 
 /**
  * Utility class for handling ExifInterface on images.
@@ -24,45 +26,30 @@ class ExifUtil {
 
         inline fun <reified T> saveJsonToExif(context: Context, model: T, uri: Uri) {
 
-            try {
-
-                context.contentResolver.openFileDescriptor(uri, "rw").use { fd ->
-
-                    fd?.let { desc ->
-
-                        val exif = ExifInterface(desc.fileDescriptor)
-
-                        val gson = Gson().toJson(
-                            model,
-                            object : TypeToken<T>() {}.type
-                        )
-
-                        exif.setAttribute(ExifInterface.TAG_USER_COMMENT, gson.toString())
-                        exif.saveAttributes()
-                    }
-                }
-
-            } catch (e: Exception) {
-
-                e.printStackTrace()
-
-                Log.d(PhotoTraitLayout.TAG, "EXIF data failed to write.")
-            }
+            val gson = Gson().toJson(model, object : TypeToken<T>() {}.type)
+            saveStringToExif(context, gson.toString(), uri)
         }
 
         fun saveStringToExif(context: Context, data: String, uri: Uri) {
 
+            // ExifInterface(FileDescriptor).saveAttributes() has a bug on some Android versions
+            // where it writes an incorrect APP1 segment length and re-includes the original JPEG's
+            // SOI byte, producing a corrupt file. Using a temp-file path avoids this bug.
+            val tempFile = File(context.cacheDir, "exif_edit_${System.currentTimeMillis()}.jpg")
+
             try {
 
-                context.contentResolver.openFileDescriptor(uri, "rw").use { fd ->
+                context.contentResolver.openInputStream(uri)?.use { input ->
+                    FileOutputStream(tempFile).use { output -> input.copyTo(output) }
+                } ?: return
 
-                    fd?.let { desc ->
+                val exif = ExifInterface(tempFile.absolutePath)
+                exif.setAttribute(ExifInterface.TAG_USER_COMMENT, data)
+                exif.saveAttributes()
 
-                        val exif = ExifInterface(desc.fileDescriptor)
-
-                        exif.setAttribute(ExifInterface.TAG_USER_COMMENT, data)
-                        exif.saveAttributes()
-                    }
+                // Write the corrected file back, truncating any previous content
+                context.contentResolver.openOutputStream(uri, "wt")?.use { output ->
+                    tempFile.inputStream().use { input -> input.copyTo(output) }
                 }
 
             } catch (e: Exception) {
@@ -70,6 +57,10 @@ class ExifUtil {
                 e.printStackTrace()
 
                 Log.d(PhotoTraitLayout.TAG, "EXIF data failed to write.")
+
+            } finally {
+
+                tempFile.delete()
             }
         }
 


### PR DESCRIPTION
### Description

Fixed corrupt photos caused by `ExifInterface(FileDescriptor).saveAttributes()` miswriting the JPEG APP1 length on Samsung devices. Now uses a temp-file path instead. Also added minor defensive improvements to camera intent permissions and error handling.


### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Photos are no longer corrupted on certain Samsung devices
```