### PR TITLE
fix pollinator counts saving to the wrong entry

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/traits/PollinatorTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PollinatorTraitLayout.kt
@@ -45,11 +45,7 @@ import com.fieldbook.tracker.traits.formats.parameters.DEFAULT_DURATION_SECONDS
 import com.fieldbook.tracker.ui.theme.AppTheme
 import com.fieldbook.tracker.utilities.CategoryJsonUtil
 import com.fieldbook.tracker.utilities.JsonUtil
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import org.brapi.v2.model.pheno.BrAPIScaleValidValuesCategories
 import org.json.JSONObject
 
@@ -94,8 +90,8 @@ class PollinatorTraitLayout : BaseTraitLayout {
     private val traitCategories = mutableStateOf<List<BrAPIScaleValidValuesCategories>>(emptyList())
     private val traitDuration = mutableIntStateOf(DEFAULT_DURATION_SECONDS)
 
-    //cancels the timer coroutine when the layout is reset
-    private var saveJob: Job? = null
+    //the observation the counts belong to, the layout only resets while it is the visible trait
+    private var stateOwner: String? = null
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
@@ -124,7 +120,6 @@ class PollinatorTraitLayout : BaseTraitLayout {
     }
 
     private fun resetObservationState() {
-        cancelTimer()
         isRunning.value = false
         isFinished.value = false
         elapsedSeconds.intValue = 0
@@ -139,8 +134,17 @@ class PollinatorTraitLayout : BaseTraitLayout {
             currentTrait?.duration?.toIntOrNull()?.takeIf { it > 0 } ?: DEFAULT_DURATION_SECONDS
         resetObservationState()
         if (onNew == false) restore(currentObservation?.value)
+        stateOwner = observationKey()
         isDataLocked.value = isLocked
     }
+
+    //study, entry, trait and rep the loaded counts came from
+    private fun observationKey(): String = listOf(
+        collectActivity.studyId,
+        collectActivity.observationUnit,
+        currentTrait?.id,
+        collectActivity.rep
+    ).joinToString("/")
 
     override fun refreshLock() {
         super.refreshLock()
@@ -169,14 +173,13 @@ class PollinatorTraitLayout : BaseTraitLayout {
         if (collectInputView.isRepeatEnabled()) refreshLayout(false) else loadLayout()
     }
 
-    private fun cancelTimer() {
-        saveJob?.cancel()
-        saveJob = null
-    }
+    //counts taken here, unlike hasData this ignores what was already stored
+    private fun hasUnsavedCounts(): Boolean =
+        elapsedSeconds.intValue > 0 || counts.values.any { it > 0 }
 
     override fun onExit() {
         isRunning.value = false
-        if (hasData()) save()
+        if (hasUnsavedCounts()) save()
     }
 
     //show the visit total instead of the raw json in the collect input and repeated values toolbar
@@ -202,7 +205,7 @@ class PollinatorTraitLayout : BaseTraitLayout {
 
     private fun key(category: BrAPIScaleValidValuesCategories): String = keyOf(category)
 
-    //build the json payload used by both async saves and the synchronous exit save
+    //build the json payload written for every count, the stop button and the exit save
     private fun buildJson(): String? {
         val cats = categories()
         if (cats.isEmpty()) return null
@@ -231,18 +234,14 @@ class PollinatorTraitLayout : BaseTraitLayout {
         }
     }
 
+    //switching traits calls onExit on the layout being switched to, never save another entry's counts
     private fun save() {
-        saveJob?.cancel()
-        saveJob = CoroutineScope(Dispatchers.IO).launch {
-            val value = buildJson() ?: return@launch
-            val savedLocked = isLocked
-            collectActivity.updateObservation(currentTrait, value, null)
-            CoroutineScope(Dispatchers.Main).launch {
-                collectInputView.text = decodeValue(value)
-                afterLoadExists(collectActivity, value)
-                isDataLocked.value = savedLocked
-            }
-        }
+        if (stateOwner != observationKey()) return
+        val value = buildJson() ?: return
+        collectActivity.updateObservation(currentTrait, value, null)
+        collectInputView.text = decodeValue(value)
+        afterLoadExists(collectActivity, value)
+        isDataLocked.value = isLocked
     }
 
     private fun setupUi() {
@@ -318,8 +317,8 @@ class PollinatorTraitLayout : BaseTraitLayout {
                     enabled = canCollect() && elapsedSeconds.intValue > 0
                 ) {
                     isRunning.value = false
-                    save()
                     isFinished.value = true
+                    save()
                 }
 
                 Text(

--- a/app/src/main/java/com/fieldbook/tracker/traits/PollinatorTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/PollinatorTraitLayout.kt
@@ -93,6 +93,12 @@ class PollinatorTraitLayout : BaseTraitLayout {
     //the observation the counts belong to, the layout only resets while it is the visible trait
     private var stateOwner: String? = null
 
+    //counting was started or a count was taken since these counts were loaded
+    private var isSessionActive = false
+
+    //there are changes that have not been written to the observation yet
+    private var isDirty = false
+
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
@@ -124,6 +130,8 @@ class PollinatorTraitLayout : BaseTraitLayout {
         isFinished.value = false
         elapsedSeconds.intValue = 0
         counts.clear()
+        isSessionActive = false
+        isDirty = false
     }
 
     //reload the saved counts when navigating between repeated measures
@@ -139,15 +147,22 @@ class PollinatorTraitLayout : BaseTraitLayout {
     }
 
     //study, entry, trait and rep the loaded counts came from
+    //the rep only moves without a reload when repeated measures are on, reading it from the
+    //activity otherwise costs a repeated values query on every count
     private fun observationKey(): String = listOf(
         collectActivity.studyId,
         collectActivity.observationUnit,
         currentTrait?.id,
-        collectActivity.rep
+        if (collectInputView.isRepeatEnabled()) collectInputView.getRep() else ""
     ).joinToString("/")
+
+    //a session started here stays editable until it is stopped, frozen applies again on the next load
+    private fun isSessionInProgress(): Boolean = isSessionActive && !isFinished.value
 
     override fun refreshLock() {
         super.refreshLock()
+        //frozen locks an entry once an observation exists and counting writes one on the first count
+        if (isSessionInProgress()) isLocked = collectActivity.isLocked()
         isDataLocked.value = isLocked
         //never keep counting into an observation that has just been locked
         if (isLocked) isRunning.value = false
@@ -173,13 +188,9 @@ class PollinatorTraitLayout : BaseTraitLayout {
         if (collectInputView.isRepeatEnabled()) refreshLayout(false) else loadLayout()
     }
 
-    //counts taken here, unlike hasData this ignores what was already stored
-    private fun hasUnsavedCounts(): Boolean =
-        elapsedSeconds.intValue > 0 || counts.values.any { it > 0 }
-
     override fun onExit() {
         isRunning.value = false
-        if (hasUnsavedCounts()) save()
+        save()
     }
 
     //show the visit total instead of the raw json in the collect input and repeated values toolbar
@@ -210,6 +221,8 @@ class PollinatorTraitLayout : BaseTraitLayout {
         val cats = categories()
         if (cats.isEmpty()) return null
         val countsJson = JSONObject()
+        //keep counts collected under categories that have since been removed from the trait
+        counts.forEach { (k, count) -> countsJson.put(k, count) }
         cats.forEach { countsJson.put(key(it), counts[key(it)] ?: 0) }
         val json = JSONObject()
         json.put(COUNTS_KEY, countsJson)
@@ -236,12 +249,18 @@ class PollinatorTraitLayout : BaseTraitLayout {
 
     //switching traits calls onExit on the layout being switched to, never save another entry's counts
     private fun save() {
+        //restoring an observation fills the counts, only write when something was collected here
+        if (!isDirty) return
         if (stateOwner != observationKey()) return
         val value = buildJson() ?: return
+        val locked = isLocked
         collectActivity.updateObservation(currentTrait, value, null)
         collectInputView.text = decodeValue(value)
+        //afterLoadExists re-locks under frozen, a save must not end a session that is in progress
         afterLoadExists(collectActivity, value)
+        isLocked = locked
         isDataLocked.value = isLocked
+        isDirty = false
     }
 
     private fun setupUi() {
@@ -263,13 +282,19 @@ class PollinatorTraitLayout : BaseTraitLayout {
             if (isRunning.value) {
                 val start = SystemClock.elapsedRealtime() - elapsedSeconds.intValue * 1000L
                 while (isRunning.value && elapsedSeconds.intValue < total) {
-                    elapsedSeconds.intValue = ((SystemClock.elapsedRealtime() - start) / 1000).toInt()
+                    val seconds = ((SystemClock.elapsedRealtime() - start) / 1000).toInt()
+                    //the loop ticks faster than the countdown, only a new second is a change
+                    if (seconds != elapsedSeconds.intValue) {
+                        elapsedSeconds.intValue = seconds
+                        isDirty = true
+                    }
                     delay(200)
                 }
                 if (elapsedSeconds.intValue >= total) {
                     elapsedSeconds.intValue = total
                     isRunning.value = false
                     isFinished.value = true
+                    isDirty = true
                     save()
                 }
             }
@@ -318,6 +343,7 @@ class PollinatorTraitLayout : BaseTraitLayout {
                 ) {
                     isRunning.value = false
                     isFinished.value = true
+                    isDirty = true
                     save()
                 }
 
@@ -336,8 +362,14 @@ class PollinatorTraitLayout : BaseTraitLayout {
                 ControlButton(
                     if (isRunning.value) Icons.Default.Pause else Icons.Default.PlayArrow,
                     context.getString(if (isRunning.value) R.string.pause else R.string.play),
-                    enabled = canCollect() && categories.isNotEmpty()
-                ) { isRunning.value = !isRunning.value }
+                    //a restored observation longer than a shortened duration has no time left to run
+                    enabled = canCollect() && categories.isNotEmpty() && elapsedSeconds.intValue < total
+                ) {
+                    val wasRunning = isRunning.value
+                    isRunning.value = !wasRunning
+                    //pausing is the only user action that ends counting without ending the observation
+                    if (wasRunning) save() else isSessionActive = true
+                }
             }
         }
     }
@@ -352,6 +384,8 @@ class PollinatorTraitLayout : BaseTraitLayout {
             onClick = {
                 if (isRunning.value && canCollect()) {
                     counts[k] = (counts[k] ?: 0) + 1
+                    isSessionActive = true
+                    isDirty = true
                     save()
                 }
             },

--- a/docs/traits/trait-pollinator.md
+++ b/docs/traits/trait-pollinator.md
@@ -15,8 +15,9 @@ At least one category is required.
 On the Collect screen, press the <img class="icon" src="../_static/icons/formats/play.png"> start button to start the countdown.
 Press the <img class="icon" src="../_static/icons/formats/pause.png"> pause button to pause the countdown.
 Press a category button each time a pollinator of that type is observed to increment its count.
-Press the <img class="icon" src="../_static/icons/formats/stop.png"> stop button to end the observation and save the counts.
-The observation is also saved automatically when the timer reaches zero.
+Press the <img class="icon" src="../_static/icons/formats/stop.png"> stop button to end the observation.
+The observation also ends automatically when the timer reaches zero.
+Counts are saved as they are recorded, so an observation is kept even if it is not stopped.
 Use the delete button in the toolbar to remove a saved observation and start the entry over.
 
 Per-category counts and the elapsed time are saved together for each entry.


### PR DESCRIPTION
### Description

Fixes two bugs in the pollinator trait reported from the field, both in v7.3.0. Selecting the trait on an entry could copy the previous entry's counts onto it, which stored `finished` and left every control disabled so it could only be recorded after deleting it, or write zeros over an entry that was already recorded. `onExit` runs on the layout being switched to rather than the one being left, and the layout keeps its counts until it is shown again, so it was saving counts belonging to a different entry. The layout now tracks which observation its counts came from and skips the save once the entry has changed, and the exit save looks at counts taken here rather than `hasData`. Saving moves back to the main thread because `updateObservation` resolves the entry when it runs, so a background write lands on whichever entry is current by then.

### Change Type

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

```release-note
Fixed several issues with the Pollinator trait
```
