### PR TITLE
fix movetoplot off by one

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -661,8 +661,10 @@ public class CollectActivity extends ThemedActivity
 
     @Override
     public void refreshMain() {
-        rangeBox.saveLastPlotAndTrait();
+        // refresh first so the current range reflects the new paging position,
+        // otherwise the previous plot would be saved as the last plot
         rangeBox.refresh();
+        rangeBox.saveLastPlotAndTrait();
 
         Log.d(TAG, "Refresh main.");
 
@@ -1264,6 +1266,8 @@ public class CollectActivity extends ThemedActivity
         // Reload traits based on selected plot
         rangeBox.display();
 
+        rangeBox.saveLastPlot();
+
         Log.d(TAG, "Move to result core: " + j);
 
         initWidgets(false);
@@ -1283,6 +1287,8 @@ public class CollectActivity extends ThemedActivity
         rangeBox.display();
 
         traitBox.setSelection(traitIndex);
+
+        rangeBox.saveLastPlot();
 
         saveLastTrait();
 

--- a/app/src/main/java/com/fieldbook/tracker/views/RangeBoxView.kt
+++ b/app/src/main/java/com/fieldbook/tracker/views/RangeBoxView.kt
@@ -504,6 +504,12 @@ class RangeBoxView : ConstraintLayout {
         rangeRight.performClick()
     }
 
+    fun saveLastPlot() {
+        controller.getPreferences().edit {
+            putString(GeneralKeys.LAST_PLOT, cRange.uniqueId)
+        }
+    }
+
     fun saveLastPlotAndTrait() {
         controller.getPreferences().edit {
             putString(GeneralKeys.LAST_PLOT, cRange.uniqueId)


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

Fix off by one error in `moveToPlot`
Closes #1516

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
Last selected entry no longer changes after modifying trait visibility
```