### PR TITLE
filter observation variables to match selected level

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/BrapiStudyImportActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/BrapiStudyImportActivity.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.fieldbook.tracker.R
 import com.fieldbook.tracker.activities.ThemedActivity
+import com.fieldbook.tracker.activities.brapi.io.mapper.isAtObservationLevel
 import com.fieldbook.tracker.activities.brapi.io.mapper.toTraitObject
 import com.fieldbook.tracker.adapters.StudyAdapter
 import com.fieldbook.tracker.adapters.StudyAdapter.Model
@@ -266,6 +267,13 @@ class BrapiStudyImportActivity : ThemedActivity(), CoroutineScope by MainScope()
         .map { it.observationUnitPosition.observationLevel.levelName }
         .toSet()).toTypedArray()
 
+    /**
+     * The observation level the user has chosen, or null while no choice has been made yet.
+     */
+    private fun selectedLevelName() = existingLevels().let { levels ->
+        if (selectedLevel in levels.indices) levels[selectedLevel] else null
+    }
+
     private fun setLevelListOptions() {
 
         listView.adapter = ArrayAdapter(
@@ -467,7 +475,9 @@ class BrapiStudyImportActivity : ThemedActivity(), CoroutineScope by MainScope()
                 id: String,
                 position: Int
             ): HashSet<BrAPIObservationVariable>? {
-                return observationVariables[id]?.toHashSet()
+                val levelName = selectedLevelName()
+                return observationVariables[id]?.filter { it.isAtObservationLevel(levelName) }
+                    ?.toHashSet()
             }
 
             override fun getObservationUnits(
@@ -653,7 +663,9 @@ class BrapiStudyImportActivity : ThemedActivity(), CoroutineScope by MainScope()
                     details.numberOfPlots = units.size
                     details.trialName = study.trialName
 
-                    details.traits = observationVariables[study.studyDbId]?.toList()
+                    //BMS specific, only import the variables used at the selected level
+                    details.traits = observationVariables[study.studyDbId]
+                        ?.filter { it.isAtObservationLevel(level.observationLevelName) }
                         ?.map { it.toTraitObject(this@BrapiStudyImportActivity).also {
                             it.realPosition = maxVariableIndex++
                         } } ?: listOf()

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/mapper/PhenotypingMapper.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/io/mapper/PhenotypingMapper.kt
@@ -1,6 +1,7 @@
 package com.fieldbook.tracker.activities.brapi.io.mapper
 
 import android.content.Context
+import android.util.Log
 import com.fieldbook.tracker.brapi.service.BrAPIService
 import com.fieldbook.tracker.brapi.service.BrAPIServiceV2.ADDITIONAL_INFO_OBSERVATION_LEVEL_NAMES
 import com.fieldbook.tracker.objects.TraitObject
@@ -56,21 +57,48 @@ fun BrAPIObservationVariable.toTraitObject(context: Context) = TraitObject().als
         }
     }
 
-    if (additionalInfo != null && additionalInfo.has(ADDITIONAL_INFO_OBSERVATION_LEVEL_NAMES)) {
-
-        additionalInfo.getAsJsonArray(ADDITIONAL_INFO_OBSERVATION_LEVEL_NAMES)?.let { array ->
-
-            val listType = object : TypeToken<List<String?>?>() {}.type
-
-            it.observationLevelNames =
-                Gson().fromJson<List<String>>(
-                    array,
-                    listType
-                )
-
-        }
-    }
+    it.observationLevelNames = getObservationLevelNames()
 
     it.visible = true
 
+}
+
+/**
+ * The BMS implementation of BrAPI 2.x includes an observationLevelNames array in a variable's
+ * additionalInfo. This metadata identifies the level(s) at which a variable is used within a
+ * study/field, and is not otherwise retrievable through GET /variables.
+ *
+ * Returns null when the variable does not carry the metadata.
+ */
+fun BrAPIObservationVariable.getObservationLevelNames(): List<String>? {
+
+    if (additionalInfo == null || !additionalInfo.has(ADDITIONAL_INFO_OBSERVATION_LEVEL_NAMES)) return null
+
+    return try {
+
+        val array = additionalInfo.getAsJsonArray(ADDITIONAL_INFO_OBSERVATION_LEVEL_NAMES) ?: return null
+
+        val listType = object : TypeToken<List<String?>?>() {}.type
+
+        Gson().fromJson<List<String>>(array, listType)
+
+    } catch (e: Exception) {
+
+        Log.e("PhenotypingMapper", "Failed to parse $ADDITIONAL_INFO_OBSERVATION_LEVEL_NAMES", e)
+
+        null
+    }
+}
+
+/**
+ * BMS specific. Variables that declare observation levels only belong to the study at those
+ * levels; variables without the metadata are kept, so servers that don't supply it are unaffected.
+ */
+fun BrAPIObservationVariable.isAtObservationLevel(levelName: String?): Boolean {
+
+    if (levelName == null) return true
+
+    val levels = getObservationLevelNames() ?: return true
+
+    return levels.any { it.equals(levelName, ignoreCase = true) }
 }


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

Closes #1512 

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Traits imported via BrAPI are now filtered to match the correct observation unit level
```