### PR TITLE
notify user when data doesn't save

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -363,6 +363,8 @@ public class CollectActivity extends ThemedActivity
 
     private AlertDialog dialogCrashReport;
 
+    private AlertDialog saveFailedDialog;
+
     private Boolean deleteValueButtonEnabled = true;
 
     public void onCreate(Bundle savedInstanceState) {
@@ -1557,12 +1559,15 @@ public class CollectActivity extends ThemedActivity
             Log.e(TAG, "Failed to get location", e);
         }
 
+        //the primary key that should hold this value once the write completes
+        long observationId;
+
         if (obs == null) {
             String obsUnit = getObservationUnit();
             String studyId = getStudyId();
             String rep = getRep();
             //insert the new observation
-            database.insertObservation(obsUnit, traitDbId, value, person, location,
+            observationId = database.insertObservation(obsUnit, traitDbId, value, person, location,
                     "", studyId, null, null, null, rep);
 
         } else {
@@ -1576,7 +1581,20 @@ public class CollectActivity extends ThemedActivity
 
             obs.setValue(value);
 
-            database.updateObservationModels(database.getDb(), Collections.singletonList(obs));
+            int updated = database.updateObservationModels(database.getDb(), Collections.singletonList(obs));
+
+            observationId = updated > 0 ? obs.getInternal_id_observation() : -1;
+        }
+
+        //read the row back before telling the collector it was saved. insert() returns -1 on a
+        //swallowed SQLException (full disk, I/O error), and without this check the trait would be
+        //marked collected either way -- the failure would only surface when the field is exported
+        if (!database.isObservationSaved(observationId, value)) {
+
+            final String failedTraitDbId = traitDbId;
+            runOnUiThread(() -> onObservationSaveFailed(trait, failedTraitDbId, value, nullableRep));
+
+            return;
         }
 
         runOnUiThread(() -> {
@@ -1586,6 +1604,56 @@ public class CollectActivity extends ThemedActivity
             refreshRepeatedValuesToolbarIndicator();
             collectInputView.refreshTimestamp();
         });
+    }
+
+    /**
+     * Called when a value could not be written to the database.
+     * <p>
+     * The collector is told at the plot where it happened rather than discovering the loss when the
+     * field is exported days later. The trait indicator is reset to what is actually stored, and the
+     * value is left in the input so it can be retried once the underlying problem is cleared.
+     *
+     * @param trait       the trait that was being scored, null means the currently selected trait
+     * @param traitDbId   the resolved id of that trait
+     * @param value       the value that failed to save
+     * @param nullableRep the repeated value that was targeted, may be null
+     */
+    private void onObservationSaveFailed(@Nullable TraitObject trait, String traitDbId,
+                                         String value, @Nullable String nullableRep) {
+
+        Log.e(TAG, "Failed to save observation. study=" + getStudyId()
+                + " unit=" + getObservationUnit() + " trait=" + traitDbId + " value=" + value);
+
+        try {
+            soundHelper.playError();
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to play error sound", e);
+        }
+
+        //show what the database actually holds, not what was typed
+        try {
+            ObservationModel[] saved = database.getRepeatedValues(getStudyId(), getObservationUnit(), traitDbId);
+            updateCurrentTraitStatus(saved != null && saved.length > 0);
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to refresh trait status", e);
+        }
+
+        if (isFinishing() || isDestroyed()) return;
+
+        if (saveFailedDialog != null && saveFailedDialog.isShowing()) return;
+
+        saveFailedDialog = new AlertDialog.Builder(this, R.style.AppAlertDialog)
+                .setTitle(R.string.dialog_save_failed_title)
+                .setMessage(getString(R.string.dialog_save_failed_message, getObservationUnit()))
+                .setPositiveButton(R.string.dialog_save_failed_retry, (d, which) -> {
+                    d.dismiss();
+                    updateObservation(trait, value, nullableRep);
+                })
+                .setNegativeButton(R.string.dialog_save_failed_dismiss, (d, which) -> d.dismiss())
+                .setCancelable(false)
+                .create();
+
+        saveFailedDialog.show();
     }
 
     public void insertRep(String value, String rep) {

--- a/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
+++ b/app/src/main/java/com/fieldbook/tracker/database/DataHelper.java
@@ -488,10 +488,36 @@ public class DataHelper {
         ObservationUnitDao.Companion.updateObservationUnitModels(db, models);
     }
 
-    public void updateObservationModels(SQLiteDatabase db, List<ObservationModel> observations) {
+    public int updateObservationModels(SQLiteDatabase db, List<ObservationModel> observations) {
 
-        ObservationDao.Companion.updateObservationModels(db, observations);
+        return ObservationDao.Companion.updateObservationModels(db, observations);
 
+    }
+
+    /**
+     * Reads an observation back out of the database to confirm a write actually landed.
+     * <p>
+     * Android's SQLiteDatabase.insert() catches SQLException internally and returns -1, so a full
+     * disk (SQLiteFullException) or an I/O error (SQLiteDiskIOException) is otherwise
+     * indistinguishable from a successful save. Anything that shows the collector a saved state
+     * must confirm the row exists first.
+     *
+     * @param internalId    the primary key the write should have produced
+     * @param expectedValue the value that was submitted
+     * @return true only if the row exists and holds the submitted value
+     */
+    public boolean isObservationSaved(long internalId, String expectedValue) {
+
+        if (internalId <= 0) return false;
+
+        open();
+
+        String stored = ObservationDao.Companion.getValueById(String.valueOf(internalId));
+
+        if (stored == null) return false;
+
+        return ObservationDao.Companion.sanitizeValue(stored)
+                .equals(ObservationDao.Companion.sanitizeValue(expectedValue));
     }
 
     public void updateObservationMediaUris(ObservationModel observation) {

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
@@ -773,12 +773,39 @@ class ObservationDao {
             db.delete(Observation.tableName, "${Study.FK} = ?", arrayOf(studyId))
         }.also { ObservationChangeTracker.markChanged() }
 
-        fun updateObservationModels(db: SQLiteDatabase, observations: List<ObservationModel>) {
+        /**
+         * Mirrors the null-control-character stripping that [insertObservation] applies, so a value
+         * read back out of the database can be compared against the value that was submitted.
+         */
+        fun sanitizeValue(value: String?): String = (value ?: String()).filterNot { it.code == 0 }
+
+        /**
+         * Reads back the value stored under an observation's primary key.
+         * Returns null when no such row exists, which is how a write that never landed is told
+         * apart from one that saved an empty value.
+         */
+        fun getValueById(id: String): String? = withDatabase { db ->
+
+            db.rawQuery(
+                "SELECT value FROM ${Observation.tableName} WHERE ${Observation.PK} = ? LIMIT 1",
+                arrayOf(id)
+            ).use { cursor ->
+
+                if (cursor.moveToFirst()) cursor.getString(0) ?: String() else null
+            }
+        }
+
+        /**
+         * @return the number of rows actually updated, so callers can tell a no-op apart from a save
+         */
+        fun updateObservationModels(db: SQLiteDatabase, observations: List<ObservationModel>): Int {
+
+            var updated = 0
 
             observations.forEach {
 
                 val content = it.toContentValues()
-                db.update(
+                updated += db.update(
                     Observation.tableName,
                     content,
                     "${Observation.PK} = ?", arrayOf(it.internal_id_observation.toString())
@@ -786,6 +813,8 @@ class ObservationDao {
             }
 
             ObservationChangeTracker.markChanged()
+
+            return updated
         }
 
         /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -809,6 +809,12 @@
     <string name="dialog_multi_measure_delete">Delete</string>
     <string name="dialog_multi_measure_select_all">Select all</string>
 
+    <!--- Save failure -->
+    <string name="dialog_save_failed_title">Couldn\'t save this value</string>
+    <string name="dialog_save_failed_message">Nothing was recorded for entry %1$s. The value is still on screen but it is not in the database.\n\nThis usually means the device is out of storage. Free up space, then retry.\n\nDon\'t keep collecting until a value saves — anything you enter will be lost.</string>
+    <string name="dialog_save_failed_retry">Retry</string>
+    <string name="dialog_save_failed_dismiss">Dismiss</string>
+
     <!--- GeoNav -->
     <string name="menu_collect_start_geo_nav_title">Start GeoNav</string>
     <string name="activity_collect_found_plot">Navigated to plot in vicinity</string>

--- a/app/src/test/java/ObservationValueSanitizeTest.java
+++ b/app/src/test/java/ObservationValueSanitizeTest.java
@@ -1,0 +1,69 @@
+import com.fieldbook.tracker.database.dao.ObservationDao;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * CollectActivity confirms a save by reading the row back and comparing it to the value that was
+ * submitted. insertObservation strips null control characters on the way in, so the comparison has
+ * to strip them the same way -- otherwise every paste from an affected device would look like a
+ * failed write and raise the save-failure dialog on a value that actually saved fine.
+ */
+public class ObservationValueSanitizeTest {
+
+    private static final String NUL = String.valueOf((char) 0);
+
+    private static String sanitize(String value) {
+        return ObservationDao.Companion.sanitizeValue(value);
+    }
+
+    @Test
+    public void ordinaryValueIsUnchanged() {
+        assertEquals("38", sanitize("38"));
+        assertEquals("a note with spaces", sanitize("a note with spaces"));
+    }
+
+    @Test
+    public void nullBecomesEmptyString() {
+        assertEquals("", sanitize(null));
+    }
+
+    @Test
+    public void emptyValueStaysEmpty() {
+        assertEquals("", sanitize(""));
+    }
+
+    @Test
+    public void nullCharactersAreStripped() {
+        assertEquals("38", sanitize("3" + NUL + "8"));
+        assertEquals("38", sanitize(NUL + "38" + NUL));
+    }
+
+    /**
+     * The submitted value carries null characters, the stored value does not. They must still
+     * compare equal or the write would be reported as failed.
+     */
+    @Test
+    public void submittedAndStoredFormsCompareEqual() {
+        String submitted = "12" + NUL + ".5";
+        String stored = "12.5";
+        assertEquals(sanitize(stored), sanitize(submitted));
+    }
+
+    @Test
+    public void sanitizeIsIdempotent() {
+        String submitted = "4" + NUL + "2";
+        assertEquals(sanitize(submitted), sanitize(sanitize(submitted)));
+    }
+
+    /**
+     * Verification must still catch a genuinely different value, e.g. a row that was overwritten
+     * by another write between the save and the read-back.
+     */
+    @Test
+    public void differentValuesDoNotCompareEqual() {
+        assertNotEquals(sanitize("38"), sanitize("39"));
+    }
+}


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

Add user notification when data isn't being correctly saved to the database

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [x] **`CHANGE`** (fix or feature that alters existing functionality)
- [ ] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
User is now notified of failed database writes
```