### PR TITLE
brapi accountmanager fixes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,12 @@ android {
 
         buildConfigField "String", "NIX_LICENSE", "\"${nixLicense.replaceAll("\"", "\\\\\"")}\""
 
+        // The BrAPI account type this app owns, read by res/xml/brapi_authenticator.xml. It has to
+        // stay equal to BrapiAccountConstants.accountTypeFor(applicationId), which is what the code
+        // derives at runtime — and it has to differ per variant, or a debug and a release install
+        // would fight over the same account type on one device.
+        resValue "string", "brapi_account_type", "org.phenoapps.brapi.com.fieldbook.tracker"
+
     }
 
     buildTypes {
@@ -94,6 +100,7 @@ android {
             clean
             debuggable true
             applicationIdSuffix ".debug"
+            resValue "string", "brapi_account_type", "org.phenoapps.brapi.com.fieldbook.tracker.debug"
             //proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,14 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.fieldbook.tracker">
 
-    <!-- Custom permission allowing other PhenoApps to request BrAPI tokens via AccountManager.
-         Normal protection: any app that declares uses-permission is granted it without a user
-         prompt. Account visibility is controlled per-package in BrapiAuthenticator. -->
-    <permission
-        android:name="org.phenoapps.brapi.READ_TOKEN"
-        android:protectionLevel="normal" />
-
-    <uses-permission android:name="org.phenoapps.brapi.READ_TOKEN" />
+    <!-- No custom BrAPI permission is declared here on purpose. Only one installed app may define
+         a given permission name, and a second app declaring it under a different signing key fails
+         to install outright — which blocked the debug and release variants from coexisting, and
+         would have blocked a sibling PhenoApp from declaring the same thing. Cross-app BrAPI
+         access is gated by account visibility, the authenticator, and the config provider's own
+         caller checks instead. -->
 
     <application
         android:name=".application.FieldBook"

--- a/app/src/main/java/com/fieldbook/tracker/activities/FieldEditorActivity.kt
+++ b/app/src/main/java/com/fieldbook/tracker/activities/FieldEditorActivity.kt
@@ -475,8 +475,7 @@ class FieldEditorActivity : BaseFieldActivity(), FieldSortController {
         if (hasBrapi) {
             val activeAccount = brapiAccountHelper.findAccount()
             val displayName = activeAccount?.let {
-                brapiAccountHelper.getUserData(it, com.fieldbook.tracker.brapi.BrapiAuthenticator.KEY_DISPLAY_NAME)
-                    ?.takeIf { name -> name.isNotEmpty() }
+                brapiAccountHelper.accountInfo(it)?.displayName?.takeIf { name -> name.isNotEmpty() }
             } ?: getString(R.string.brapi_edit_display_name_default)
             importArray[3] = displayName
         }

--- a/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiAuthActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/brapi/BrapiAuthActivity.java
@@ -33,6 +33,8 @@ import net.openid.appauth.AuthorizationServiceConfiguration;
 import net.openid.appauth.Preconditions;
 import net.openid.appauth.ResponseTypeValues;
 import net.openid.appauth.TokenResponse;
+
+import org.phenoapps.brapi.account.BrapiTokenStoreResult;
 import net.openid.appauth.connectivity.ConnectionBuilder;
 
 import java.net.HttpURLConnection;
@@ -272,25 +274,77 @@ public class BrapiAuthActivity extends ThemedActivity {
         getIntent().setData(null);
 
         Log.e("BrAPI", "Error starting BrAPI auth", ex);
-        Toast.makeText(this, R.string.brapi_auth_error_starting, Toast.LENGTH_LONG).show();
+
+        // A bare "Error Starting BrAPI Auth" gives the user nothing to act on and nothing to
+        // report, so surface whatever the provider actually said — a bad client id and a refused
+        // redirect URI are very different problems and look identical without this.
+        String reason = describeAuthFailure(ex);
+        String message = reason.isEmpty()
+                ? getString(R.string.brapi_auth_error_starting)
+                : getString(R.string.brapi_auth_error_starting_reason, reason);
+
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show();
         setResult(RESULT_CANCELED);
         finish();
+    }
+
+    /**
+     * Best available human-readable cause for an auth failure, or empty when nothing was reported.
+     *
+     * AppAuth puts the provider's own wording in {@code errorDescription} and the OAuth error code
+     * in {@code error}; both are absent for transport-level failures, where the exception message
+     * is all there is.
+     */
+    private String describeAuthFailure(Exception ex) {
+        if (ex == null) return "";
+
+        if (ex instanceof AuthorizationException) {
+            AuthorizationException authEx = (AuthorizationException) ex;
+            if (authEx.errorDescription != null && !authEx.errorDescription.isEmpty()) {
+                return authEx.errorDescription;
+            }
+            if (authEx.error != null && !authEx.error.isEmpty()) {
+                return authEx.error;
+            }
+            if (authEx.getCause() != null && authEx.getCause().getMessage() != null) {
+                return authEx.getCause().getMessage();
+            }
+        }
+
+        return ex.getMessage() == null ? "" : ex.getMessage();
     }
 
     private void authSuccess(String accessToken, @Nullable String idToken) {
 
         String serverUrl = launchServerUrl;
 
+        BrapiTokenStoreResult stored = BrapiTokenStoreResult.STORED;
         if (!serverUrl.isEmpty()) {
-            accountHelper.storeToken(serverUrl, accessToken, idToken);
+            stored = accountHelper.storeToken(serverUrl, accessToken, idToken);
         }
 
         // Clear our data from our deep link so the app doesn't think it is
         // coming from a deep link if it is coming from deep link on pause and resume.
         getIntent().setData(null);
 
-        Log.d("BrAPI", "Auth successful");
-        Toast.makeText(this, R.string.brapi_auth_success, Toast.LENGTH_LONG).show();
+        // The provider signed us in either way, but only STORED means the server now has an
+        // account of its own here. Saying "authorization successful" for the other outcomes would
+        // promise a server card that never appears.
+        int message;
+        switch (stored) {
+            case ALREADY_SHARED:
+                message = R.string.brapi_auth_success_already_shared;
+                break;
+            case ACCOUNT_UNAVAILABLE:
+                message = R.string.brapi_auth_success_no_account;
+                break;
+            default:
+                message = R.string.brapi_auth_success;
+                break;
+        }
+
+        Log.d("BrAPI", "Auth successful, token stored: " + stored);
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show();
         setResult(RESULT_OK);
         finish();
     }
@@ -350,7 +404,9 @@ public class BrapiAuthActivity extends ThemedActivity {
                             if (response != null && response.accessToken != null) {
                                 authSuccess(response.accessToken, response.idToken);
                             } else {
-                                authError(null);
+                                // The exchange failure carries the provider's reason; dropping it
+                                // here is what made token-exchange problems unreportable.
+                                authError(ex);
                             }
                         }
                     });

--- a/app/src/main/java/com/fieldbook/tracker/brapi/BrapiAuthenticator.kt
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/BrapiAuthenticator.kt
@@ -14,9 +14,25 @@ class BrapiAuthenticator(context: Context) : BrapiAccountAuthenticator(
 ) {
 
     companion object {
-        const val ACCOUNT_TYPE = BrapiAccountConstants.ACCOUNT_TYPE
+        /**
+         * Field Book's own BrAPI account type.
+         *
+         * Per-app rather than shared: only the app registered as a type's authenticator, or one
+         * co-signed with it, may write its accounts, so sibling PhenoApps under different signing
+         * keys each need their own. Not a constant because it is derived from the package, which
+         * differs between the debug and release variants.
+         */
+        @JvmStatic
+        fun accountType(context: Context): String =
+            BrapiAccountConstants.accountTypeFor(context.packageName)
+
+        /** Whether [accountType] is a BrAPI account type belonging to any PhenoApp. */
+        @JvmStatic
+        fun isBrapiAccountType(accountType: String?): Boolean =
+            BrapiAccountConstants.isPerAppAccountType(accountType) ||
+                accountType == BrapiAccountConstants.LEGACY_ACCOUNT_TYPE
+
         const val AUTH_TOKEN_TYPE = BrapiAccountConstants.AUTH_TOKEN_TYPE
-        const val READ_TOKEN_PERMISSION = BrapiAccountConstants.READ_TOKEN_PERMISSION
         const val KEY_ID_TOKEN = BrapiAccountConstants.KEY_ID_TOKEN
         const val KEY_SERVER_URL = BrapiAccountConstants.KEY_SERVER_URL
         const val KEY_DISPLAY_NAME = BrapiAccountConstants.KEY_DISPLAY_NAME

--- a/app/src/main/java/com/fieldbook/tracker/brapi/dialogs/BaseBrapiAccountDialogFragment.kt
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/dialogs/BaseBrapiAccountDialogFragment.kt
@@ -80,7 +80,10 @@ abstract class BaseBrapiAccountDialogFragment : DialogFragment() {
             }
             authResponse?.onResult(Bundle().apply {
                 putString(AccountManager.KEY_ACCOUNT_NAME, viewModel.uiState.value.url)
-                putString(AccountManager.KEY_ACCOUNT_TYPE, BrapiAuthenticator.ACCOUNT_TYPE)
+                putString(
+                    AccountManager.KEY_ACCOUNT_TYPE,
+                    BrapiAuthenticator.accountType(requireContext()),
+                )
             })
             dismiss()
             if (authResponse != null) {
@@ -160,7 +163,12 @@ abstract class BaseBrapiAccountDialogFragment : DialogFragment() {
                 // dismissal happens in the authLauncher callback above.
             }
             is BrapiAccountEvent.ShowError -> {
-                Toast.makeText(requireContext(), event.messageRes, Toast.LENGTH_LONG).show()
+                val message = if (event.args.isEmpty()) {
+                    getString(event.messageRes)
+                } else {
+                    getString(event.messageRes, *event.args.toTypedArray())
+                }
+                Toast.makeText(requireContext(), message, Toast.LENGTH_LONG).show()
             }
             is BrapiAccountEvent.Dismissed -> {
                 if (authResponse != null) {

--- a/app/src/main/java/com/fieldbook/tracker/brapi/dialogs/BrapiAccountViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/dialogs/BrapiAccountViewModel.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.phenoapps.brapi.BrapiAccountConstants
 import org.phenoapps.brapi.ui.BrapiAccountConfig
 import org.phenoapps.brapi.ui.BrapiAccountUiState
 import org.phenoapps.brapi.ui.defaultBrapiAccountState
@@ -180,6 +181,7 @@ class BrapiAccountViewModel @Inject constructor(
             showInvalidUrlError()
             return
         }
+        if (rejectedAsAlreadyShared(url)) return
         accountWasNew = accountHelper.getAccountByUrl(url) == null
         val displayName = state.displayName.trim().takeIf { it.isNotEmpty() } ?: url
         accountHelper.addAccountConfig(
@@ -190,7 +192,7 @@ class BrapiAccountViewModel @Inject constructor(
             oidcClientId = state.oidcClientId.trim(),
             oidcScope = state.oidcScope.trim(),
             brapiVersion = state.brapiVersion,
-        )
+        ) ?: return
         if (accountHelper.setActiveAccount(url)) invalidateCache()
         viewModelScope.launch {
             _events.emit(
@@ -218,6 +220,9 @@ class BrapiAccountViewModel @Inject constructor(
             showInvalidUrlError()
             return
         }
+        // Only an edit that repoints this account at a server a sibling shares is a problem; an
+        // edit that leaves the URL alone is matched to the existing account by originalServerUrl.
+        if (url != editOriginalUrl && rejectedAsAlreadyShared(url)) return
         val displayName = state.displayName.trim().takeIf { it.isNotEmpty() } ?: url
         accountHelper.addAccountConfig(
             serverUrl = url,
@@ -228,7 +233,7 @@ class BrapiAccountViewModel @Inject constructor(
             oidcScope = state.oidcScope.trim(),
             brapiVersion = state.brapiVersion,
             originalServerUrl = editOriginalUrl,
-        )
+        ) ?: return
         // Editing the active account has to repoint its preference mirrors, otherwise a changed
         // BrAPI version or OIDC setting is stored but never used. Matched on the URL the account
         // was active under, since the edit may have changed the URL itself.
@@ -298,6 +303,29 @@ class BrapiAccountViewModel @Inject constructor(
             )
         }
     }
+
+    /**
+     * Refuses a URL another app already shares, naming that app.
+     *
+     * Adding it here would create a second account for the same server and list it twice in the
+     * system account settings; the shared one is already usable from the server list. Returns true
+     * when the caller should stop.
+     */
+    private fun rejectedAsAlreadyShared(url: String): Boolean {
+        val shared = accountHelper.sharedAccountForUrl(url) ?: return false
+        val owner = BrapiAccountConstants.displayNameForPackage(
+            accountHelper.ownerPackageOf(shared),
+        )
+        viewModelScope.launch {
+            _events.emit(
+                BrapiAccountEvent.ShowError(
+                    R.string.brapi_add_account_already_shared,
+                    listOf(owner),
+                ),
+            )
+        }
+        return true
+    }
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
@@ -313,8 +341,14 @@ sealed class BrapiAccountEvent {
         val brapiVersion: String,
     ) : BrapiAccountEvent()
 
-    /** Fragment should show a Toast with this string resource. */
-    data class ShowError(@StringRes val messageRes: Int) : BrapiAccountEvent()
+    /**
+     * Fragment should show a Toast with this string resource, formatted with [args] when the
+     * message names something the user needs to see — the app sharing a server, for instance.
+     */
+    data class ShowError(
+        @StringRes val messageRes: Int,
+        val args: List<String> = emptyList(),
+    ) : BrapiAccountEvent()
 
     /** Fragment should dismiss (and finish the host activity if launched from AccountManager). */
     object Dismissed : BrapiAccountEvent()

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIService.java
@@ -173,7 +173,7 @@ public interface BrAPIService {
                 android.accounts.AccountManager am = android.accounts.AccountManager.get(context);
                 String token = helper.peekToken();
                 if (token != null) {
-                    am.invalidateAuthToken(com.fieldbook.tracker.brapi.BrapiAuthenticator.ACCOUNT_TYPE, token);
+                    am.invalidateAuthToken(active.type, token);
                 }
             }
             // Also clear SharedPreferences token for legacy compatibility

--- a/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceFactory.java
+++ b/app/src/main/java/com/fieldbook/tracker/brapi/service/BrAPIServiceFactory.java
@@ -1,13 +1,11 @@
 package com.fieldbook.tracker.brapi.service;
 
 import android.accounts.Account;
-import android.accounts.AccountManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 
 import androidx.preference.PreferenceManager;
 
-import com.fieldbook.tracker.brapi.BrapiAuthenticator;
 import com.fieldbook.tracker.preferences.PreferenceKeys;
 import com.fieldbook.tracker.utilities.BrapiAccountHelper;
 
@@ -20,7 +18,7 @@ public class BrAPIServiceFactory {
         BrapiAccountHelper accountHelper = new BrapiAccountHelper(context, prefs);
         accountHelper.migrateFromPrefsIfNeeded();
 
-        // Read BrAPI version from the active account's AccountManager user data (fallback to prefs)
+        // Read BrAPI version from the active account's config (fallback to prefs)
         String version = getActiveAccountVersion(context, accountHelper, prefs);
 
         BrAPIService brAPIService;
@@ -35,7 +33,7 @@ public class BrAPIServiceFactory {
 
     /**
      * Returns the BrAPI version for the active account.
-     * Reads from AccountManager user data first, falls back to SharedPreferences.
+     * Reads the account's config first, falls back to SharedPreferences.
      */
     public static String getActiveAccountVersion(
             Context context,
@@ -44,9 +42,8 @@ public class BrAPIServiceFactory {
     ) {
         Account active = accountHelper.findAccount();
         if (active != null) {
-            AccountManager am = AccountManager.get(context);
-            String version = am.getUserData(active, BrapiAuthenticator.KEY_BRAPI_VERSION);
-            if (version != null && !version.isEmpty()) return version;
+            String version = accountHelper.accountInfoOrEmpty(active).getBrapiVersion();
+            if (!version.isEmpty()) return version;
         }
         return prefs.getString(PreferenceKeys.BRAPI_VERSION, "V1");
     }

--- a/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitEditorViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/viewmodels/TraitEditorViewModel.kt
@@ -76,8 +76,7 @@ class TraitEditorViewModel @Inject constructor(
 
     fun getBrapiDisplayName(default: String): String {
         val account = brapiAccountHelper.findAccount() ?: return default
-        return brapiAccountHelper.getUserData(account, com.fieldbook.tracker.brapi.BrapiAuthenticator.KEY_DISPLAY_NAME)
-            ?.takeIf { it.isNotEmpty() } ?: default
+        return brapiAccountHelper.accountInfo(account)?.displayName?.takeIf { it.isNotEmpty() } ?: default
     }
 
     fun previouslyExported() = prefs.getBoolean(GeneralKeys.TRAITS_EXPORTED, false)

--- a/app/src/main/java/com/fieldbook/tracker/preferences/BrapiPreferencesFragment.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/BrapiPreferencesFragment.java
@@ -12,14 +12,15 @@ import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Typeface;
-import android.text.SpannableString;
-import android.text.Spanned;
-import android.text.style.StyleSpan;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.style.StyleSpan;
 import android.util.DisplayMetrics;
 import android.view.WindowMetrics;
+import android.widget.ImageView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -33,10 +34,10 @@ import androidx.preference.PreferenceFragmentCompat;
 import com.fieldbook.tracker.R;
 import com.fieldbook.tracker.activities.PreferencesActivity;
 import com.fieldbook.tracker.activities.brapi.BrapiAuthActivity;
+import com.fieldbook.tracker.activities.brapi.io.BrapiFilterCache;
 import com.fieldbook.tracker.brapi.BrapiAuthenticator;
 import com.fieldbook.tracker.brapi.dialogs.BrapiManualAccountDialogFragment;
 import com.fieldbook.tracker.brapi.dialogs.BrapiStepperAccountDialogFragment;
-import com.fieldbook.tracker.activities.brapi.io.BrapiFilterCache;
 import com.fieldbook.tracker.utilities.BrapiAccountHelper;
 import com.fieldbook.tracker.utilities.OpenAuthConfigurationUtil;
 import com.fieldbook.tracker.utilities.Utils;
@@ -45,8 +46,6 @@ import com.google.zxing.BarcodeFormat;
 import com.google.zxing.MultiFormatWriter;
 import com.google.zxing.WriterException;
 import com.google.zxing.common.BitMatrix;
-
-import android.widget.ImageView;
 
 import net.openid.appauth.AuthorizationService;
 import net.openid.appauth.EndSessionRequest;
@@ -198,7 +197,7 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
 
     /**
      * Moves a pre-7.3 BrAPI server config into AccountManager.
-     *
+     * <p>
      * Either way the old preferences stay put, but the two failures need different answers. A
      * deferred write is the brief post-update window before the platform attributes the BrAPI
      * account type to Field Book, and retrying clears it. A blocked one means another installed
@@ -307,7 +306,7 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
     /**
      * Wires the card's actions, limiting a shared account to the ones Field Book may actually
      * perform on an account another app owns.
-     *
+     * <p>
      * Signing in, editing and removing are the owner's to do. Authorizing here would run Field
      * Book's own OAuth and store the result against a new Field Book account, leaving the same
      * server listed twice in the system account settings; its token is borrowed from the owner
@@ -433,14 +432,16 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
             // Selecting a shared server is not enough to use it: its token belongs to the app that
             // owns the account, so fetch it now and mirror it locally. Without this the server
             // looks signed out no matter how many times it is selected.
-            accountHelper.borrowToken(account, getActivity(), token -> {
-                if (token == null) {
-                    Toast.makeText(context, R.string.brapi_shared_account_not_signed_in,
-                            Toast.LENGTH_LONG).show();
-                }
-                refreshServerCards();
-                return Unit.INSTANCE;
-            });
+            if (isAdded()) {
+                accountHelper.borrowToken(account, getActivity(), token -> {
+                    if (token == null) {
+                        Toast.makeText(context, R.string.brapi_shared_account_not_signed_in,
+                                Toast.LENGTH_LONG).show();
+                    }
+                    refreshServerCards();
+                    return Unit.INSTANCE;
+                });
+            }
             return;
         }
 

--- a/app/src/main/java/com/fieldbook/tracker/preferences/BrapiPreferencesFragment.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/BrapiPreferencesFragment.java
@@ -186,7 +186,7 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
     public void onResume() {
         super.onResume();
         setupToolbar();
-        if (migrationDeferred) {
+        if (migrationDeferred && !migrationNoticeShown) {
             runPrefMigration();
         }
         accountHelper.refreshOwnedAccountVisibility();

--- a/app/src/main/java/com/fieldbook/tracker/preferences/BrapiPreferencesFragment.java
+++ b/app/src/main/java/com/fieldbook/tracker/preferences/BrapiPreferencesFragment.java
@@ -53,6 +53,8 @@ import net.openid.appauth.EndSessionRequest;
 
 import org.jetbrains.annotations.NotNull;
 import org.phenoapps.brapi.BrapiAccountConstants;
+import org.phenoapps.brapi.account.BrapiMigrationResult;
+import org.phenoapps.brapi.config.BrapiAccountInfo;
 import org.phenoapps.brapi.ui.BrapiAccountConfig;
 
 import java.util.List;
@@ -101,6 +103,11 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
 
     // Tracks the shared account awaiting explicit user selection in AccountManager.
     private Account pendingChooseAccount = null;
+
+    // Set when the pre-AccountManager config could not be migrated yet, so the retry in onResume
+    // knows to run and the user is told once why their servers are missing.
+    private boolean migrationDeferred = false;
+    private boolean migrationNoticeShown = false;
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -158,7 +165,7 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
             });
         }
 
-        accountHelper.migrateFromPrefsIfNeeded();
+        runPrefMigration();
 
         activeServerCategory = findPreference("brapi_active_server_category");
         availableServersCategory = findPreference("brapi_available_servers_category");
@@ -180,9 +187,31 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
     public void onResume() {
         super.onResume();
         setupToolbar();
+        if (migrationDeferred) {
+            runPrefMigration();
+        }
         accountHelper.refreshOwnedAccountVisibility();
+        accountHelper.pruneStaleGrants();
         boolean brapiEnabled = preferences.getBoolean(PreferenceKeys.BRAPI_ENABLED, false);
         updateServerSectionsVisibility(brapiEnabled);
+    }
+
+    /**
+     * Moves a pre-7.3 BrAPI server config into AccountManager.
+     *
+     * Either way the old preferences stay put, but the two failures need different answers. A
+     * deferred write is the brief post-update window before the platform attributes the BrAPI
+     * account type to Field Book, and retrying clears it. A blocked one means another installed
+     * app is registered as the authenticator for that type — Android permits only one — and no
+     * amount of retrying will ever get past it, so it is worth interrupting the user for.
+     */
+    private void runPrefMigration() {
+        migrationDeferred = accountHelper.migrateFromPrefsIfNeeded() == BrapiMigrationResult.DEFERRED;
+
+        if (migrationDeferred && !migrationNoticeShown) {
+            migrationNoticeShown = true;
+            Toast.makeText(context, R.string.brapi_account_migration_deferred, Toast.LENGTH_SHORT).show();
+        }
     }
 
     // ─── Account cards ──────────────────────────────────────────────────────────
@@ -196,18 +225,16 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
 
         String activeUrl = preferences.getString(PreferenceKeys.BRAPI_BASE_URL, "");
 
-        AccountManager am = AccountManager.get(context);
         List<Account> allAccounts = accountHelper.getAllAccounts();
         boolean hasActive = false;
 
         for (Account account : allAccounts) {
-            String serverUrl = am.getUserData(account, BrapiAuthenticator.KEY_SERVER_URL);
-            String ownerPkg = am.getUserData(account, BrapiAuthenticator.KEY_OWNER_PACKAGE);
-            boolean isOwnAccount = context.getPackageName().equals(ownerPkg);
-            boolean isActive = activeUrl.equals(serverUrl);
+            BrapiAccountInfo info = accountHelper.accountInfoOrEmpty(account);
+            boolean isOwnAccount = accountHelper.isOwnAccount(account);
+            boolean isActive = activeUrl.equals(info.getServerUrl());
 
             if (!isOwnAccount) {
-                BrapiServerCardPreference card = buildSharedCard(account, isActive);
+                BrapiServerCardPreference card = buildSharedCard(account, info, isActive);
                 if (isActive) {
                     activeServerCategory.addPreference(card);
                     hasActive = true;
@@ -217,7 +244,7 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
                 continue;
             }
 
-            BrapiServerCardPreference card = buildCard(account, isActive);
+            BrapiServerCardPreference card = buildCard(account, info, isActive);
 
             if (isActive) {
                 activeServerCategory.addPreference(card);
@@ -239,10 +266,8 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
         }
     }
 
-    private BrapiServerCardPreference buildSharedCard(Account account, boolean isActive) {
-        AccountManager am = AccountManager.get(context);
-        String ownerPkg = am.getUserData(account, BrapiAuthenticator.KEY_OWNER_PACKAGE);
-        String ownerName = BrapiAccountConstants.INSTANCE.displayNameForPackage(ownerPkg);
+    private BrapiServerCardPreference buildSharedCard(Account account, BrapiAccountInfo info, boolean isActive) {
+        String ownerName = BrapiAccountConstants.INSTANCE.displayNameForPackage(info.getOwnerPackage());
         String ownerLabel = ownerName.isEmpty()
                 ? ""
                 : getString(org.phenoapps.brapi.R.string.pheno_brapi_shared_account_from, ownerName);
@@ -253,36 +278,51 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
         card.setExpanded(isActive);
         card.setKey("shared_" + account.name + "_" + (isActive ? "active" : "available"));
         card.setOrder(0);
-        final String label = ownerLabel;
-        card.setOwnerLabel(label);
-        card.setHasToken(accountHelper.peekTokenForAccount(account) != null);
-        configureCardActions(card);
+        card.setOwnerLabel(ownerLabel);
+        card.setDisplayName(info.getLabel());
+        card.setServerUrl(info.getServerUrl());
+        // A shared account's token lives in the owning app, out of reach of peekAuthToken, so its
+        // sign-in state comes from what that app published about it.
+        card.setHasToken(info.getHasToken());
+        configureCardActions(card, false);
         return card;
     }
 
-    private BrapiServerCardPreference buildCard(Account account, boolean isActive) {
+    private BrapiServerCardPreference buildCard(Account account, BrapiAccountInfo info, boolean isActive) {
         BrapiServerCardPreference card = new BrapiServerCardPreference(context);
         card.setAccount(account);
         card.setActive(isActive);
         card.setExpanded(isActive); // active card starts expanded; inactive cards start collapsed
         card.setKey(account.name + "_" + (isActive ? "active" : "available"));
         card.setOrder(0);
+        card.setDisplayName(info.getLabel());
+        card.setServerUrl(info.getServerUrl());
         card.setHasToken(accountHelper.peekTokenForAccount(account) != null);
 
-        configureCardActions(card);
+        configureCardActions(card, true);
 
         return card;
     }
 
-    private void configureCardActions(BrapiServerCardPreference card) {
+    /**
+     * Wires the card's actions, limiting a shared account to the ones Field Book may actually
+     * perform on an account another app owns.
+     *
+     * Signing in, editing and removing are the owner's to do. Authorizing here would run Field
+     * Book's own OAuth and store the result against a new Field Book account, leaving the same
+     * server listed twice in the system account settings; its token is borrowed from the owner
+     * instead. Logging out stays available, since that only drops the borrowed token locally.
+     */
+    private void configureCardActions(BrapiServerCardPreference card, boolean isOwnAccount) {
         card.setOnLogOut(this::logOutAccount);
-        card.setOnAuthorize(this::authorizeAccount);
         card.setOnEnable(this::enableAccount);
         card.setOnCheckCompatibility(this::checkServerCompatibility);
         card.setOnShareSettings(this::shareAccountSettings);
-        card.setOnEdit(this::editAccount);
-        card.setOnRemove(this::removeAccount);
         card.setOnSwitchServer(this::showSwitchServerDialog);
+
+        card.setOnAuthorize(isOwnAccount ? this::authorizeAccount : null);
+        card.setOnEdit(isOwnAccount ? this::editAccount : null);
+        card.setOnRemove(isOwnAccount ? this::removeAccount : null);
     }
 
     // ─── Account actions ────────────────────────────────────────────────────────
@@ -298,10 +338,7 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
     }
 
     private @NotNull Unit logOutAccount(Account account) {
-        AccountManager am = AccountManager.get(context);
-        String displayName = am.getUserData(account, BrapiAuthenticator.KEY_DISPLAY_NAME);
-        if (displayName == null) displayName = account.name;
-        final String finalDisplayName = displayName;
+        final String finalDisplayName = accountHelper.accountInfoOrEmpty(account).getLabel();
 
         String messageTemplate = getString(R.string.brapi_logout_manage_message, finalDisplayName);
         SpannableString styledMessage = new SpannableString(messageTemplate);
@@ -312,30 +349,39 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
                     Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         }
 
-        new AlertDialog.Builder(context, R.style.AppAlertDialog)
+        AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.AppAlertDialog)
                 .setTitle(R.string.brapi_logout_manage_title)
                 .setMessage(styledMessage)
                 .setNeutralButton(R.string.brapi_logout_only, (d, w) -> {
                     pendingRemoveAfterLogout = false;
                     doLogout(account);
                 })
-                .setPositiveButton(R.string.brapi_logout_and_remove, (d, w) -> {
-                    pendingRemoveAfterLogout = true;
-                    doLogout(account);
-                })
-                .setNegativeButton(android.R.string.cancel, null)
-                .show();
+                .setNegativeButton(android.R.string.cancel, null);
+
+        // Removal is the owner's to do. Offering it for a shared account promises something
+        // removeAccount() cannot deliver — it only touches accounts this app owns — so the entry
+        // would appear to do nothing.
+        if (accountHelper.isOwnAccount(account)) {
+            builder.setPositiveButton(R.string.brapi_logout_and_remove, (d, w) -> {
+                pendingRemoveAfterLogout = true;
+                doLogout(account);
+            });
+        }
+
+        builder.show();
         return Unit.INSTANCE;
     }
 
     private void doLogout(Account account) {
-        AccountManager am = AccountManager.get(context);
-        String idToken = am.getUserData(account, BrapiAuthenticator.KEY_ID_TOKEN);
+        BrapiAccountInfo info = accountHelper.accountInfoOrEmpty(account);
+        // Only the owning app holds an id token, so a shared account has no OIDC session for
+        // Field Book to end — signing out locally is all there is to do.
+        String idToken = accountHelper.peekIdTokenForAccount(account);
 
         if (idToken != null) {
             Toast.makeText(context, R.string.logging_out_please_wait, Toast.LENGTH_SHORT).show();
             pendingAuthAccount = account;
-            String accountOidcUrl = am.getUserData(account, BrapiAuthenticator.KEY_OIDC_URL);
+            String accountOidcUrl = info.getOidcUrl();
             // Resolved up front: getAuthServiceConfiguration() calls back asynchronously, by which
             // point the fragment may be detached and getString() would throw.
             final Uri postLogoutRedirect = Uri.parse(getString(R.string.brapi_redirect_uri));
@@ -351,17 +397,17 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
                 return null;
             }, accountOidcUrl);
         } else {
-            String serverUrl = am.getUserData(account, BrapiAuthenticator.KEY_SERVER_URL);
-            accountHelper.clearToken(serverUrl != null ? serverUrl : "");
+            String serverUrl = info.getServerUrl();
+            accountHelper.clearToken(serverUrl);
 
             String activeUrl = preferences.getString(PreferenceKeys.BRAPI_BASE_URL, "");
-            if (serverUrl != null && serverUrl.equals(activeUrl)) {
+            if (!serverUrl.isEmpty() && serverUrl.equals(activeUrl)) {
                 preferences.edit().putString(PreferenceKeys.BRAPI_BASE_URL, "").apply();
                 BrapiFilterCache.Companion.delete(context, true);
             }
             if (pendingRemoveAfterLogout) {
                 pendingRemoveAfterLogout = false;
-                if (serverUrl != null) {
+                if (!serverUrl.isEmpty()) {
                     accountHelper.removeAccount(serverUrl);
                 }
             }
@@ -382,6 +428,22 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
 
     private void activateAccount(Account account) {
         makeAccountActive(account);
+
+        if (!accountHelper.isOwnAccount(account)) {
+            // Selecting a shared server is not enough to use it: its token belongs to the app that
+            // owns the account, so fetch it now and mirror it locally. Without this the server
+            // looks signed out no matter how many times it is selected.
+            accountHelper.borrowToken(account, getActivity(), token -> {
+                if (token == null) {
+                    Toast.makeText(context, R.string.brapi_shared_account_not_signed_in,
+                            Toast.LENGTH_LONG).show();
+                }
+                refreshServerCards();
+                return Unit.INSTANCE;
+            });
+            return;
+        }
+
         refreshServerCards();
     }
 
@@ -393,9 +455,7 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
      * @return the account's server URL
      */
     private String makeAccountActive(Account account) {
-        AccountManager am = AccountManager.get(context);
-        String serverUrl = am.getUserData(account, BrapiAuthenticator.KEY_SERVER_URL);
-        if (serverUrl == null) serverUrl = account.name;
+        String serverUrl = accountHelper.serverUrlOf(account);
         if (accountHelper.setActiveAccount(serverUrl)) {
             BrapiFilterCache.Companion.delete(context, true);
         }
@@ -403,28 +463,22 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
     }
 
     private @NotNull Unit authorizeAccount(Account account) {
-        AccountManager am = AccountManager.get(context);
+        BrapiAccountInfo info = accountHelper.accountInfoOrEmpty(account);
         // Make this account active so BrapiAuthActivity picks up its config
         String serverUrl = makeAccountActive(account);
         pendingAuthAccount = account;
         Intent authIntent = new Intent(context, BrapiAuthActivity.class);
         authIntent.putExtra(BrapiAuthActivity.EXTRA_SERVER_URL, serverUrl);
-        authIntent.putExtra(BrapiAuthActivity.EXTRA_OIDC_URL,
-                am.getUserData(account, BrapiAuthenticator.KEY_OIDC_URL));
-        authIntent.putExtra(BrapiAuthActivity.EXTRA_OIDC_FLOW,
-                am.getUserData(account, BrapiAuthenticator.KEY_OIDC_FLOW));
-        authIntent.putExtra(BrapiAuthActivity.EXTRA_OIDC_CLIENT_ID,
-                am.getUserData(account, BrapiAuthenticator.KEY_OIDC_CLIENT_ID));
-        authIntent.putExtra(BrapiAuthActivity.EXTRA_OIDC_SCOPE,
-                am.getUserData(account, BrapiAuthenticator.KEY_OIDC_SCOPE));
+        authIntent.putExtra(BrapiAuthActivity.EXTRA_OIDC_URL, info.getOidcUrl());
+        authIntent.putExtra(BrapiAuthActivity.EXTRA_OIDC_FLOW, info.getOidcFlow());
+        authIntent.putExtra(BrapiAuthActivity.EXTRA_OIDC_CLIENT_ID, info.getOidcClientId());
+        authIntent.putExtra(BrapiAuthActivity.EXTRA_OIDC_SCOPE, info.getOidcScope());
         startActivityForResult(authIntent, AUTH_REQUEST_CODE);
         return Unit.INSTANCE;
     }
 
     private @NotNull Unit checkServerCompatibility(Account account) {
-        AccountManager am = AccountManager.get(context);
-        String serverUrl = am.getUserData(account, BrapiAuthenticator.KEY_SERVER_URL);
-        if (serverUrl == null) serverUrl = account.name;
+        String serverUrl = accountHelper.serverUrlOf(account);
 
         FragmentActivity act = getActivity();
         if (act != null) {
@@ -442,22 +496,21 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
     }
 
     private @NotNull Unit shareAccountSettings(Account account) {
-        AccountManager am = AccountManager.get(context);
         Activity act = getActivity();
         if (act == null) return Unit.INSTANCE;
 
         try {
+            BrapiAccountInfo info = accountHelper.accountInfoOrEmpty(account);
             BrapiAccountConfig config = new BrapiAccountConfig(
-                    am.getUserData(account, BrapiAuthenticator.KEY_SERVER_URL),
-                    am.getUserData(account, BrapiAuthenticator.KEY_DISPLAY_NAME),
-                    am.getUserData(account, BrapiAuthenticator.KEY_BRAPI_VERSION),
+                    info.getServerUrl(),
+                    info.getDisplayName(),
+                    info.getBrapiVersion(),
                     // Published as the portable "code"/"implicit" spelling so that installs which
                     // predate the stable flow identifiers still read this config correctly.
-                    BrapiAccountConstants.INSTANCE.toSharedConfigOidcFlow(
-                            am.getUserData(account, BrapiAuthenticator.KEY_OIDC_FLOW)),
-                    am.getUserData(account, BrapiAuthenticator.KEY_OIDC_URL),
-                    am.getUserData(account, BrapiAuthenticator.KEY_OIDC_CLIENT_ID),
-                    am.getUserData(account, BrapiAuthenticator.KEY_OIDC_SCOPE)
+                    BrapiAccountConstants.INSTANCE.toSharedConfigOidcFlow(info.getOidcFlow()),
+                    info.getOidcUrl(),
+                    info.getOidcClientId(),
+                    info.getOidcScope()
             );
 
             String jsonConfig = new Gson().toJson(config);
@@ -469,15 +522,15 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
     }
 
     private @NotNull Unit editAccount(Account account) {
-        AccountManager am = AccountManager.get(context);
+        BrapiAccountInfo info = accountHelper.accountInfoOrEmpty(account);
         BrapiAccountConfig config = new BrapiAccountConfig(
-                am.getUserData(account, BrapiAuthenticator.KEY_SERVER_URL),
-                am.getUserData(account, BrapiAuthenticator.KEY_DISPLAY_NAME),
-                am.getUserData(account, BrapiAuthenticator.KEY_BRAPI_VERSION),
-                am.getUserData(account, BrapiAuthenticator.KEY_OIDC_FLOW),
-                am.getUserData(account, BrapiAuthenticator.KEY_OIDC_URL),
-                am.getUserData(account, BrapiAuthenticator.KEY_OIDC_CLIENT_ID),
-                am.getUserData(account, BrapiAuthenticator.KEY_OIDC_SCOPE)
+                info.getServerUrl(),
+                info.getDisplayName(),
+                info.getBrapiVersion(),
+                info.getOidcFlow(),
+                info.getOidcUrl(),
+                info.getOidcClientId(),
+                info.getOidcScope()
         );
 
         BrapiManualAccountDialogFragment frag = BrapiManualAccountDialogFragment.Companion.newInstance(
@@ -488,10 +541,9 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
     }
 
     private @NotNull Unit removeAccount(Account account) {
-        AccountManager am = AccountManager.get(context);
-        String serverUrl = am.getUserData(account, BrapiAuthenticator.KEY_SERVER_URL);
-        String displayName = am.getUserData(account, BrapiAuthenticator.KEY_DISPLAY_NAME);
-        if (displayName == null) displayName = account.name;
+        BrapiAccountInfo info = accountHelper.accountInfoOrEmpty(account);
+        String serverUrl = info.getServerUrl();
+        String displayName = info.getLabel();
 
         String removeMessageTemplate = getString(R.string.brapi_logout_manage_message, displayName);
         SpannableString removeStyledMessage = new SpannableString(removeMessageTemplate);
@@ -506,7 +558,7 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
                 .setTitle(R.string.brapi_logout_manage_title)
                 .setMessage(removeStyledMessage)
                 .setPositiveButton(R.string.brapi_logout_and_remove, (dialog, which) -> {
-                    if (serverUrl != null) {
+                    if (!serverUrl.isEmpty()) {
                         accountHelper.removeAccount(serverUrl);
                         String activeUrl = preferences.getString(PreferenceKeys.BRAPI_BASE_URL, "");
                         if (serverUrl.equals(activeUrl)) {
@@ -553,7 +605,7 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
             } else if (resultCode == RESULT_OK && data != null) {
                 String accountName = data.getStringExtra(AccountManager.KEY_ACCOUNT_NAME);
                 String accountType = data.getStringExtra(AccountManager.KEY_ACCOUNT_TYPE);
-                if (accountName != null && BrapiAuthenticator.ACCOUNT_TYPE.equals(accountType)) {
+                if (accountName != null && BrapiAuthenticator.isBrapiAccountType(accountType)) {
                     Account selected = new Account(accountName, accountType);
                     if (accountHelper.canAccessAccount(selected)) {
                         accountHelper.grantSelectedAccount(selected);
@@ -582,12 +634,11 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
 
             // OIDC end-session completed — clear token for the pending account
             if (loggedOutAccount != null) {
-                AccountManager am = AccountManager.get(context);
-                String serverUrl = am.getUserData(loggedOutAccount, BrapiAuthenticator.KEY_SERVER_URL);
-                accountHelper.clearToken(serverUrl != null ? serverUrl : "");
+                String serverUrl = accountHelper.accountInfoOrEmpty(loggedOutAccount).getServerUrl();
+                accountHelper.clearToken(serverUrl);
 
                 String activeUrl = preferences.getString(PreferenceKeys.BRAPI_BASE_URL, "");
-                boolean wasActiveAccount = serverUrl != null && serverUrl.equals(activeUrl);
+                boolean wasActiveAccount = !serverUrl.isEmpty() && serverUrl.equals(activeUrl);
 
                 if (wasActiveAccount) {
                     // The legacy BRAPI_TOKEN/BRAPI_ID_TOKEN prefs mirror the *active* account, so
@@ -603,7 +654,7 @@ public class BrapiPreferencesFragment extends PreferenceFragmentCompat {
                             .apply();
                     BrapiFilterCache.Companion.delete(context, true);
                 }
-                if (removeAfterLogout && serverUrl != null) {
+                if (removeAfterLogout && !serverUrl.isEmpty()) {
                     accountHelper.removeAccount(serverUrl);
                 }
             } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1412,9 +1412,15 @@
     <string name="brapi_auth_deny">BrAPI Authorization Denied</string>
     <string name="brapi_auth_failed_remove">Remove</string>
     <string name="brapi_auth_error_starting">Error Starting BrAPI Auth</string>
+    <string name="brapi_auth_error_starting_reason">Error Starting BrAPI Auth: %1$s</string>
     <string name="brapi_auth_permission_deny">ERROR: You do not have the permissions necessary to perform this action</string>
     <string name="brapi_auth_needed_title">Login Needed</string>
     <string name="brapi_auth_needed">You need to be logged into the system you are attempting to sync data with in order to sync your data.\n\nWould you like to authenticate now?</string>
+    <string name="brapi_account_migration_deferred">Restart Field Book to finish the BrAPI update</string>
+    <string name="brapi_shared_account_not_signed_in">Sign in to this server from the app that owns it, then select it here again</string>
+    <string name="brapi_add_account_already_shared">%1$s already provides this server. Choose it from Shared Servers instead of adding it again</string>
+    <string name="brapi_auth_success_already_shared">Signed in. This server is already shared from another app, so it stays listed there</string>
+    <string name="brapi_auth_success_no_account">Signed in, but the server could not be saved. Restart Field Book and try again</string>
 
     <!-- BrAPI Import -->
     <string name="import_dialog_title_brapi_fields">BrAPI Field Import</string>

--- a/app/src/main/res/xml/brapi_authenticator.xml
+++ b/app/src/main/res/xml/brapi_authenticator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <account-authenticator
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:accountType="org.phenoapps.brapi"
+    android:accountType="@string/brapi_account_type"
     android:icon="@drawable/pheno_brapi_logo"
     android:smallIcon="@drawable/pheno_brapi_logo"
     android:label="@string/pheno_brapi_account_label" />

--- a/brapi-provider/src/main/AndroidManifest.xml
+++ b/brapi-provider/src/main/AndroidManifest.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- AS complains about having these permissions for the account manager even though our min is 24 -->
+    <uses-permission
+        android:name="android.permission.AUTHENTICATE_ACCOUNTS"
+        android:maxSdkVersion="22" />
+    <uses-permission
+        android:name="android.permission.USE_CREDENTIALS"
+        android:maxSdkVersion="22" />
+
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
 
     <queries>

--- a/brapi-provider/src/main/AndroidManifest.xml
+++ b/brapi-provider/src/main/AndroidManifest.xml
@@ -17,6 +17,20 @@
             android:name="org.phenoapps.brapi.account.BrapiAccessConfirmActivity"
             android:exported="true"
             android:theme="@style/Theme.AppCompat.Light.Dialog.Alert" />
+
+        <!-- Publishes this app's BrAPI account config to sibling PhenoApps. The authority is
+             per-app because each app owns its own account type.
+
+             Deliberately not guarded by a custom permission. Only one installed app may define a
+             given permission name, and a second app declaring it under a different signing key
+             cannot install at all — the same constraint that forced per-app account types. The
+             provider gates itself instead: it serves only accounts this app owns, only to callers
+             whose package is a known PhenoApp, and only once the account has been made visible to
+             that caller. Nothing secret is served — tokens still go through AccountManager. -->
+        <provider
+            android:name="org.phenoapps.brapi.config.BrapiConfigProvider"
+            android:authorities="${applicationId}.brapi.config"
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/BrapiAccountConstants.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/BrapiAccountConstants.kt
@@ -1,9 +1,40 @@
 package org.phenoapps.brapi
 
 object BrapiAccountConstants {
-    const val ACCOUNT_TYPE = "org.phenoapps.brapi"
+    /**
+     * Namespace every app's BrAPI account type sits under.
+     *
+     * Android registers exactly one authenticator package per account type, and admits writes to
+     * it only from callers whose signature matches that package's. Sibling PhenoApps ship under
+     * separate signing keys, so a single shared type would let exactly one of them manage BrAPI
+     * accounts and lock the rest out entirely. Each app therefore owns [accountTypeFor] its own
+     * package, and cross-app sharing works by discovering the others under this prefix.
+     */
+    const val ACCOUNT_TYPE_PREFIX = "org.phenoapps.brapi"
+
+    /**
+     * The single account type used before per-app types.
+     *
+     * Only apps co-signed with whichever one claimed it could ever write to it, which is why it
+     * appeared to work while every app was built with the shared debug key. Accounts left under
+     * it are read and migrated out, never written to.
+     */
+    const val LEGACY_ACCOUNT_TYPE = ACCOUNT_TYPE_PREFIX
+
     const val AUTH_TOKEN_TYPE = "access_token"
-    const val READ_TOKEN_PERMISSION = "org.phenoapps.brapi.READ_TOKEN"
+
+    /** Suffix appended to a package name to form its config provider authority. */
+    const val CONFIG_AUTHORITY_SUFFIX = ".brapi.config"
+
+    /** The BrAPI account type owned by [packageName]. */
+    fun accountTypeFor(packageName: String): String = "$ACCOUNT_TYPE_PREFIX.$packageName"
+
+    /** The config provider authority exposed by [packageName]. */
+    fun configAuthorityFor(packageName: String): String = "$packageName$CONFIG_AUTHORITY_SUFFIX"
+
+    /** Whether [accountType] is a BrAPI account type owned by some app rather than the legacy one. */
+    fun isPerAppAccountType(accountType: String?): Boolean =
+        accountType != null && accountType.startsWith("$ACCOUNT_TYPE_PREFIX.")
 
     // AccountManager user-data keys
     const val KEY_ID_TOKEN = "id_token"

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountAccessPolicy.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountAccessPolicy.kt
@@ -31,8 +31,24 @@ class BrapiAccountAccessPolicy(
         return getCallingPackages(options).any { BrapiAccountConstants.isPackageAllowed(it) }
     }
 
+    /**
+     * The package that owns [account], read off its type.
+     *
+     * Per-app types encode their owner, which is both cheaper and more reliable than the user-data
+     * copy — the copy is unreadable from anywhere but the owning app. Legacy accounts predate the
+     * per-app types and still have to be asked.
+     */
+    fun ownerPackageOf(account: Account): String? =
+        if (BrapiAccountConstants.isPerAppAccountType(account.type)) {
+            account.type.removePrefix("${BrapiAccountConstants.ACCOUNT_TYPE_PREFIX}.")
+        } else {
+            runCatching {
+                accountManager.getUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
+            }.getOrNull()
+        }
+
     fun callingPackageForAccount(account: Account, options: Bundle?): String? {
-        val ownerPackage = accountManager.getUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
+        val ownerPackage = ownerPackageOf(account)
         val callingPackages = getCallingPackages(options)
         return callingPackages.firstOrNull { it == ownerPackage }
             ?: callingPackages.firstOrNull {
@@ -42,7 +58,7 @@ class BrapiAccountAccessPolicy(
 
     fun needsLegacyAccessGrant(account: Account, callingPackage: String): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) return false
-        val ownerPackage = accountManager.getUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
+        val ownerPackage = ownerPackageOf(account)
         if (ownerPackage.isNullOrEmpty() || ownerPackage == callingPackage) return false
         return accountManager.getUserData(
             account,
@@ -67,8 +83,9 @@ class BrapiAccountAccessPolicy(
         )
     }
 
+    /** Looks up one of this app's own accounts — the only ones its authenticator serves. */
     fun findAccount(accountName: String): Account? =
-        accountManager.getAccountsByType(BrapiAccountConstants.ACCOUNT_TYPE)
+        accountManager.getAccountsByType(BrapiAccountConstants.accountTypeFor(context.packageName))
             .firstOrNull { it.name == accountName }
 
     fun tokenResultBundle(account: Account, authTokenType: String): Bundle =

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountAuthenticator.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountAuthenticator.kt
@@ -43,7 +43,7 @@ open class BrapiAccountAuthenticator(
         options: Bundle?,
     ): Bundle {
         val am = AccountManager.get(context)
-        val ownerPackage = am.getUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
+        val ownerPackage = accessPolicy.ownerPackageOf(account)
         val callingPackage = accessPolicy.callingPackageForAccount(account, options)
             ?: return accessPolicy.permissionDeniedBundle()
 

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountRepository.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountRepository.kt
@@ -85,8 +85,8 @@ open class BrapiAccountRepository(
         AccountManager.get(context).authenticatorTypes
             .filter {
                 BrapiAccountConstants.isPerAppAccountType(it.type) &&
-                    it.type != accountType &&
-                    BrapiAccountConstants.isPackageAllowed(it.packageName)
+                        it.type != accountType &&
+                        BrapiAccountConstants.isPackageAllowed(it.packageName)
             }
             .map { it.type }
     }.getOrDefault(emptyList())
@@ -113,7 +113,11 @@ open class BrapiAccountRepository(
         if (BrapiAccountConstants.isPerAppAccountType(account.type)) {
             account.type.removePrefix("${BrapiAccountConstants.ACCOUNT_TYPE_PREFIX}.")
         } else {
-            readUserData(AccountManager.get(context), account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
+            readUserData(
+                AccountManager.get(context),
+                account,
+                BrapiAccountConstants.KEY_OWNER_PACKAGE
+            )
         }
 
     /**
@@ -471,7 +475,11 @@ open class BrapiAccountRepository(
      * could be written; the result says which of those happened so callers can report it honestly
      * rather than claiming an account was created.
      */
-    fun storeToken(serverUrl: String, accessToken: String, idToken: String?): BrapiTokenStoreResult {
+    fun storeToken(
+        serverUrl: String,
+        accessToken: String,
+        idToken: String?
+    ): BrapiTokenStoreResult {
         val am = AccountManager.get(context)
         val normalizedUrl = normalizeUrl(serverUrl)
         val displayName = preferences.getString(preferenceKeys.displayName, normalizedUrl)
@@ -557,7 +565,16 @@ open class BrapiAccountRepository(
                 accountUrl == serverUrl || accountUrl == normalizedUrl || it.name == serverUrl
             }
             .forEach { account ->
-                accountWrite("removeAccount") { am.removeAccountExplicitly(account) }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+                    accountWrite("removeAccount") {
+                        am.removeAccountExplicitly(account)
+                    }
+                } else {
+                    Log.w(
+                        TAG,
+                        "BrAPI account write rejected, SDK_INT < LOLLIPOP_MR1: removeAccount"
+                    )
+                }
                 // Drop the grant alongside the account, or it lingers in preferences forever and
                 // silently re-grants an account later created with the same name.
                 preferences.edit().remove(localGrantPreferenceKey(account)).apply()
@@ -705,7 +722,7 @@ open class BrapiAccountRepository(
                 .map { it.type }
                 .filter {
                     BrapiAccountConstants.isPerAppAccountType(it) ||
-                        it == BrapiAccountConstants.LEGACY_ACCOUNT_TYPE
+                            it == BrapiAccountConstants.LEGACY_ACCOUNT_TYPE
                 }
                 .toSet()
         }.getOrNull() ?: return
@@ -714,7 +731,7 @@ open class BrapiAccountRepository(
 
         val stale = preferences.all.keys.filter { key ->
             key.startsWith(GRANT_PREFERENCE_PREFIX) &&
-                liveTypes.none { key.startsWith("$GRANT_PREFERENCE_PREFIX$it$GRANT_KEY_SEPARATOR") }
+                    liveTypes.none { key.startsWith("$GRANT_PREFERENCE_PREFIX$it$GRANT_KEY_SEPARATOR") }
         }
         if (stale.isEmpty()) return
 
@@ -733,7 +750,11 @@ open class BrapiAccountRepository(
         val ownerPackage = readUserData(am, account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
         if (ownerPackage.isNullOrEmpty()) {
             accountWrite("claimOwnership") {
-                am.setUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE, context.packageName)
+                am.setUserData(
+                    account,
+                    BrapiAccountConstants.KEY_OWNER_PACKAGE,
+                    context.packageName
+                )
             }
             configureOwnedAccountVisibility(am, account)
         } else if (ownerPackage == context.packageName) {
@@ -813,7 +834,11 @@ open class BrapiAccountRepository(
 
     private fun canDisplayAccount(am: AccountManager, account: Account): Boolean {
         val ownerPackage = ownerPackageOf(account)
-        if (!BrapiAccountConstants.canPackageAccessAccount(ownerPackage, context.packageName)) return false
+        if (!BrapiAccountConstants.canPackageAccessAccount(
+                ownerPackage,
+                context.packageName
+            )
+        ) return false
         if (ownerPackage == context.packageName) return true
         return hasGrant(am, account)
     }
@@ -823,7 +848,11 @@ open class BrapiAccountRepository(
 
     private fun canUseToken(am: AccountManager, account: Account): Boolean {
         val ownerPackage = ownerPackageOf(account)
-        if (!BrapiAccountConstants.canPackageAccessAccount(ownerPackage, context.packageName)) return false
+        if (!BrapiAccountConstants.canPackageAccessAccount(
+                ownerPackage,
+                context.packageName
+            )
+        ) return false
         if (ownerPackage.isNullOrEmpty() || ownerPackage == context.packageName) return true
         return hasGrant(am, account)
     }

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountRepository.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountRepository.kt
@@ -9,6 +9,7 @@ import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
+import androidx.annotation.RequiresApi
 import org.phenoapps.brapi.BrapiAccountConstants
 import org.phenoapps.brapi.config.BrapiAccountInfo
 import org.phenoapps.brapi.config.BrapiConfigClient
@@ -556,6 +557,7 @@ open class BrapiAccountRepository(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
     fun removeAccount(serverUrl: String) {
         val am = AccountManager.get(context)
         val normalizedUrl = normalizeUrl(serverUrl)
@@ -565,15 +567,8 @@ open class BrapiAccountRepository(
                 accountUrl == serverUrl || accountUrl == normalizedUrl || it.name == serverUrl
             }
             .forEach { account ->
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-                    accountWrite("removeAccount") {
-                        am.removeAccountExplicitly(account)
-                    }
-                } else {
-                    Log.w(
-                        TAG,
-                        "BrAPI account write rejected, SDK_INT < LOLLIPOP_MR1: removeAccount"
-                    )
+                accountWrite("removeAccount") {
+                    am.removeAccountExplicitly(account)
                 }
                 // Drop the grant alongside the account, or it lingers in preferences forever and
                 // silently re-grants an account later created with the same name.
@@ -601,6 +596,7 @@ open class BrapiAccountRepository(
      * that type. Both have to fail quietly rather than take the caller down with them, but only
      * the first is worth retrying, so they are reported apart.
      */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
     fun migrateFromPrefsIfNeeded(): BrapiMigrationResult {
         migrateLegacyTypeAccounts()
 
@@ -632,6 +628,7 @@ open class BrapiAccountRepository(
      * replacement exists, so the server appears once rather than twice; a failure part-way leaves
      * the original in place to try again.
      */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
     private fun migrateLegacyTypeAccounts() {
         val am = AccountManager.get(context)
         for (legacy in legacyOwnedAccounts(am)) {

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountRepository.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountRepository.kt
@@ -2,12 +2,50 @@ package org.phenoapps.brapi.account
 
 import android.accounts.Account
 import android.accounts.AccountManager
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import org.phenoapps.brapi.BrapiAccountConstants
+import org.phenoapps.brapi.config.BrapiAccountInfo
+import org.phenoapps.brapi.config.BrapiConfigClient
+
+/** Outcome of [BrapiAccountRepository.migrateFromPrefsIfNeeded]. */
+enum class BrapiMigrationResult {
+    /** There was nothing in the legacy preferences to migrate, or it has already been migrated. */
+    NOT_NEEDED,
+
+    /** The legacy preference config now has an AccountManager account behind it. */
+    MIGRATED,
+
+    /**
+     * The account could not be created yet. The legacy preferences are untouched, so calling
+     * again once the platform accepts the write finishes the migration.
+     */
+    DEFERRED,
+}
+
+/** Outcome of [BrapiAccountRepository.storeToken]. */
+enum class BrapiTokenStoreResult {
+    /** The token is on an account this app owns. */
+    STORED,
+
+    /**
+     * A sibling app already owns an account for this server, so no second one was created and the
+     * token lives only in the preference mirrors. Creating one would list the same server twice in
+     * the system account settings.
+     */
+    ALREADY_SHARED,
+
+    /**
+     * No account could be written — see [BrapiAccountRepository.authenticatorOwnerPackage]. The
+     * token is still mirrored, so the sign-in is not lost.
+     */
+    ACCOUNT_UNAVAILABLE,
+}
 
 open class BrapiAccountRepository(
     private val context: Context,
@@ -15,19 +53,132 @@ open class BrapiAccountRepository(
     private val preferenceKeys: BrapiPreferenceKeys,
 ) {
 
+    private val configClient = BrapiConfigClient(context)
+
+    /** The account type this app owns and is registered as the authenticator for. */
+    val accountType: String = BrapiAccountConstants.accountTypeFor(context.packageName)
+
+    /**
+     * Every account this app can see: the ones it owns, plus the ones sibling PhenoApps have
+     * shared with it.
+     *
+     * Siblings own their own account types, so their accounts are reached by enumerating those
+     * types rather than by filtering one shared type. AccountManager only returns accounts the
+     * calling package has been made visible to, so a sibling account appearing here already means
+     * the user granted it.
+     */
     fun getAllAccounts(): List<Account> {
         val am = AccountManager.get(context)
-        return am.getAccountsByType(BrapiAccountConstants.ACCOUNT_TYPE)
+        return (listOf(accountType) + siblingAccountTypes() + BrapiAccountConstants.LEGACY_ACCOUNT_TYPE)
+            .distinct()
+            .flatMap { type -> accountsByType(am, type) }
             .filter { canDisplayAccount(am, it) }
-            .toList()
     }
 
-    fun getAccountByUrl(serverUrl: String): Account? {
+    /**
+     * BrAPI account types owned by other installed PhenoApps.
+     *
+     * Discovered rather than hardcoded: an app's type is its package under the shared prefix, so
+     * the registered authenticators are already the list of siblings that can share accounts.
+     */
+    fun siblingAccountTypes(): List<String> = runCatching {
+        AccountManager.get(context).authenticatorTypes
+            .filter {
+                BrapiAccountConstants.isPerAppAccountType(it.type) &&
+                    it.type != accountType &&
+                    BrapiAccountConstants.isPackageAllowed(it.packageName)
+            }
+            .map { it.type }
+    }.getOrDefault(emptyList())
+
+    /**
+     * The package AccountManager holds as the authenticator for this app's account type, or null
+     * when nothing is registered for it.
+     *
+     * Should always be this app, since the type is namespaced by package name. It is checked
+     * anyway because the registry is rebuilt from package broadcasts, so an install that declares
+     * the authenticator for the first time has a window where the app is running but the type is
+     * not attributed to it yet.
+     */
+    fun authenticatorOwnerPackage(): String? = authenticatorOwnerPackageFor(accountType)
+
+    /**
+     * The package that owns [account].
+     *
+     * Taken from the account type, which encodes it, rather than from user data — reading user
+     * data off another app's account is refused unless the two are co-signed. Legacy accounts
+     * predate per-app types and still have to be asked.
+     */
+    fun ownerPackageOf(account: Account): String? =
+        if (BrapiAccountConstants.isPerAppAccountType(account.type)) {
+            account.type.removePrefix("${BrapiAccountConstants.ACCOUNT_TYPE_PREFIX}.")
+        } else {
+            readUserData(AccountManager.get(context), account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
+        }
+
+    /**
+     * Everything known about [account] — its server URL, display name, version and OIDC settings.
+     *
+     * For an owned account this is AccountManager user data. For a shared one it comes from the
+     * owning app's config provider, since user data is unreadable across a signature boundary.
+     * Null means the owner published nothing for this app, which is the normal state for an
+     * account that has been discovered but not yet granted.
+     */
+    fun accountInfo(account: Account): BrapiAccountInfo? {
+        val owner = ownerPackageOf(account)
+        if (owner == context.packageName || owner.isNullOrEmpty()) {
+            return ownedAccountInfo(account, owner ?: context.packageName)
+        }
+        return configClient.accountsFrom(owner).firstOrNull { it.accountName == account.name }
+    }
+
+    private fun ownedAccountInfo(account: Account, owner: String): BrapiAccountInfo {
         val am = AccountManager.get(context)
+        fun data(key: String) = readUserData(am, account, key).orEmpty()
+        return BrapiAccountInfo(
+            accountName = account.name,
+            ownerPackage = owner,
+            serverUrl = data(BrapiAccountConstants.KEY_SERVER_URL),
+            displayName = data(BrapiAccountConstants.KEY_DISPLAY_NAME).ifEmpty { account.name },
+            brapiVersion = data(BrapiAccountConstants.KEY_BRAPI_VERSION),
+            oidcUrl = data(BrapiAccountConstants.KEY_OIDC_URL),
+            oidcFlow = data(BrapiAccountConstants.KEY_OIDC_FLOW),
+            oidcClientId = data(BrapiAccountConstants.KEY_OIDC_CLIENT_ID),
+            oidcScope = data(BrapiAccountConstants.KEY_OIDC_SCOPE),
+            hasToken = !peekTokenForAccount(account).isNullOrEmpty(),
+        )
+    }
+
+    /**
+     * [accountInfo] with an empty description substituted when the owner published nothing, so
+     * callers rendering an account can read every field without a null check.
+     */
+    fun accountInfoOrEmpty(account: Account): BrapiAccountInfo =
+        accountInfo(account) ?: BrapiAccountInfo(
+            accountName = account.name,
+            ownerPackage = ownerPackageOf(account).orEmpty(),
+        )
+
+    /** A visible account owned by another app that already serves [serverUrl], if there is one. */
+    fun sharedAccountForUrl(serverUrl: String): Account? {
+        val normalized = runCatching { normalizeUrl(serverUrl) }.getOrDefault(serverUrl)
+        return getAllAccounts()
+            .filterNot { isOwnAccount(it) }
+            .firstOrNull {
+                val accountUrl = accountInfo(it)?.serverUrl
+                accountUrl == serverUrl || accountUrl == normalized
+            }
+    }
+
+    /** The server URL [account] points at, from whichever source can describe it. */
+    fun serverUrlOf(account: Account): String =
+        accountInfo(account)?.serverUrl?.takeIf { it.isNotEmpty() } ?: account.name
+
+    fun getAccountByUrl(serverUrl: String): Account? {
         val normalized = runCatching { normalizeUrl(serverUrl) }.getOrDefault(serverUrl)
         return getAllAccounts()
             .firstOrNull {
-                val accountUrl = am.getUserData(it, BrapiAccountConstants.KEY_SERVER_URL)
+                val accountUrl = accountInfo(it)?.serverUrl
                 accountUrl == serverUrl || accountUrl == normalized || it.name == serverUrl
             }
     }
@@ -52,34 +203,45 @@ open class BrapiAccountRepository(
     fun setActiveAccount(serverUrl: String): Boolean {
         val normalized = normalizeUrl(serverUrl)
         val changed = !isActiveAccount(normalized)
-        preferences.edit().putString(preferenceKeys.baseUrl, normalized).apply()
+
+        val editor = preferences.edit().putString(preferenceKeys.baseUrl, normalized)
+        if (changed) {
+            // The token mirrors belong to whichever account was active until now. Carrying them
+            // over would report the newly selected server as signed in and send the previous
+            // server's token to it. An account this app owns re-peeks its real token from
+            // AccountManager; a shared one is repopulated by borrowToken.
+            editor.remove(preferenceKeys.accessToken).remove(preferenceKeys.idToken)
+        }
+        editor.apply()
+
         getAccountByUrl(normalized)?.let { syncActiveAccountPrefs(it) }
         return changed
     }
 
     /**
-     * Mirrors [account]'s stored config into the host's SharedPreference keys.
+     * Mirrors [account]'s config into the host's SharedPreference keys.
      *
-     * Only keys the host declared in [preferenceKeys] are written, and only for user data the
-     * account actually carries — a missing value leaves the existing mirror alone rather than
-     * blanking it.
+     * Only keys the host declared in [preferenceKeys] are written, and only for values the account
+     * actually carries — a missing one leaves the existing mirror alone rather than blanking it.
+     * Shared accounts are described by their owner's config provider, so this works the same for
+     * an account owned by another app as for one of this app's own.
      */
     fun syncActiveAccountPrefs(account: Account) {
-        val am = AccountManager.get(context)
+        val info = accountInfo(account) ?: return
         val editor = preferences.edit()
 
-        fun mirror(prefKey: String?, userDataKey: String) {
-            if (prefKey.isNullOrEmpty()) return
-            am.getUserData(account, userDataKey)?.let { editor.putString(prefKey, it) }
+        fun mirror(prefKey: String?, value: String) {
+            if (prefKey.isNullOrEmpty() || value.isEmpty()) return
+            editor.putString(prefKey, value)
         }
 
-        mirror(preferenceKeys.baseUrl, BrapiAccountConstants.KEY_SERVER_URL)
-        mirror(preferenceKeys.displayName, BrapiAccountConstants.KEY_DISPLAY_NAME)
-        mirror(preferenceKeys.oidcUrl, BrapiAccountConstants.KEY_OIDC_URL)
-        mirror(preferenceKeys.oidcFlow, BrapiAccountConstants.KEY_OIDC_FLOW)
-        mirror(preferenceKeys.oidcClientId, BrapiAccountConstants.KEY_OIDC_CLIENT_ID)
-        mirror(preferenceKeys.oidcScope, BrapiAccountConstants.KEY_OIDC_SCOPE)
-        mirror(preferenceKeys.brapiVersion, BrapiAccountConstants.KEY_BRAPI_VERSION)
+        mirror(preferenceKeys.baseUrl, info.serverUrl)
+        mirror(preferenceKeys.displayName, info.displayName)
+        mirror(preferenceKeys.oidcUrl, info.oidcUrl)
+        mirror(preferenceKeys.oidcFlow, info.oidcFlow)
+        mirror(preferenceKeys.oidcClientId, info.oidcClientId)
+        mirror(preferenceKeys.oidcScope, info.oidcScope)
+        mirror(preferenceKeys.brapiVersion, info.brapiVersion)
 
         editor.apply()
     }
@@ -91,14 +253,20 @@ open class BrapiAccountRepository(
         return activeUrl.isNotEmpty() && (activeUrl == serverUrl || activeUrl == normalized)
     }
 
+    /**
+     * Whether the active account is signed in.
+     *
+     * Deliberately does no blocking token fetch: [AccountManager.blockingGetAuthToken] throws when
+     * called from the main thread, and this is reached from UI. A shared account's token is not
+     * peekable here — it belongs to another app — so the mirror written by [borrowToken] when the
+     * account was enabled is what answers for it.
+     */
     fun hasActiveAccount(): Boolean {
         if (!preferences.getBoolean(preferenceKeys.enabled, false)) return false
         val account = findAccount() ?: return false
         if (!canUseToken(account)) return false
-        val token = AccountManager.get(context)
-            .peekAuthToken(account, BrapiAccountConstants.AUTH_TOKEN_TYPE)
-        if (!token.isNullOrEmpty()) return true
-        return !isOwnAccount(account) && !getTokenBlocking().isNullOrEmpty()
+        if (!peekTokenForAccount(account).isNullOrEmpty()) return true
+        return !preferences.getString(preferenceKeys.accessToken, null).isNullOrEmpty()
     }
 
     fun hasActiveServer(): Boolean {
@@ -126,14 +294,59 @@ open class BrapiAccountRepository(
         }
     }
 
+    /**
+     * The cached token for [account], or null.
+     *
+     * Peeking is restricted to the app that owns the account type, so this only ever answers for
+     * this app's own accounts; a shared account's token has to be fetched with [borrowToken].
+     */
     fun peekTokenForAccount(account: Account): String? =
         AccountManager.get(context).let { am ->
-            if (canUseToken(am, account)) {
+            if (!canUseToken(am, account)) return null
+            runCatching {
                 am.peekAuthToken(account, BrapiAccountConstants.AUTH_TOKEN_TYPE)
-            } else {
-                null
-            }
+            }.getOrNull()
         }
+
+    /**
+     * Fetches [account]'s token from the app that owns it and mirrors it locally.
+     *
+     * This is what makes a shared server usable rather than merely visible. The request crosses to
+     * the owning app's authenticator, which is the one path into another app's token that does not
+     * require a matching signature; passing [activity] lets that app raise its consent screen if it
+     * has not already granted this one. On success the token and id token are written to the
+     * preference mirrors, which is where request building and [hasActiveAccount] read them —
+     * nothing is written into AccountManager, because a borrowed token belongs to its owner.
+     *
+     * Fails with null when the owner has no token to lend, meaning the user has to sign in from
+     * that app first.
+     */
+    fun borrowToken(account: Account, activity: Activity?, onResult: (String?) -> Unit) {
+        if (!canUseToken(account)) {
+            onResult(null)
+            return
+        }
+
+        AccountManager.get(context).getAuthToken(
+            account,
+            BrapiAccountConstants.AUTH_TOKEN_TYPE,
+            null,
+            activity,
+            { future ->
+                val token = runCatching {
+                    future.result?.getString(AccountManager.KEY_AUTHTOKEN)
+                }.onFailure {
+                    Log.w(TAG, "Could not borrow a token for ${account.name}", it)
+                }.getOrNull()
+
+                if (!token.isNullOrEmpty()) {
+                    preferences.edit().putString(preferenceKeys.accessToken, token).apply()
+                }
+                onResult(token?.takeIf { it.isNotEmpty() })
+            },
+            null,
+        )
+    }
 
     fun peekIdToken(): String? {
         val account = findAccount() ?: return null
@@ -143,15 +356,14 @@ open class BrapiAccountRepository(
     fun peekIdTokenForAccount(account: Account): String? {
         return AccountManager.get(context).let { am ->
             if (canUseToken(am, account)) {
-                am.getUserData(account, BrapiAccountConstants.KEY_ID_TOKEN)
+                readUserData(am, account, BrapiAccountConstants.KEY_ID_TOKEN)
             } else {
                 null
             }
         }
     }
 
-    fun isOwnAccount(account: Account): Boolean =
-        AccountManager.get(context).getUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE) == context.packageName
+    fun isOwnAccount(account: Account): Boolean = ownerPackageOf(account) == context.packageName
 
     fun canDisplayAccount(account: Account): Boolean =
         canDisplayAccount(AccountManager.get(context), account)
@@ -167,12 +379,20 @@ open class BrapiAccountRepository(
         preferences.edit().putBoolean(localGrantPreferenceKey(account), true).apply()
     }
 
+    /**
+     * The system account chooser, listing every BrAPI type on the device.
+     *
+     * All of them, not just this app's: choosing a sibling's account here is how the user grants
+     * this app visibility of it, which is the entire shared-server flow.
+     */
     @Suppress("DEPRECATION")
     fun buildChooseAccountIntent(preselected: Account? = null): Intent =
         AccountManager.newChooseAccountIntent(
             preselected,
             null,
-            arrayOf(BrapiAccountConstants.ACCOUNT_TYPE),
+            (listOf(accountType) + siblingAccountTypes() + BrapiAccountConstants.LEGACY_ACCOUNT_TYPE)
+                .distinct()
+                .toTypedArray(),
             true,
             null,
             null,
@@ -183,11 +403,26 @@ open class BrapiAccountRepository(
         )
 
     fun getUserData(account: Account, key: String): String? =
-        AccountManager.get(context).getUserData(account, key)
+        readUserData(AccountManager.get(context), account, key)
 
-    fun setUserData(account: Account, key: String, value: String?) =
-        AccountManager.get(context).setUserData(account, key, value)
+    fun setUserData(account: Account, key: String, value: String?) {
+        accountWrite("setUserData($key)") {
+            AccountManager.get(context).setUserData(account, key, value)
+        }
+    }
 
+    /**
+     * Creates or updates the account for [serverUrl], returning null when it was refused.
+     *
+     * Refused either because AccountManager rejected the write (see [authenticatorOwnerPackage])
+     * or because a sibling app already shares this server — callers should check
+     * [sharedAccountForUrl] first if they want to tell the user which it was. Adding a second
+     * account for a server a sibling already provides is what puts the same server in the system
+     * account settings twice, so it is declined here rather than left to each caller to remember.
+     *
+     * [adoptExistingShared] opts out of that check for callers moving an account this app already
+     * owns, where the account is not new and refusing would lose it.
+     */
     fun addAccountConfig(
         serverUrl: String,
         displayName: String,
@@ -197,43 +432,85 @@ open class BrapiAccountRepository(
         oidcScope: String = "",
         brapiVersion: String = "V2",
         originalServerUrl: String? = null,
-    ): Account {
+        adoptExistingShared: Boolean = false,
+    ): Account? {
         val am = AccountManager.get(context)
         val normalizedUrl = normalizeUrl(serverUrl)
         val lookupUrl = originalServerUrl?.let { normalizeUrl(it) } ?: normalizedUrl
         val accountName = displayName.ifEmpty { extractHostname(normalizedUrl) }
 
-        val account = getWritableAccountByUrl(am, lookupUrl) ?: createAccount(am, accountName)
+        if (!adoptExistingShared && getWritableAccountByUrl(am, lookupUrl) == null) {
+            sharedAccountForUrl(normalizedUrl)?.let { shared ->
+                Log.i(TAG, "Not adding ${shared.name}, already shared by ${ownerPackageOf(shared)}")
+                return null
+            }
+        }
+
+        val account = getWritableAccountByUrl(am, lookupUrl)
+            ?: createAccount(am, accountName)
+            ?: return null
         initializeOwnedAccount(am, account)
 
-        am.setUserData(account, BrapiAccountConstants.KEY_SERVER_URL, normalizedUrl)
-        am.setUserData(account, BrapiAccountConstants.KEY_DISPLAY_NAME, accountName)
-        am.setUserData(account, BrapiAccountConstants.KEY_OIDC_URL, oidcUrl)
-        am.setUserData(account, BrapiAccountConstants.KEY_OIDC_FLOW, oidcFlow)
-        am.setUserData(account, BrapiAccountConstants.KEY_OIDC_CLIENT_ID, oidcClientId)
-        am.setUserData(account, BrapiAccountConstants.KEY_OIDC_SCOPE, oidcScope)
-        am.setUserData(account, BrapiAccountConstants.KEY_BRAPI_VERSION, brapiVersion)
+        val written = accountWrite("addAccountConfig") {
+            am.setUserData(account, BrapiAccountConstants.KEY_SERVER_URL, normalizedUrl)
+            am.setUserData(account, BrapiAccountConstants.KEY_DISPLAY_NAME, accountName)
+            am.setUserData(account, BrapiAccountConstants.KEY_OIDC_URL, oidcUrl)
+            am.setUserData(account, BrapiAccountConstants.KEY_OIDC_FLOW, oidcFlow)
+            am.setUserData(account, BrapiAccountConstants.KEY_OIDC_CLIENT_ID, oidcClientId)
+            am.setUserData(account, BrapiAccountConstants.KEY_OIDC_SCOPE, oidcScope)
+            am.setUserData(account, BrapiAccountConstants.KEY_BRAPI_VERSION, brapiVersion)
+        } != null
 
-        return account
+        return if (written) account else null
     }
 
-    fun storeToken(serverUrl: String, accessToken: String, idToken: String?) {
+    /**
+     * Stores [accessToken] against [serverUrl]'s account and repoints the preference mirrors at it.
+     *
+     * The mirrors are written whatever the outcome, so a sign-in is never lost even when no account
+     * could be written; the result says which of those happened so callers can report it honestly
+     * rather than claiming an account was created.
+     */
+    fun storeToken(serverUrl: String, accessToken: String, idToken: String?): BrapiTokenStoreResult {
         val am = AccountManager.get(context)
         val normalizedUrl = normalizeUrl(serverUrl)
         val displayName = preferences.getString(preferenceKeys.displayName, normalizedUrl)
             ?.takeIf { it.isNotEmpty() } ?: extractHostname(normalizedUrl)
-        val account = getWritableAccountByUrl(am, normalizedUrl) ?: createAccount(am, displayName)
-        initializeOwnedAccount(am, account)
 
-        am.setUserData(account, BrapiAccountConstants.KEY_SERVER_URL, normalizedUrl)
-        am.setAuthToken(account, BrapiAccountConstants.AUTH_TOKEN_TYPE, accessToken)
-        am.setUserData(account, BrapiAccountConstants.KEY_ID_TOKEN, idToken)
-
-        preferences.edit()
+        fun mirror() = preferences.edit()
             .putString(preferenceKeys.baseUrl, normalizedUrl)
             .putString(preferenceKeys.accessToken, accessToken)
             .putString(preferenceKeys.idToken, idToken)
             .apply()
+
+        // A server already covered by a shared account must not get a second, locally owned one:
+        // that is how the same server ends up listed twice in the system account settings.
+        if (getWritableAccountByUrl(am, normalizedUrl) == null) {
+            sharedAccountForUrl(normalizedUrl)?.let { shared ->
+                Log.i(TAG, "Not duplicating ${shared.name}, which ${ownerPackageOf(shared)} owns")
+                mirror()
+                return BrapiTokenStoreResult.ALREADY_SHARED
+            }
+        }
+
+        val account = getWritableAccountByUrl(am, normalizedUrl) ?: createAccount(am, displayName)
+
+        val stored = account?.let { target ->
+            accountWrite("storeToken") {
+                initializeOwnedAccount(am, target)
+                am.setUserData(target, BrapiAccountConstants.KEY_SERVER_URL, normalizedUrl)
+                am.setAuthToken(target, BrapiAccountConstants.AUTH_TOKEN_TYPE, accessToken)
+                am.setUserData(target, BrapiAccountConstants.KEY_ID_TOKEN, idToken)
+            }
+        } != null
+
+        mirror()
+
+        return if (stored) {
+            BrapiTokenStoreResult.STORED
+        } else {
+            BrapiTokenStoreResult.ACCOUNT_UNAVAILABLE
+        }
     }
 
     /**
@@ -254,10 +531,12 @@ open class BrapiAccountRepository(
         val normalizedUrl = runCatching { normalizeUrl(serverUrl) }.getOrDefault(serverUrl)
 
         getWritableAccountByUrl(am, serverUrl)?.let { account ->
-            am.peekAuthToken(account, BrapiAccountConstants.AUTH_TOKEN_TYPE)?.let { token ->
-                am.invalidateAuthToken(BrapiAccountConstants.ACCOUNT_TYPE, token)
+            accountWrite("clearToken") {
+                am.peekAuthToken(account, BrapiAccountConstants.AUTH_TOKEN_TYPE)?.let { token ->
+                    am.invalidateAuthToken(account.type, token)
+                }
+                am.setUserData(account, BrapiAccountConstants.KEY_ID_TOKEN, null)
             }
-            am.setUserData(account, BrapiAccountConstants.KEY_ID_TOKEN, null)
         }
 
         val activeUrl = preferences.getString(preferenceKeys.baseUrl, "") ?: ""
@@ -272,14 +551,17 @@ open class BrapiAccountRepository(
     fun removeAccount(serverUrl: String) {
         val am = AccountManager.get(context)
         val normalizedUrl = normalizeUrl(serverUrl)
-        am.getAccountsByType(BrapiAccountConstants.ACCOUNT_TYPE)
+        writableAccounts(am)
             .filter {
-                val ownerPackage = am.getUserData(it, BrapiAccountConstants.KEY_OWNER_PACKAGE)
-                val accountUrl = am.getUserData(it, BrapiAccountConstants.KEY_SERVER_URL)
-                (ownerPackage.isNullOrEmpty() || ownerPackage == context.packageName) &&
-                    (accountUrl == serverUrl || accountUrl == normalizedUrl || it.name == serverUrl)
+                val accountUrl = readUserData(am, it, BrapiAccountConstants.KEY_SERVER_URL)
+                accountUrl == serverUrl || accountUrl == normalizedUrl || it.name == serverUrl
             }
-            .forEach { am.removeAccountExplicitly(it) }
+            .forEach { account ->
+                accountWrite("removeAccount") { am.removeAccountExplicitly(account) }
+                // Drop the grant alongside the account, or it lingers in preferences forever and
+                // silently re-grants an account later created with the same name.
+                preferences.edit().remove(localGrantPreferenceKey(account)).apply()
+            }
 
         val activeUrl = preferences.getString(preferenceKeys.baseUrl, "") ?: ""
         if (activeUrl == serverUrl || activeUrl == normalizedUrl) {
@@ -291,11 +573,81 @@ open class BrapiAccountRepository(
         }
     }
 
-    fun migrateFromPrefsIfNeeded() {
+    /**
+     * Moves a pre-AccountManager BrAPI config out of the host's SharedPreferences and into an
+     * account, leaving the preferences in place as the source to retry from.
+     *
+     * Nothing here is destructive and nothing latches: the only thing that stops it running again
+     * is an account already existing for the configured server. The write can be refused either
+     * temporarily — an update that adds the authenticator reaches this before the platform has
+     * attributed the account type to the app — or permanently, when another installed app owns
+     * that type. Both have to fail quietly rather than take the caller down with them, but only
+     * the first is worth retrying, so they are reported apart.
+     */
+    fun migrateFromPrefsIfNeeded(): BrapiMigrationResult {
+        migrateLegacyTypeAccounts()
+
         val serverUrl = preferences.getString(preferenceKeys.baseUrl, "") ?: ""
-        val existingToken = preferences.getString(preferenceKeys.accessToken, null) ?: return
-        if (serverUrl.isEmpty() || findAccount() != null) return
-        storeToken(serverUrl, existingToken, preferences.getString(preferenceKeys.idToken, null))
+        val existingToken = preferences.getString(preferenceKeys.accessToken, null)
+            ?: return BrapiMigrationResult.NOT_NEEDED
+        if (serverUrl.isEmpty()) return BrapiMigrationResult.NOT_NEEDED
+
+        return try {
+            if (findAccount() != null) return BrapiMigrationResult.NOT_NEEDED
+            val idToken = preferences.getString(preferenceKeys.idToken, null)
+            when (storeToken(serverUrl, existingToken, idToken)) {
+                BrapiTokenStoreResult.STORED -> BrapiMigrationResult.MIGRATED
+                // A sibling already provides this server, so there is nothing left to migrate.
+                BrapiTokenStoreResult.ALREADY_SHARED -> BrapiMigrationResult.NOT_NEEDED
+                BrapiTokenStoreResult.ACCOUNT_UNAVAILABLE -> BrapiMigrationResult.DEFERRED
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Deferring BrAPI preference migration for $serverUrl", e)
+            BrapiMigrationResult.DEFERRED
+        }
+    }
+
+    /**
+     * Re-creates accounts this app left under the legacy shared type beneath its own type.
+     *
+     * Only reachable when this app is the one that happened to claim the shared type, which is the
+     * state a co-signed development install ends up in. The old account is removed once its
+     * replacement exists, so the server appears once rather than twice; a failure part-way leaves
+     * the original in place to try again.
+     */
+    private fun migrateLegacyTypeAccounts() {
+        val am = AccountManager.get(context)
+        for (legacy in legacyOwnedAccounts(am)) {
+            val info = ownedAccountInfo(legacy, context.packageName)
+            if (info.serverUrl.isEmpty()) continue
+            if (getWritableAccountByUrl(am, info.serverUrl) != null) continue
+
+            val moved = addAccountConfig(
+                serverUrl = info.serverUrl,
+                displayName = info.displayName,
+                oidcUrl = info.oidcUrl,
+                oidcFlow = info.oidcFlow,
+                oidcClientId = info.oidcClientId,
+                oidcScope = info.oidcScope,
+                brapiVersion = info.brapiVersion.ifEmpty { "V2" },
+                // This account is already this app's; it is being moved, not added. Declining it
+                // because a sibling happens to share the same server would lose it outright.
+                adoptExistingShared = true,
+            ) ?: continue
+
+            readUserData(am, legacy, BrapiAccountConstants.KEY_ID_TOKEN)?.let {
+                accountWrite("moveIdToken") {
+                    am.setUserData(moved, BrapiAccountConstants.KEY_ID_TOKEN, it)
+                }
+            }
+            am.peekAuthToken(legacy, BrapiAccountConstants.AUTH_TOKEN_TYPE)?.let { token ->
+                accountWrite("moveAuthToken") {
+                    am.setAuthToken(moved, BrapiAccountConstants.AUTH_TOKEN_TYPE, token)
+                }
+            }
+            accountWrite("removeLegacyAccount") { am.removeAccountExplicitly(legacy) }
+            Log.i(TAG, "Moved BrAPI account ${legacy.name} to $accountType")
+        }
     }
 
     fun normalizeUrl(url: String): String {
@@ -304,10 +656,24 @@ open class BrapiAccountRepository(
         else "https://$trimmed"
     }
 
-    private fun createAccount(am: AccountManager, baseName: String): Account {
-        val existingNames = am.getAccountsByType(BrapiAccountConstants.ACCOUNT_TYPE)
-            .map { it.name }
-            .toSet()
+    /**
+     * Adds an account named after [baseName], or null when AccountManager refuses to create it.
+     *
+     * The refusal is expected rather than exceptional right after an update that introduces the
+     * authenticator, so it is reported to the caller instead of thrown — see
+     * [authenticatorOwnerPackage].
+     */
+    private fun createAccount(am: AccountManager, baseName: String): Account? {
+        val owner = authenticatorOwnerPackage()
+        if (owner != context.packageName) {
+            Log.w(
+                TAG,
+                "BrAPI account type is owned by ${owner ?: "no package"}, not ${context.packageName}",
+            )
+            return null
+        }
+
+        val existingNames = accountsByType(am, accountType).map { it.name }.toSet()
         var uniqueName = baseName
         var suffix = 2
         while (uniqueName in existingNames) {
@@ -315,63 +681,163 @@ open class BrapiAccountRepository(
             suffix++
         }
 
-        return Account(uniqueName, BrapiAccountConstants.ACCOUNT_TYPE).also { account ->
+        val account = Account(uniqueName, accountType)
+        val added = accountWrite("addAccountExplicitly") {
             am.addAccountExplicitly(account, null, null)
-            initializeOwnedAccount(am, account)
         }
+        if (added != true) return null
+
+        initializeOwnedAccount(am, account)
+        return account
+    }
+
+    /**
+     * Drops grant records left behind by BrAPI apps that are no longer installed.
+     *
+     * Deliberately narrow: a grant is only discarded when nothing on the device registers an
+     * authenticator for its account type, which means the app that owned it is gone. Pruning on
+     * "no matching account visible" instead would revoke grants for accounts that are merely
+     * hidden at the moment, making the user re-pick them.
+     */
+    fun pruneStaleGrants() {
+        val liveTypes = runCatching {
+            AccountManager.get(context).authenticatorTypes
+                .map { it.type }
+                .filter {
+                    BrapiAccountConstants.isPerAppAccountType(it) ||
+                        it == BrapiAccountConstants.LEGACY_ACCOUNT_TYPE
+                }
+                .toSet()
+        }.getOrNull() ?: return
+
+        if (liveTypes.isEmpty()) return
+
+        val stale = preferences.all.keys.filter { key ->
+            key.startsWith(GRANT_PREFERENCE_PREFIX) &&
+                liveTypes.none { key.startsWith("$GRANT_PREFERENCE_PREFIX$it$GRANT_KEY_SEPARATOR") }
+        }
+        if (stale.isEmpty()) return
+
+        preferences.edit().apply { stale.forEach { remove(it) } }.apply()
+        Log.i(TAG, "Pruned ${stale.size} BrAPI grant(s) for uninstalled apps")
     }
 
     fun refreshOwnedAccountVisibility() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val am = AccountManager.get(context)
-            am.getAccountsByType(BrapiAccountConstants.ACCOUNT_TYPE)
-                .filter { am.getUserData(it, BrapiAccountConstants.KEY_OWNER_PACKAGE) == context.packageName }
-                .forEach { configureOwnedAccountVisibility(am, it) }
+            writableAccounts(am).forEach { configureOwnedAccountVisibility(am, it) }
         }
     }
 
     private fun initializeOwnedAccount(am: AccountManager, account: Account) {
-        val ownerPackage = am.getUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
+        val ownerPackage = readUserData(am, account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
         if (ownerPackage.isNullOrEmpty()) {
-            am.setUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE, context.packageName)
+            accountWrite("claimOwnership") {
+                am.setUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE, context.packageName)
+            }
             configureOwnedAccountVisibility(am, account)
         } else if (ownerPackage == context.packageName) {
             configureOwnedAccountVisibility(am, account)
         }
     }
 
+    /**
+     * This app's own account for [serverUrl].
+     *
+     * Deliberately its own type only. Legacy-type accounts are writable too, but a caller looking
+     * up an account to write config into wants the one under the current type — otherwise
+     * [migrateLegacyTypeAccounts] would update the account it is trying to replace and then delete
+     * the result.
+     */
     private fun getWritableAccountByUrl(am: AccountManager, serverUrl: String): Account? {
         val normalized = runCatching { normalizeUrl(serverUrl) }.getOrDefault(serverUrl)
-        return am.getAccountsByType(BrapiAccountConstants.ACCOUNT_TYPE)
+        return accountsByType(am, accountType)
             .firstOrNull {
-                val ownerPackage = am.getUserData(it, BrapiAccountConstants.KEY_OWNER_PACKAGE)
-                val accountUrl = am.getUserData(it, BrapiAccountConstants.KEY_SERVER_URL)
-                (ownerPackage.isNullOrEmpty() || ownerPackage == context.packageName) &&
-                    (accountUrl == serverUrl || accountUrl == normalized || it.name == serverUrl)
+                val accountUrl = readUserData(am, it, BrapiAccountConstants.KEY_SERVER_URL)
+                accountUrl == serverUrl || accountUrl == normalized || it.name == serverUrl
             }
     }
 
+    /**
+     * Every account this app may modify: its own type, plus any it left behind under the legacy
+     * shared type back when it owned that.
+     */
+    private fun writableAccounts(am: AccountManager): List<Account> =
+        accountsByType(am, accountType) + legacyOwnedAccounts(am)
+
+    private fun legacyOwnedAccounts(am: AccountManager): List<Account> {
+        if (authenticatorOwnerPackageFor(BrapiAccountConstants.LEGACY_ACCOUNT_TYPE) != context.packageName) {
+            return emptyList()
+        }
+        return accountsByType(am, BrapiAccountConstants.LEGACY_ACCOUNT_TYPE).filter {
+            val owner = readUserData(am, it, BrapiAccountConstants.KEY_OWNER_PACKAGE)
+            owner.isNullOrEmpty() || owner == context.packageName
+        }
+    }
+
+    private fun authenticatorOwnerPackageFor(type: String): String? = runCatching {
+        AccountManager.get(context).authenticatorTypes
+            .firstOrNull { it.type == type }
+            ?.packageName
+    }.getOrNull()
+
+    private fun accountsByType(am: AccountManager, type: String): List<Account> = runCatching {
+        am.getAccountsByType(type).toList()
+    }.getOrDefault(emptyList())
+
+    /**
+     * Reads account user data, treating a refusal as absent data.
+     *
+     * Reads are restricted to the package that owns the account type, so this only ever answers for
+     * accounts this app owns; a sibling's config comes from its config provider instead.
+     */
+    private fun readUserData(am: AccountManager, account: Account, key: String): String? = try {
+        am.getUserData(account, key)
+    } catch (_: SecurityException) {
+        null
+    }
+
+    /**
+     * Runs an AccountManager write, returning null rather than throwing when the platform rejects
+     * it. Callers decide what a rejected write means; nothing here is worth crashing the host over.
+     */
+    private fun <T> accountWrite(operation: String, block: () -> T): T? = try {
+        block()
+    } catch (e: SecurityException) {
+        Log.w(TAG, "BrAPI account write refused: $operation", e)
+        null
+    } catch (e: IllegalArgumentException) {
+        Log.w(TAG, "BrAPI account write rejected: $operation", e)
+        null
+    }
+
     private fun canDisplayAccount(am: AccountManager, account: Account): Boolean {
-        val ownerPackage = am.getUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
+        val ownerPackage = ownerPackageOf(account)
         if (!BrapiAccountConstants.canPackageAccessAccount(ownerPackage, context.packageName)) return false
         if (ownerPackage == context.packageName) return true
         return hasGrant(am, account)
     }
 
-    private fun canAccessAccount(am: AccountManager, account: Account): Boolean {
-        val ownerPackage = am.getUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
-        return BrapiAccountConstants.canPackageAccessAccount(ownerPackage, context.packageName)
-    }
+    private fun canAccessAccount(am: AccountManager, account: Account): Boolean =
+        BrapiAccountConstants.canPackageAccessAccount(ownerPackageOf(account), context.packageName)
 
     private fun canUseToken(am: AccountManager, account: Account): Boolean {
-        val ownerPackage = am.getUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE)
+        val ownerPackage = ownerPackageOf(account)
         if (!BrapiAccountConstants.canPackageAccessAccount(ownerPackage, context.packageName)) return false
         if (ownerPackage.isNullOrEmpty() || ownerPackage == context.packageName) return true
         return hasGrant(am, account)
     }
 
+    /**
+     * Whether the user has let this app use [account].
+     *
+     * The grant the owner records on the account is only readable by co-signed callers, so the
+     * local copy written by [grantSelectedAccount] when the user picks the account is what
+     * normally answers this.
+     */
     private fun hasGrant(am: AccountManager, account: Account): Boolean {
-        val accountGrant = am.getUserData(
+        val accountGrant = readUserData(
+            am,
             account,
             BrapiAccountConstants.grantedPackageKey(context.packageName),
         ) == "true"
@@ -379,12 +845,12 @@ open class BrapiAccountRepository(
         return accountGrant || localGrant
     }
 
-    private fun localGrantPreferenceKey(account: Account): String {
-        val am = AccountManager.get(context)
-        val ownerPackage = am.getUserData(account, BrapiAccountConstants.KEY_OWNER_PACKAGE) ?: "legacy"
-        val serverUrl = am.getUserData(account, BrapiAccountConstants.KEY_SERVER_URL) ?: account.name
-        return "brapi_account_grant_${ownerPackage}_${account.type}_${serverUrl}"
-    }
+    /**
+     * Keyed on the account's identity rather than its server URL, since the URL lives in user data
+     * this app cannot read on an account another app owns.
+     */
+    private fun localGrantPreferenceKey(account: Account): String =
+        "$GRANT_PREFERENCE_PREFIX${account.type}$GRANT_KEY_SEPARATOR${account.name}"
 
     private fun extractHostname(url: String): String = try {
         java.net.URL(url).host.ifEmpty { url }
@@ -393,7 +859,9 @@ open class BrapiAccountRepository(
     }
 
     private fun configureOwnedAccountVisibility(am: AccountManager, account: Account) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        accountWrite("setAccountVisibility") {
             am.setAccountVisibility(
                 account,
                 AccountManager.PACKAGE_NAME_KEY_LEGACY_VISIBLE,
@@ -422,5 +890,11 @@ open class BrapiAccountRepository(
                 }
             }
         }
+    }
+
+    companion object {
+        private const val TAG = "BrapiAccountRepo"
+        private const val GRANT_PREFERENCE_PREFIX = "brapi_account_grant_"
+        private const val GRANT_KEY_SEPARATOR = "_"
     }
 }

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountRepository.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/account/BrapiAccountRepository.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.core.content.edit
 import org.phenoapps.brapi.BrapiAccountConstants
 import org.phenoapps.brapi.config.BrapiAccountInfo
 import org.phenoapps.brapi.config.BrapiConfigClient
@@ -209,15 +210,18 @@ open class BrapiAccountRepository(
         val normalized = normalizeUrl(serverUrl)
         val changed = !isActiveAccount(normalized)
 
-        val editor = preferences.edit().putString(preferenceKeys.baseUrl, normalized)
-        if (changed) {
-            // The token mirrors belong to whichever account was active until now. Carrying them
-            // over would report the newly selected server as signed in and send the previous
-            // server's token to it. An account this app owns re-peeks its real token from
-            // AccountManager; a shared one is repopulated by borrowToken.
-            editor.remove(preferenceKeys.accessToken).remove(preferenceKeys.idToken)
+        preferences.edit {
+            putString(preferenceKeys.baseUrl, normalized)
+
+            if (changed) {
+                // The token mirrors belong to whichever account was active until now. Carrying them
+                // over would report the newly selected server as signed in and send the previous
+                // server's token to it. An account this app owns re-peeks its real token from
+                // AccountManager; a shared one is repopulated by borrowToken.
+                remove(preferenceKeys.accessToken)
+                remove(preferenceKeys.idToken)
+            }
         }
-        editor.apply()
 
         getAccountByUrl(normalized)?.let { syncActiveAccountPrefs(it) }
         return changed
@@ -233,22 +237,22 @@ open class BrapiAccountRepository(
      */
     fun syncActiveAccountPrefs(account: Account) {
         val info = accountInfo(account) ?: return
-        val editor = preferences.edit()
+        preferences.edit {
 
-        fun mirror(prefKey: String?, value: String) {
-            if (prefKey.isNullOrEmpty() || value.isEmpty()) return
-            editor.putString(prefKey, value)
+            fun mirror(prefKey: String?, value: String) {
+                if (prefKey.isNullOrEmpty() || value.isEmpty()) return
+                putString(prefKey, value)
+            }
+
+            mirror(preferenceKeys.baseUrl, info.serverUrl)
+            mirror(preferenceKeys.displayName, info.displayName)
+            mirror(preferenceKeys.oidcUrl, info.oidcUrl)
+            mirror(preferenceKeys.oidcFlow, info.oidcFlow)
+            mirror(preferenceKeys.oidcClientId, info.oidcClientId)
+            mirror(preferenceKeys.oidcScope, info.oidcScope)
+            mirror(preferenceKeys.brapiVersion, info.brapiVersion)
+
         }
-
-        mirror(preferenceKeys.baseUrl, info.serverUrl)
-        mirror(preferenceKeys.displayName, info.displayName)
-        mirror(preferenceKeys.oidcUrl, info.oidcUrl)
-        mirror(preferenceKeys.oidcFlow, info.oidcFlow)
-        mirror(preferenceKeys.oidcClientId, info.oidcClientId)
-        mirror(preferenceKeys.oidcScope, info.oidcScope)
-        mirror(preferenceKeys.brapiVersion, info.brapiVersion)
-
-        editor.apply()
     }
 
     /** Whether [serverUrl] is the account the preference mirrors currently describe. */
@@ -345,7 +349,7 @@ open class BrapiAccountRepository(
                 }.getOrNull()
 
                 if (!token.isNullOrEmpty()) {
-                    preferences.edit().putString(preferenceKeys.accessToken, token).apply()
+                    preferences.edit { putString(preferenceKeys.accessToken, token) }
                 }
                 onResult(token?.takeIf { it.isNotEmpty() })
             },
@@ -381,7 +385,7 @@ open class BrapiAccountRepository(
 
     fun grantSelectedAccount(account: Account) {
         if (!canAccessAccount(account)) return
-        preferences.edit().putBoolean(localGrantPreferenceKey(account), true).apply()
+        preferences.edit { putBoolean(localGrantPreferenceKey(account), true) }
     }
 
     /**
@@ -486,11 +490,11 @@ open class BrapiAccountRepository(
         val displayName = preferences.getString(preferenceKeys.displayName, normalizedUrl)
             ?.takeIf { it.isNotEmpty() } ?: extractHostname(normalizedUrl)
 
-        fun mirror() = preferences.edit()
-            .putString(preferenceKeys.baseUrl, normalizedUrl)
-            .putString(preferenceKeys.accessToken, accessToken)
-            .putString(preferenceKeys.idToken, idToken)
-            .apply()
+        fun mirror() = preferences.edit {
+            putString(preferenceKeys.baseUrl, normalizedUrl)
+            putString(preferenceKeys.accessToken, accessToken)
+            putString(preferenceKeys.idToken, idToken)
+        }
 
         // A server already covered by a shared account must not get a second, locally owned one:
         // that is how the same server ends up listed twice in the system account settings.
@@ -550,10 +554,10 @@ open class BrapiAccountRepository(
 
         val activeUrl = preferences.getString(preferenceKeys.baseUrl, "") ?: ""
         if (activeUrl == serverUrl || activeUrl == normalizedUrl) {
-            preferences.edit()
-                .remove(preferenceKeys.accessToken)
-                .remove(preferenceKeys.idToken)
-                .apply()
+            preferences.edit {
+                remove(preferenceKeys.accessToken)
+                remove(preferenceKeys.idToken)
+            }
         }
     }
 
@@ -572,16 +576,16 @@ open class BrapiAccountRepository(
                 }
                 // Drop the grant alongside the account, or it lingers in preferences forever and
                 // silently re-grants an account later created with the same name.
-                preferences.edit().remove(localGrantPreferenceKey(account)).apply()
+                preferences.edit { remove(localGrantPreferenceKey(account)) }
             }
 
         val activeUrl = preferences.getString(preferenceKeys.baseUrl, "") ?: ""
         if (activeUrl == serverUrl || activeUrl == normalizedUrl) {
-            preferences.edit()
-                .remove(preferenceKeys.baseUrl)
-                .remove(preferenceKeys.accessToken)
-                .remove(preferenceKeys.idToken)
-                .apply()
+            preferences.edit {
+                remove(preferenceKeys.baseUrl)
+                remove(preferenceKeys.accessToken)
+                remove(preferenceKeys.idToken)
+            }
         }
     }
 
@@ -732,7 +736,9 @@ open class BrapiAccountRepository(
         }
         if (stale.isEmpty()) return
 
-        preferences.edit().apply { stale.forEach { remove(it) } }.apply()
+        preferences.edit {
+            stale.forEach { remove(it) }
+        }
         Log.i(TAG, "Pruned ${stale.size} BrAPI grant(s) for uninstalled apps")
     }
 

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/config/BrapiConfigClient.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/config/BrapiConfigClient.kt
@@ -1,0 +1,62 @@
+package org.phenoapps.brapi.config
+
+import android.content.Context
+import android.database.Cursor
+import android.util.Log
+
+/**
+ * Reads BrAPI account config published by sibling PhenoApps.
+ *
+ * Every failure here is expected traffic rather than an error: the sibling may not be installed,
+ * may predate the provider, or may simply not have granted this app the account. All of them come
+ * back as "no config", which callers render as an account they can see but not yet describe.
+ */
+class BrapiConfigClient(private val context: Context) {
+
+    /** Every account [ownerPackage] has published to this app, empty when it publishes none. */
+    fun accountsFrom(ownerPackage: String): List<BrapiAccountInfo> {
+        val uri = BrapiConfigContract.accountsUri(ownerPackage)
+        return try {
+            context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+                buildList {
+                    while (cursor.moveToNext()) {
+                        add(cursor.toAccountInfo(ownerPackage))
+                    }
+                }
+            }.orEmpty()
+        } catch (e: Exception) {
+            Log.w(TAG, "No BrAPI config available from $ownerPackage", e)
+            emptyList()
+        }
+    }
+
+    private fun Cursor.toAccountInfo(ownerPackage: String): BrapiAccountInfo {
+        fun text(column: String): String {
+            val index = getColumnIndex(column)
+            return if (index < 0) "" else getString(index).orEmpty()
+        }
+
+        fun flag(column: String): Boolean {
+            val index = getColumnIndex(column)
+            return index >= 0 && getInt(index) == 1
+        }
+
+        val accountName = text(BrapiConfigContract.COLUMN_ACCOUNT_NAME)
+        return BrapiAccountInfo(
+            accountName = accountName,
+            ownerPackage = ownerPackage,
+            serverUrl = text(BrapiConfigContract.COLUMN_SERVER_URL),
+            displayName = text(BrapiConfigContract.COLUMN_DISPLAY_NAME).ifEmpty { accountName },
+            brapiVersion = text(BrapiConfigContract.COLUMN_BRAPI_VERSION),
+            oidcUrl = text(BrapiConfigContract.COLUMN_OIDC_URL),
+            oidcFlow = text(BrapiConfigContract.COLUMN_OIDC_FLOW),
+            oidcClientId = text(BrapiConfigContract.COLUMN_OIDC_CLIENT_ID),
+            oidcScope = text(BrapiConfigContract.COLUMN_OIDC_SCOPE),
+            hasToken = flag(BrapiConfigContract.COLUMN_HAS_TOKEN),
+        )
+    }
+
+    companion object {
+        private const val TAG = "BrapiConfigClient"
+    }
+}

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/config/BrapiConfigContract.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/config/BrapiConfigContract.kt
@@ -1,0 +1,67 @@
+package org.phenoapps.brapi.config
+
+import android.net.Uri
+import org.phenoapps.brapi.BrapiAccountConstants
+
+/**
+ * The read-only surface each app exposes so sibling PhenoApps can describe its BrAPI accounts.
+ *
+ * AccountManager gates `getUserData` on a signature match with the account type's authenticator,
+ * so an app cannot read another app's account config directly once each owns its own type. Tokens
+ * still cross through the authenticator, but a shared server card needs its URL, version and OIDC
+ * settings before the user has granted anything — hence this provider.
+ *
+ * Nothing secret travels here: tokens are deliberately absent, and [COLUMN_HAS_TOKEN] reports only
+ * whether one exists so a card can show whether the server is signed in.
+ */
+object BrapiConfigContract {
+
+    const val PATH_ACCOUNTS = "accounts"
+
+    const val COLUMN_ACCOUNT_NAME = "account_name"
+    const val COLUMN_SERVER_URL = "server_url"
+    const val COLUMN_DISPLAY_NAME = "display_name"
+    const val COLUMN_BRAPI_VERSION = "brapi_version"
+    const val COLUMN_OIDC_URL = "oidc_url"
+    const val COLUMN_OIDC_FLOW = "oidc_flow"
+    const val COLUMN_OIDC_CLIENT_ID = "oidc_client_id"
+    const val COLUMN_OIDC_SCOPE = "oidc_scope"
+    const val COLUMN_HAS_TOKEN = "has_token"
+
+    val COLUMNS = arrayOf(
+        COLUMN_ACCOUNT_NAME,
+        COLUMN_SERVER_URL,
+        COLUMN_DISPLAY_NAME,
+        COLUMN_BRAPI_VERSION,
+        COLUMN_OIDC_URL,
+        COLUMN_OIDC_FLOW,
+        COLUMN_OIDC_CLIENT_ID,
+        COLUMN_OIDC_SCOPE,
+        COLUMN_HAS_TOKEN,
+    )
+
+    /** The accounts table exposed by [packageName]. */
+    fun accountsUri(packageName: String): Uri = Uri.parse(
+        "content://${BrapiAccountConstants.configAuthorityFor(packageName)}/$PATH_ACCOUNTS",
+    )
+}
+
+/**
+ * A BrAPI account's configuration, sourced either from AccountManager user data (for accounts this
+ * app owns) or from the owning app's [BrapiConfigContract] provider (for shared ones).
+ */
+data class BrapiAccountInfo(
+    val accountName: String,
+    val ownerPackage: String,
+    val serverUrl: String = "",
+    val displayName: String = "",
+    val brapiVersion: String = "",
+    val oidcUrl: String = "",
+    val oidcFlow: String = "",
+    val oidcClientId: String = "",
+    val oidcScope: String = "",
+    val hasToken: Boolean = false,
+) {
+    /** What to show for this account, falling back to the account name when unnamed. */
+    val label: String get() = displayName.ifEmpty { accountName }
+}

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/config/BrapiConfigProvider.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/config/BrapiConfigProvider.kt
@@ -1,0 +1,100 @@
+package org.phenoapps.brapi.config
+
+import android.accounts.Account
+import android.accounts.AccountManager
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.util.Log
+import org.phenoapps.brapi.BrapiAccountConstants
+import org.phenoapps.brapi.account.BrapiAccountAccessPolicy
+
+/**
+ * Publishes this app's BrAPI account config to sibling PhenoApps.
+ *
+ * Only accounts this app owns are served, and only to a caller that is both a known PhenoApps
+ * package and one the account has been made visible to — the same grant the user performs in the
+ * account chooser. The read-token permission on the provider is `normal`, so it is a declaration
+ * of intent rather than a boundary; the caller check and the visibility check are what actually
+ * gate this.
+ */
+class BrapiConfigProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean = true
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? {
+        val context = context ?: return null
+        if (uri.lastPathSegment != BrapiConfigContract.PATH_ACCOUNTS) return null
+
+        val caller = callingPackage
+        if (!BrapiAccountConstants.isPackageAllowed(caller) || caller == null) {
+            Log.w(TAG, "Refusing BrAPI config request from $caller")
+            return null
+        }
+
+        val am = AccountManager.get(context)
+        val policy = BrapiAccountAccessPolicy(context)
+        val ownType = BrapiAccountConstants.accountTypeFor(context.packageName)
+        val cursor = MatrixCursor(BrapiConfigContract.COLUMNS)
+
+        val accounts = runCatching { am.getAccountsByType(ownType) }.getOrNull() ?: return cursor
+        for (account in accounts) {
+            // The caller has to have been granted this account already. Ungranted accounts are
+            // discovered through the system account chooser instead, which is where the user
+            // makes that call — publishing them here would route around it.
+            if (caller != context.packageName && !policy.isVisibleToCaller(account, caller)) continue
+            cursor.addRow(rowFor(am, account))
+        }
+        return cursor
+    }
+
+    private fun rowFor(am: AccountManager, account: Account): Array<Any?> {
+        fun data(key: String): String = runCatching { am.getUserData(account, key) }
+            .getOrNull()
+            .orEmpty()
+
+        val hasToken = runCatching {
+            !am.peekAuthToken(account, BrapiAccountConstants.AUTH_TOKEN_TYPE).isNullOrEmpty()
+        }.getOrDefault(false)
+
+        return arrayOf(
+            account.name,
+            data(BrapiAccountConstants.KEY_SERVER_URL),
+            data(BrapiAccountConstants.KEY_DISPLAY_NAME).ifEmpty { account.name },
+            data(BrapiAccountConstants.KEY_BRAPI_VERSION),
+            data(BrapiAccountConstants.KEY_OIDC_URL),
+            data(BrapiAccountConstants.KEY_OIDC_FLOW),
+            data(BrapiAccountConstants.KEY_OIDC_CLIENT_ID),
+            data(BrapiAccountConstants.KEY_OIDC_SCOPE),
+            if (hasToken) 1 else 0,
+        )
+    }
+
+    override fun getType(uri: Uri): String =
+        "vnd.android.cursor.dir/vnd.${BrapiAccountConstants.ACCOUNT_TYPE_PREFIX}.account"
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? =
+        throw UnsupportedOperationException("BrAPI config is read-only")
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = throw UnsupportedOperationException("BrAPI config is read-only")
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int =
+        throw UnsupportedOperationException("BrAPI config is read-only")
+
+    companion object {
+        private const val TAG = "BrapiConfigProvider"
+    }
+}

--- a/brapi-provider/src/main/java/org/phenoapps/brapi/ui/BrapiServerCardPreference.kt
+++ b/brapi-provider/src/main/java/org/phenoapps/brapi/ui/BrapiServerCardPreference.kt
@@ -1,7 +1,6 @@
 package org.phenoapps.brapi.ui
 
 import android.accounts.Account
-import android.accounts.AccountManager
 import android.content.Context
 import android.util.AttributeSet
 import androidx.compose.runtime.getValue
@@ -11,7 +10,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
-import org.phenoapps.brapi.BrapiAccountConstants
 import org.phenoapps.brapi.R
 
 open class BrapiServerCardPreference @JvmOverloads constructor(
@@ -34,6 +32,19 @@ open class BrapiServerCardPreference @JvmOverloads constructor(
     var ownerLabel: String? = null
         set(value) { field = value; notifyChanged() }
 
+    /**
+     * What the card shows for the account.
+     *
+     * Supplied by the host rather than read here: an account owned by another app keeps its config
+     * out of reach of `getUserData`, so only the host — which can ask that app's config provider —
+     * can describe a shared server.
+     */
+    var displayName: String? = null
+        set(value) { field = value; notifyChanged() }
+
+    var serverUrl: String? = null
+        set(value) { field = value; notifyChanged() }
+
     var hasToken: Boolean? = null
         set(value) { field = value; notifyChanged() }
 
@@ -54,11 +65,9 @@ open class BrapiServerCardPreference @JvmOverloads constructor(
     override fun onBindViewHolder(holder: PreferenceViewHolder) {
         super.onBindViewHolder(holder)
         val acct = account ?: return
-        val am = AccountManager.get(context)
 
-        val displayName = am.getUserData(acct, BrapiAccountConstants.KEY_DISPLAY_NAME)
-            ?.takeIf { it.isNotEmpty() } ?: acct.name
-        val serverUrl = am.getUserData(acct, BrapiAccountConstants.KEY_SERVER_URL) ?: ""
+        val shownName = displayName?.takeIf { it.isNotEmpty() } ?: acct.name
+        val shownUrl = serverUrl.orEmpty()
         val tokenVisible = hasToken ?: false
 
         (holder.itemView as? ComposeView)?.apply {
@@ -68,8 +77,8 @@ open class BrapiServerCardPreference @JvmOverloads constructor(
             setContent {
                 PhenoBrapiTheme {
                     BrapiServerCard(
-                        displayName = displayName,
-                        serverUrl = serverUrl,
+                        displayName = shownName,
+                        serverUrl = shownUrl,
                         isActive = isActive,
                         hasToken = tokenVisible,
                         isExpanded = expandedState,


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

- Per-app account types — each app now owns org.phenoapps.brapi.<applicationId> (declared via a per-variant resValue) instead of one shared type, since only the app registering a type, or one co-signed with it, can write its accounts. Also removed the READ_TOKEN permission declaration, which was blocking debug and release from coexisting.
- Config sharing over a ContentProvider — BrapiConfigProvider/BrapiConfigClient publish each app's own accounts' non-secret config (URL, name, version, OIDC, has_token) to granted sibling packages, because getUserData is signature-gated; every former direct read now goes through accountInfo().
- Token borrowing — borrowToken() fetches a shared account's token from its owning app via getAuthToken and mirrors it locally; shared cards no longer offer Authorize/Edit/Remove, and storeToken/addAccountConfig refuse to create a second account for a server a sibling already provides.

Test with coordinate debug, field book debug, and field book release builds

### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
BrAPI account manager improvements and optimizations
```