### PR TITLE
Fix categorical traits

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/traits/CategoricalTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/CategoricalTraitLayout.java
@@ -137,12 +137,19 @@ public class CategoricalTraitLayout extends BaseTraitLayout {
     @Override
     public void afterLoadNotExists(CollectActivity act) {
         super.afterLoadNotExists(act);
+        if (isMulticatEnabled()) {
+            categoryList = new ArrayList<>();
+        }
         setAdapter();
     }
 
     @Override
     public void afterLoadDefault(CollectActivity act) {
         super.afterLoadDefault(act);
+        if (isMulticatEnabled()) {
+            categoryList = new ArrayList<>();
+            loadMulticatScale();
+        }
         setAdapter();
     }
 


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

Closes #1497 

Categorical selections do not carry over when navigating between plots/traits

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Categorical traits with multiple categories selected now correctly reset
```