### PR TITLE
hide entry arrows setting

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -1388,6 +1388,9 @@ public class CollectActivity extends ThemedActivity
             systemMenu.findItem(R.id.datagrid).setVisible(preferences.getBoolean(PreferenceKeys.DATAGRID_SETTING, false));
         }
 
+        // apply the appearance preference in case it was changed in settings
+        rangeBox.updateRangeBoxVisibility();
+
         refreshInfoBarAdapter();
 
         // If reload data is true, it means there was an import operation, and

--- a/app/src/main/java/com/fieldbook/tracker/preferences/PreferenceKeys.kt
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/PreferenceKeys.kt
@@ -31,6 +31,7 @@ class PreferenceKeys {
         const val TOOLBAR_CUSTOMIZE = "TOOLBAR_CUSTOMIZE"
         const val INFOBAR_NUMBER = "INFOBAR_NUMBER"
         const val HIDE_INFOBAR_PREFIX = "HIDE_INFOBAR_PREFIX"
+        const val HIDE_ENTRY_NAVIGATION = "HIDE_ENTRY_NAVIGATION"
         const val QUICK_GOTO = "QuickGoTo"
         const val RANGE_PROGRESS_BAR = "RANGE_PROGRESS_BAR"
         const val TRAITS_PROGRESS_BAR = "TRAITS_PROGRESS_BAR"
@@ -45,7 +46,7 @@ class PreferenceKeys {
         const val LANGUAGE_LOCALE_SUMMARY = "com.tracker.fieldbook.preference.language.summary"
         const val LANGUAGE_LOCALE_DEFAULT_ID = "com.tracker.fieldbook.preference.language.default_id"
 
-        private val appearancePreferenceKeys = setOf(TOOLBAR_CUSTOMIZE, INFOBAR_NUMBER, HIDE_INFOBAR_PREFIX, QUICK_GOTO, RANGE_PROGRESS_BAR,
+        private val appearancePreferenceKeys = setOf(TOOLBAR_CUSTOMIZE, INFOBAR_NUMBER, HIDE_INFOBAR_PREFIX, HIDE_ENTRY_NAVIGATION, QUICK_GOTO, RANGE_PROGRESS_BAR,
             TRAITS_PROGRESS_BAR, SHOW_OBSERVATION_TIMESTAMP, THEME, TEXT_THEME, SAVED_DATA_COLOR, LANGUAGE_PREF, LANGUAGE_LOCALE_ID,
             LANGUAGE_LOCALE_SUMMARY, LANGUAGE_LOCALE_DEFAULT_ID)
 

--- a/app/src/main/java/com/fieldbook/tracker/views/RangeBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/RangeBoxView.kt
@@ -448,6 +448,17 @@ class RangeBoxView : ConstraintLayout {
         }
     }
 
+    /**
+     * Hides the whole range box when the appearance preference is enabled.
+     * The box is only hidden, so navigating with the toolbar, volume keys or
+     * the trait box still works while it is not shown.
+     */
+    fun updateRangeBoxVisibility() {
+        val hidden =
+            controller.getPreferences().getBoolean(PreferenceKeys.HIDE_ENTRY_NAVIGATION, false)
+        visibility = if (hidden) GONE else VISIBLE
+    }
+
     private fun updateProgressBarVisibility() {
         if (controller.getPreferences().getBoolean(PreferenceKeys.RANGE_PROGRESS_BAR, true)) {
             plotsProgressBar.visibility = VISIBLE

--- a/app/src/main/res/drawable/ic_hide_entry_arrows.xml
+++ b/app/src/main/res/drawable/ic_hide_entry_arrows.xml
@@ -4,9 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
 
-    <clip-path
-        android:fillColor="#000000"
-        android:pathData="M0 0 24 0 24 24 0 24 0 0M2.39 1.73 22.11 21.46 23.2 20 3.9.73Z" />
     <path
         android:fillColor="#000"
         android:pathData="M18.17,12L15,8.83L16.41,7.41L21,12L16.41,16.58L15,15.17L18.17,12

--- a/app/src/main/res/drawable/ic_hide_entry_arrows.xml
+++ b/app/src/main/res/drawable/ic_hide_entry_arrows.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <clip-path
+        android:fillColor="#000000"
+        android:pathData="M0 0 24 0 24 24 0 24 0 0M2.39 1.73 22.11 21.46 23.2 20 3.9.73Z" />
+    <path
+        android:fillColor="#000"
+        android:pathData="M18.17,12L15,8.83L16.41,7.41L21,12L16.41,16.58L15,15.17L18.17,12
+        M5.83,12L9,15.17L7.59,16.59L3,12L7.59,7.42L9,8.83L5.83,12Z" />
+    <path
+        android:fillColor="#000000"
+        android:pathData="M2.39,1.73L22.11,21.46L20.84,22.73L1.11,3Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_hide_entry_arrows.xml
+++ b/app/src/main/res/drawable/ic_hide_entry_arrows.xml
@@ -4,6 +4,9 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
 
+    <clip-path
+        android:fillColor="#000000"
+        android:pathData="M0 0 24 0 24 24 0 24 0 0M2.39 1.73 22.11 21.46 23.2 20 3.9.73Z" />
     <path
         android:fillColor="#000"
         android:pathData="M18.17,12L15,8.83L16.41,7.41L21,12L16.41,16.58L15,15.17L18.17,12

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1037,6 +1037,9 @@
     <string name="preferences_appearance_quickgoto">Quick GoTo</string>
     <string name="preferences_appearance_quickgoto_description">Change the middle section of main screen to the legacy Quick GoTo</string>
 
+    <string name="preferences_appearance_hide_entry_navigation">Hide entry navigation</string>
+    <string name="preferences_appearance_hide_entry_navigation_description">Hides the entry navigation arrows, identifiers, and progress bar on the collect screen</string>
+
     <string name="preferences_appearance_range_progress_bar">Entries progress bar</string>
     <string name="preferences_appearance_range_progress_bar_description">Shows your current position in the field</string>
 

--- a/app/src/main/res/xml/preferences_appearance.xml
+++ b/app/src/main/res/xml/preferences_appearance.xml
@@ -56,6 +56,13 @@
             android:title="@string/preferences_appearance_infobar_hide_prefix" />
 
         <CheckBoxPreference
+            android:defaultValue="false"
+            android:icon="@drawable/ic_hide_entry_arrows"
+            android:key="HIDE_ENTRY_NAVIGATION"
+            android:summary="@string/preferences_appearance_hide_entry_navigation_description"
+            android:title="@string/preferences_appearance_hide_entry_navigation" />
+
+        <CheckBoxPreference
             android:defaultValue="true"
             android:icon="@drawable/ic_range_progress"
             android:key="RANGE_PROGRESS_BAR"


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

Add option to hide entry arrows, info, and progress bar

Closes #1490

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [x] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Entry navigation area can be optionally hidden from the interface
```