### PR TITLE
Nix/Innospectra improvements

### DIFF
--- a/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
+++ b/app/src/main/java/com/fieldbook/tracker/activities/CollectActivity.java
@@ -1371,7 +1371,8 @@ public class CollectActivity extends ThemedActivity
 
         traitLayoutRefresh();
 
-        //nixSensorHelper.disconnect();
+        //release resources every trait layout owns, not just the one on screen
+        traitLayouts.onDestroy();
 
         bleScanner.stopScanning();
 

--- a/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
+++ b/app/src/main/java/com/fieldbook/tracker/database/dao/ObservationDao.kt
@@ -36,13 +36,22 @@ class ObservationDao {
 
         const val TAG = "ObservationDao"
 
+        /**
+         * Returns null when no observation carries [id].
+         *
+         * toFirst() answers a miss with an empty row rather than nothing, and ObservationModel
+         * reads its columns through map delegates, so handing that row on produced a model that
+         * threw NoSuchElementException on first field access instead of a null callers could
+         * check. Spectral facts whose observation had been deleted crashed the trait that way.
+         */
         fun getById(id: String): ObservationModel? = withDatabase { db ->
 
             db.query(Observation.tableName,
                 where = "${Observation.PK} = ?",
                 whereArgs = arrayOf(id))
                 .toFirst()
-                .let { ObservationModel(it) }
+                .takeIf { it.isNotEmpty() }
+                ?.let { ObservationModel(it) }
 
         }
 

--- a/app/src/main/java/com/fieldbook/tracker/devices/spectrometers/innospectra/InnoSpectraViewModel.kt
+++ b/app/src/main/java/com/fieldbook/tracker/devices/spectrometers/innospectra/InnoSpectraViewModel.kt
@@ -55,6 +55,73 @@ class InnoSpectraViewModel @Inject constructor() : ViewModel(), InnoSpectraViewM
 
     data class NanoConnection(val sdk: ISCNIRScanSDK, val device: NanoDevice)
 
+    /**
+     * Ordered stages of the connection handshake, with the percentage each one represents.
+     *
+     * The SDK announces every step as its own broadcast, so this is real progress rather than a
+     * timer: each stage is posted when its broadcast actually lands. The percentages are the
+     * share of a connection's wall clock that has elapsed by that point, measured on a device as
+     * 6.0s connecting, then 3.9, 2.6, 0.3, 1.7, 0.7 and 0.6s for the stages that follow. Spacing
+     * them evenly instead would make the arc lurch, since the stages differ by 20x in length.
+     *
+     * [CONNECTING] carries no percentage: nothing is broadcast until the BLE link is up, so there
+     * is nothing to report during it. The indicator spins through that stage and switches to the
+     * arc when [HANDSHAKE] lands. It is also the longest stage, which is exactly the stretch a
+     * bar parked near zero would misrepresent.
+     *
+     * [SCAN_CONFIGS] covers the config download, which reports a genuine received/total fraction
+     * and so fills the span between its own percentage and [READY].
+     */
+    enum class ConnectionStage(val percent: Int?) {
+        CONNECTING(null),
+        HANDSHAKE(38),
+        DEVICE_INFO(63),
+        DEVICE_UUID(79),
+        DEVICE_STATUS(81),
+        SCAN_CONFIGS(92),
+        READY(100)
+    }
+
+    data class ConnectionProgress(val stage: ConnectionStage, val percent: Int?)
+
+    private val mConnectionProgress: MutableLiveData<ConnectionProgress?> = MutableLiveData(null)
+
+    fun getConnectionProgress(): LiveData<ConnectionProgress?> = mConnectionProgress
+
+    /**
+     * Marks the start of a connection attempt. Called by the trait layout because nothing is
+     * broadcast until the BLE link is already up.
+     */
+    fun startConnectionProgress() = postStage(ConnectionStage.CONNECTING)
+
+    private fun postStage(stage: ConnectionStage) {
+        mConnectionProgress.postValue(ConnectionProgress(stage, stage.percent))
+    }
+
+    /**
+     * Config download progress. Held just below [ConnectionStage.READY] so the arc cannot reach
+     * the end before the active config actually arrives.
+     */
+    private fun postConfigProgress() {
+
+        val base = ConnectionStage.SCAN_CONFIGS.percent ?: return
+        val end = ConnectionStage.READY.percent ?: return
+
+        val total = mConfigSize ?: 0
+        val span = end - base
+
+        val percent = if (total > 0) {
+            //held short of the end so the arc cannot fill before the active config arrives
+            base + (span * mConfigs.size / total).coerceAtMost(span - 3)
+        } else {
+            base
+        }
+
+        mConnectionProgress.postValue(
+            ConnectionProgress(ConnectionStage.SCAN_CONFIGS, percent)
+        )
+    }
+
     //track if device is currently connected
     private var mConnected = false
 
@@ -253,6 +320,7 @@ class InnoSpectraViewModel @Inject constructor() : ViewModel(), InnoSpectraViewM
         mRefDataReady = false
         mBluetoothDevice = null
         mConnectionStarting = false
+        mConnectionProgress.postValue(null)
 
         return 1
     }
@@ -283,6 +351,15 @@ class InnoSpectraViewModel @Inject constructor() : ViewModel(), InnoSpectraViewM
     } else false
 
     private fun isRefDataReady() = mRefDataReady
+
+    /**
+     * Whether [scan] will actually start a measurement.
+     *
+     * Callers need this up front because scan() reports "cannot scan" by returning a LiveData
+     * already holding null, which is indistinguishable from the null it publishes to reset itself
+     * just before a real scan begins.
+     */
+    fun isReadyToScan() = isConnected() && isRefDataReady()
 
     override fun reset(context: Context?) {
 
@@ -353,6 +430,8 @@ class InnoSpectraViewModel @Inject constructor() : ViewModel(), InnoSpectraViewM
 
         if (isGattStateConnected()) {
 
+            postStage(ConnectionStage.HANDSHAKE)
+
             // ControlPhysicalButton(PhysicalButton.Lock)
 
             //jni call
@@ -421,6 +500,8 @@ class InnoSpectraViewModel @Inject constructor() : ViewModel(), InnoSpectraViewM
 
         mDeviceInfo.uuid = uuid
 
+        postStage(ConnectionStage.DEVICE_UUID)
+
         GetDeviceStatus()
 
     }
@@ -435,6 +516,8 @@ class InnoSpectraViewModel @Inject constructor() : ViewModel(), InnoSpectraViewM
 
         mConnected = true
 
+        postStage(ConnectionStage.DEVICE_INFO)
+
         GetUUID()
     }
 
@@ -443,6 +526,8 @@ class InnoSpectraViewModel @Inject constructor() : ViewModel(), InnoSpectraViewM
         if (mConfigs.isEmpty() || !mConfigs.any { config.scanConfigIndex == it.scanConfigIndex }) {
 
             mConfigs.add(config)
+
+            postConfigProgress()
 
             if (mConfigs.size == mConfigSize) {
 
@@ -456,11 +541,15 @@ class InnoSpectraViewModel @Inject constructor() : ViewModel(), InnoSpectraViewM
     override fun onGetActiveConfig(index: Int) {
 
         mActiveIndex = index
+
+        postStage(ConnectionStage.READY)
     }
 
     override fun onGetDeviceStatus(status: DeviceStatus) {
 
         mDeviceStatus = status
+
+        postStage(ConnectionStage.DEVICE_STATUS)
 
         GetScanConfig()
     }
@@ -468,6 +557,8 @@ class InnoSpectraViewModel @Inject constructor() : ViewModel(), InnoSpectraViewM
     override fun onGetConfigSize(size: Int) {
 
         mConfigSize = size
+
+        postConfigProgress()
     }
 
     override fun onConfigSaveStatus(status: Boolean) {

--- a/app/src/main/java/com/fieldbook/tracker/traits/BaseTraitLayout.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/BaseTraitLayout.java
@@ -224,6 +224,15 @@ public abstract class BaseTraitLayout extends LinearLayout {
     public void onExit() {}
 
     /**
+     * Called for every trait layout when the hosting activity is destroyed.
+     *
+     * Layouts are constructed once per CollectActivity, so anything a layout owns that outlives a
+     * view - a coroutine scope, a Bluetooth scan, a receiver registered on an application scoped
+     * manager - has to be released here or it leaks the activity along with it.
+     */
+    public void onDestroy() {}
+
+    /**
      * Optional warning shown before a toolbar action discards collected data, s.a. delete or
      * marking an observation missing. Return null to let the action proceed without confirming.
      */

--- a/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
@@ -497,6 +497,10 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
                 context.bindService(gattService, connection!!, Context.BIND_AUTO_CREATE)
 
                 ((context as CollectActivity).innoSpectraViewModel as? NanoEventListener)?.let { listener ->
+                    // Drop any previously registered set before creating a new one. This is the
+                    // only place receivers are registered, so unregistering here is what keeps a
+                    // reconnect from stacking a second set on top of the first.
+                    unregisterNanoReceiver()
                     nanoReceiver = InnoSpectraBase(listener).also {
                         it.register(context)
                         Log.d(TAG, "beginConnection: registered InnoSpectraBase receiver")
@@ -514,6 +518,24 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         }
     }
 
+    /**
+     * Unregisters the active [InnoSpectraBase] receiver set, if there is one.
+     *
+     * The receivers are registered against LocalBroadcastManager, which is application scoped, so
+     * nothing removes them implicitly when this view or the activity goes away. A stale set means
+     * every SDK broadcast is handled once per set, and because several of the handlers respond by
+     * issuing a BLE command that itself broadcasts a reply, duplicate sets compound on each round
+     * instead of costing a constant amount.
+     */
+    private fun unregisterNanoReceiver() {
+        try {
+            nanoReceiver?.unregister(context)
+        } catch (e: Exception) {
+            Log.d(TAG, "Error unregistering nanoReceiver: ${e.message}")
+        }
+        nanoReceiver = null
+    }
+
     private fun endConnection() {
         // Cancel ongoing device search to prevent reconnection attempts
         deviceSearchJob?.cancel()
@@ -522,13 +544,8 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         // Reset connection state
         isStarting = false
 
-        try {
-            // Unregister the broadcast receiver to prevent stale listeners
-            nanoReceiver?.unregister(context)
-            nanoReceiver = null
-        } catch (e: Exception) {
-            Log.d(TAG, "Error unregistering nanoReceiver: ${e.message}")
-        }
+        // Unregister the broadcast receivers to prevent stale listeners
+        unregisterNanoReceiver()
 
         try {
             connection?.let { context?.unbindService(it) }

--- a/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
@@ -19,8 +19,6 @@ import android.util.AttributeSet
 import android.util.Log
 import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.preference.PreferenceManager
@@ -35,6 +33,7 @@ import com.fieldbook.tracker.devices.spectrometers.Device
 import com.fieldbook.tracker.devices.spectrometers.SpectralFrame
 import com.fieldbook.tracker.devices.spectrometers.Spectrometer
 import com.fieldbook.tracker.devices.spectrometers.innospectra.InnoSpectraBase
+import com.fieldbook.tracker.devices.spectrometers.innospectra.InnoSpectraViewModel
 import com.fieldbook.tracker.devices.spectrometers.innospectra.interfaces.NanoEventListener
 import com.fieldbook.tracker.devices.spectrometers.innospectra.models.Frame
 import com.fieldbook.tracker.database.saver.SpectralSaver
@@ -59,6 +58,9 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
 
         //how long to wait for the device to report its scan config after connecting
         private const val DEVICE_INFO_TIMEOUT_MS = 30000L
+
+        //how long a measurement may run before the capture UI is restored anyway
+        private const val CAPTURE_TIMEOUT_MS = 20000L
 
         private const val DEVICE_INFO_POLL_MS = 500L
         private const val DEVICE_SEARCH_POLL_MS = 500L
@@ -92,6 +94,7 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
 
     private var deviceSearchJob: kotlinx.coroutines.Job? = null
     private var deviceInfoCheckJob: kotlinx.coroutines.Job? = null
+    private var captureTimeoutJob: kotlinx.coroutines.Job? = null
 
     @Volatile
     private var scanTimeoutJob: kotlinx.coroutines.Job? = null
@@ -105,15 +108,6 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
     constructor(context: Context?, attrs: AttributeSet?, defStyleAttr: Int) : super(
         context, attrs, defStyleAttr
     )
-
-    private fun <T> LiveData<T>.observeOnce(lifecycleOwner: LifecycleOwner, observer: Observer<T?>) {
-        observe(lifecycleOwner, object : Observer<T?> {
-            override fun onChanged(value: T?) {
-                observer.onChanged(value)
-                removeObserver(this)
-            }
-        })
-    }
 
     override fun type(): String {
         return Formats.INNO_SPECTRA_SENSOR.getDatabaseName()
@@ -146,8 +140,15 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
                         saveSpectralFrame(frame, entryId, traitId)
                         lastProcessedFrameHash = frameId
 
-                        // Hide progress bar after hardware scan completes
-                        toggleProgressBar(false)
+                        captureTimeoutJob?.cancel()
+                        captureTimeoutJob = null
+
+                        // Restore the capture UI. This is the completion point for both hardware
+                        // and UI triggered scans, so it has to re-enable the button as well as
+                        // drop the overlay.
+                        connectedNanoDevice?.let { nano ->
+                            enableCapture(nano.toDevice())
+                        } ?: toggleProgressBar(false)
                     }
                 }
             } else if (frame == null) {
@@ -159,6 +160,47 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         hardwareButtonObserver?.let { observer ->
             viewModel.getSpectralData().observe(activity, observer)
         }
+    }
+
+    private var connectionProgressObserver: Observer<InnoSpectraViewModel.ConnectionProgress?>? = null
+
+    /**
+     * Drives the determinate arc from the connection handshake.
+     *
+     * Registered once, like the hardware scan observer, so a reconnect cannot stack a second one.
+     */
+    private fun observeConnectionProgress() {
+
+        val activity = (context as? CollectActivity) ?: return
+        val viewModel = activity.innoSpectraViewModel ?: return
+
+        if (connectionProgressObserver != null) return
+
+        connectionProgressObserver = Observer { progress ->
+
+            if (progress == null) return@Observer
+
+            val label = context.getString(labelFor(progress.stage))
+
+            //a stage with no reading of its own leaves the indicator spinning
+            progress.percent?.let { percent ->
+                setProgressPercent(percent, label)
+            } ?: setProgressLabel(label)
+        }
+
+        connectionProgressObserver?.let { observer ->
+            viewModel.getConnectionProgress().observe(activity, observer)
+        }
+    }
+
+    private fun labelFor(stage: InnoSpectraViewModel.ConnectionStage) = when (stage) {
+        InnoSpectraViewModel.ConnectionStage.CONNECTING -> R.string.inno_spectra_connect_connecting
+        InnoSpectraViewModel.ConnectionStage.HANDSHAKE -> R.string.inno_spectra_connect_handshake
+        InnoSpectraViewModel.ConnectionStage.DEVICE_INFO -> R.string.inno_spectra_connect_device_info
+        InnoSpectraViewModel.ConnectionStage.DEVICE_UUID -> R.string.inno_spectra_connect_device_uuid
+        InnoSpectraViewModel.ConnectionStage.DEVICE_STATUS -> R.string.inno_spectra_connect_device_status
+        InnoSpectraViewModel.ConnectionStage.SCAN_CONFIGS -> R.string.inno_spectra_connect_scan_configs
+        InnoSpectraViewModel.ConnectionStage.READY -> R.string.inno_spectra_connect_ready
     }
 
     private fun setupScanStartedListener() {
@@ -183,6 +225,9 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
 
         // Observe spectral data from hardware button scans and auto-save them
         observeHardwareButtonScans()
+
+        // Drive the determinate arc from the connection handshake
+        observeConnectionProgress()
 
         // Set up listener to show progress bar when any scan starts
         setupScanStartedListener()
@@ -307,42 +352,61 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         callback: Spectrometer.ResultCallback
     ) {
 
-        if (!isLocked) {
-
-            val viewLifecycleOwner = (context as CollectActivity)
-
-            (context as CollectActivity).innoSpectraViewModel?.scan(context, false)?.observeOnce(viewLifecycleOwner) {
-
-                it?.let { frames ->
-                    Log.d(TAG, "Frames: $frames")
-                    for (f in frames) {
-
-                        Log.d(TAG, "Frame: ${f.rawData}")
-
-                        saveSpectralFrame(f, entryId, traitId)
-
-                        Log.d(TAG, "Spectral Data queued for save")
-                    }
-
-                    // Re-enable capture and hide progress bar
-                    enableCapture(device)
-
-                    // Notify callback that capture completed successfully
-                    callback.onResult(true)
-                } ?: run {
-                    // Scan failed or returned null
-                    enableCapture(device)
-                    callback.onResult(false)
-                }
-            }
-        } else {
+        if (isLocked) {
             // If locked, immediately callback with failure
             enableCapture(device)
             callback.onResult(false)
+            return
         }
 
-        (context as CollectActivity).innoSpectraViewModel?.setEventListener {
-            Log.d(TAG, "Event listener called")
+        val viewModel = (context as CollectActivity).innoSpectraViewModel
+
+        if (viewModel == null || !viewModel.isReadyToScan()) {
+            Log.w(TAG, "capture: device is not ready to scan")
+            enableCapture(device)
+            callback.onResult(false)
+            return
+        }
+
+        // scan() starts the measurement. The frame it produces is handled by
+        // observeHardwareButtonScans(), which is the single place a scan is saved no matter
+        // whether the UI or the hardware button triggered it.
+        //
+        // This used to observe the returned LiveData as well, but scan() publishes a null to
+        // reset itself before starting, and that null arrived immediately and was read as a
+        // failed capture. The result was a visible flash: the overlay came up on the button
+        // press, was torn straight back down by that phantom failure, then came up again when
+        // the scan actually started.
+        viewModel.scan(context, false)
+
+        callback.onResult(true)
+
+        startCaptureTimeout(device)
+    }
+
+    /**
+     * Restores the UI if a measurement never reports back.
+     *
+     * The busy overlay swallows touches, so a scan that silently never completes would otherwise
+     * leave the trait unusable until the user navigates away.
+     */
+    private fun startCaptureTimeout(device: Device) {
+
+        captureTimeoutJob?.cancel()
+
+        captureTimeoutJob = background.launch {
+
+            delay(CAPTURE_TIMEOUT_MS)
+
+            withContext(Dispatchers.Main) {
+
+                Log.w(TAG, "capture: no frame received within timeout, restoring the capture UI")
+
+                enableCapture(device)
+
+                //drop the placeholder row that was added when the capture started
+                submitList()
+            }
         }
     }
 
@@ -423,7 +487,7 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
 
         connectButton?.visibility = VISIBLE
         captureButton?.visibility = GONE
-        progressBar?.visibility = GONE
+        toggleProgressBar(false)
         settingsButton?.visibility = GONE
     }
 
@@ -544,9 +608,19 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
             withContext(Dispatchers.Main) {
                 controller.getSecurityChecker().withNearby {
                     nano.let {
-                        progressBar?.visibility = VISIBLE
+                        //the handshake reports each step, so this one is determinate
+                        toggleProgressBar(
+                            true,
+                            determinate = true,
+                            label = context.getString(R.string.inno_spectra_connect_connecting)
+                        )
+
                         connectButton?.visibility = GONE
-                        (context as CollectActivity).innoSpectraViewModel?.setBluetoothDevice(context, bt)
+
+                        (context as CollectActivity).innoSpectraViewModel?.let { vm ->
+                            vm.setBluetoothDevice(context, bt)
+                            vm.startConnectionProgress()
+                        }
 
                         beginConnection(it)
                     }
@@ -674,6 +748,9 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
 
         deviceInfoCheckJob?.cancel()
         deviceInfoCheckJob = null
+
+        captureTimeoutJob?.cancel()
+        captureTimeoutJob = null
 
         // Stop any scan started while looking for this device
         stopDeviceScan()

--- a/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
@@ -49,6 +49,11 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
 
     companion object {
         const val TAG = "SpectralTraitLayout"
+
+        //how long a device scan may run before it stops itself
+        private const val SCAN_PERIOD_MS = 30000L
+
+        private const val DEFAULT_DEVICE_FILTER = "NIR"
     }
 
     private var bluetoothManager: BluetoothManager? = null
@@ -58,8 +63,24 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
     private var nanoReceiver: InnoSpectraBase? = null
     private var isStarting = false
 
+    //held so the scan can actually be stopped again; non-null means a scan is running.
+    //volatile because the scan is started on the main thread but stopDeviceScan() is also reached
+    //from the background auto-reconnect path in scheduleDeviceSearch -> connectDevice
+    @Volatile
+    private var bluetoothLeScanner: BluetoothLeScanner? = null
+
+    @Volatile
+    private var scanCallback: ScanCallback? = null
+
+    //name filter for the running scan, read once per scan rather than per advertisement
+    @Volatile
+    private var scanNameFilter: String = DEFAULT_DEVICE_FILTER
+
     private var deviceConnectionJob: kotlinx.coroutines.Job? = null
     private var deviceSearchJob: kotlinx.coroutines.Job? = null
+
+    @Volatile
+    private var scanTimeoutJob: kotlinx.coroutines.Job? = null
 
     private var connection: ServiceConnection? = null
 
@@ -432,6 +453,10 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
             return
         }
 
+        // We have the device we were looking for, so stop scanning. Leaving the scan running
+        // competes with the GATT connection we are about to open.
+        stopDeviceScan()
+
         // persist selection
         controller.getPreferences().edit {
             putString(GeneralKeys.INNOSPECTRA_NANO_DEVICE_ID, nano.nanoMac)
@@ -541,6 +566,9 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         deviceSearchJob?.cancel()
         deviceSearchJob = null
 
+        // Stop any scan started while looking for this device
+        stopDeviceScan()
+
         // Reset connection state
         isStarting = false
 
@@ -645,11 +673,8 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
 
     private fun parseScanDeviceResult(result: ScanResult, device: BluetoothDevice) {
 
-        val nanoName = getStringPref(
-            context,
-            SharedPreferencesKeys.DeviceFilter,
-            "NIR"
-        )
+        //read once when the scan starts, this runs for every advertisement received
+        val nanoName = scanNameFilter
 
         result.scanRecord?.deviceName?.let { name ->
 
@@ -664,7 +689,7 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
                         nanoName
                     )
 
-                    if (!deviceList.map { it.second.nanoMac }.contains(nanoDevice.nanoMac)) {
+                    if (deviceList.none { it.second.nanoMac == nanoDevice.nanoMac }) {
 
                         deviceList.add(device to nanoDevice)
 
@@ -691,7 +716,22 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
             return
         }
 
-        scanner.startScan(object : ScanCallback() {
+        // A scan is already running. Starting another would register a second callback with the
+        // Bluetooth stack that nothing would ever stop, so extend the current one instead.
+        scanCallback?.let { running ->
+            Log.d(TAG, "startScan: scan already running, extending scan period")
+            scheduleScanTimeout(running)
+            return
+        }
+
+        // Constant for the life of the scan, so read it here instead of on every advertisement.
+        scanNameFilter = getStringPref(
+            context,
+            SharedPreferencesKeys.DeviceFilter,
+            DEFAULT_DEVICE_FILTER
+        )
+
+        val callback = object : ScanCallback() {
 
             override fun onScanResult(callbackType: Int, result: ScanResult?) {
                 super.onScanResult(callbackType, result)
@@ -709,7 +749,89 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
 
                 }
             }
-        })
+
+            override fun onScanFailed(errorCode: Int) {
+                super.onScanFailed(errorCode)
+
+                Log.e(TAG, "startScan: scan failed with error code $errorCode")
+
+                stopDeviceScan()
+            }
+        }
+
+        bluetoothLeScanner = scanner
+        scanCallback = callback
+
+        try {
+            scanner.startScan(callback)
+        } catch (e: SecurityException) {
+            Log.e(TAG, "startScan: missing permission - ${e.message}")
+            bluetoothLeScanner = null
+            scanCallback = null
+            return
+        }
+
+        scheduleScanTimeout(callback)
+    }
+
+    /**
+     * Arms the timeout that stops the running scan.
+     *
+     * Without it a device that never appears leaves the radio scanning, and the callback
+     * delivering onto the main thread, for the rest of the process. Re-arming on each request is
+     * what lets a repeated search extend the window rather than start a second scan.
+     */
+    private fun scheduleScanTimeout(callback: ScanCallback) {
+
+        scanTimeoutJob?.cancel()
+
+        scanTimeoutJob = background.launch {
+
+            delay(SCAN_PERIOD_MS)
+
+            withContext(Dispatchers.Main) {
+
+                //only stop the scan this timeout was armed for
+                if (scanCallback === callback) {
+
+                    Log.d(TAG, "scheduleScanTimeout: scan period elapsed, stopping scan")
+
+                    stopDeviceScan()
+                }
+            }
+        }
+    }
+
+    /**
+     * Stops the running BLE scan, if there is one.
+     *
+     * BluetoothLeScanner holds a callback until it is explicitly stopped and delivers results on
+     * the main looper, so an abandoned scan keeps doing UI thread work for the life of the
+     * process and degrades the throughput of the connections that are already established.
+     * Android also caps how many scanners a single app may register.
+     */
+    private fun stopDeviceScan() {
+
+        scanTimeoutJob?.cancel()
+        scanTimeoutJob = null
+
+        val scanner = bluetoothLeScanner
+        val callback = scanCallback
+
+        bluetoothLeScanner = null
+        scanCallback = null
+
+        if (scanner == null || callback == null) return
+
+        try {
+            scanner.stopScan(callback)
+            Log.d(TAG, "stopDeviceScan: scan stopped")
+        } catch (e: SecurityException) {
+            Log.d(TAG, "stopDeviceScan: missing permission - ${e.message}")
+        } catch (e: IllegalStateException) {
+            //adapter turned off underneath us
+            Log.d(TAG, "stopDeviceScan: adapter unavailable - ${e.message}")
+        }
     }
 
     private fun buildInnoSpectraServiceConnection(onSdkInitialized: (ISCNIRScanSDK) -> Unit): ServiceConnection =

--- a/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
@@ -631,6 +631,15 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
 
     private fun beginConnection(device: NanoDevice) {
 
+        // Bail before touching anything. This check has to come first: unbinding and reassigning
+        // `connection` on a duplicate attempt orphaned the live binding, and left the field
+        // pointing at an object that was never bound, so the later endConnection() unbound the
+        // wrong instance and swallowed the resulting IllegalArgumentException.
+        if (isStarting) {
+            Log.w(TAG, "beginConnection: connection already starting, ignoring duplicate attempt")
+            return
+        }
+
         // Ensure previous service connection is cleaned up before starting new one
         try {
             if (connection != null) {
@@ -660,34 +669,30 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
             }
         }
 
-        if (!isStarting) {
-            isStarting = true
-            Log.d(TAG, "beginConnection: binding to GATT service for device ${device.nanoMac}")
+        isStarting = true
+        Log.d(TAG, "beginConnection: binding to GATT service for device ${device.nanoMac}")
 
-            try {
-                val gattService = Intent(context, ISCNIRScanSDK::class.java)
-                context.bindService(gattService, connection!!, Context.BIND_AUTO_CREATE)
+        try {
+            val gattService = Intent(context, ISCNIRScanSDK::class.java)
+            context.bindService(gattService, connection!!, Context.BIND_AUTO_CREATE)
 
-                ((context as CollectActivity).innoSpectraViewModel as? NanoEventListener)?.let { listener ->
-                    // Drop any previously registered set before creating a new one. This is the
-                    // only place receivers are registered, so unregistering here is what keeps a
-                    // reconnect from stacking a second set on top of the first.
-                    unregisterNanoReceiver()
-                    nanoReceiver = InnoSpectraBase(listener).also {
-                        it.register(context)
-                        Log.d(TAG, "beginConnection: registered InnoSpectraBase receiver")
-                    }
-                    registerGattDisconnectReceiver()
+            ((context as CollectActivity).innoSpectraViewModel as? NanoEventListener)?.let { listener ->
+                // Drop any previously registered set before creating a new one. This is the
+                // only place receivers are registered, so unregistering here is what keeps a
+                // reconnect from stacking a second set on top of the first.
+                unregisterNanoReceiver()
+                nanoReceiver = InnoSpectraBase(listener).also {
+                    it.register(context)
+                    Log.d(TAG, "beginConnection: registered InnoSpectraBase receiver")
                 }
-            } catch (e: Exception) {
-                Log.e(TAG, "beginConnection: failed to bind service - ${e.message}")
-                isStarting = false
-                background.launch(Dispatchers.Main) {
-                    setupConnectUi()
-                }
+                registerGattDisconnectReceiver()
             }
-        } else {
-            Log.w(TAG, "beginConnection: connection already starting, ignoring duplicate attempt")
+        } catch (e: Exception) {
+            Log.e(TAG, "beginConnection: failed to bind service - ${e.message}")
+            isStarting = false
+            background.launch(Dispatchers.Main) {
+                setupConnectUi()
+            }
         }
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
@@ -188,6 +188,22 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         setupScanStartedListener()
     }
 
+    /**
+     * Releases the BLE scan, the SDK receivers and the service binding.
+     *
+     * None of these are tied to the view lifecycle: the scan is registered with the Bluetooth
+     * stack, the receivers with an application scoped LocalBroadcastManager, and the binding with
+     * the activity manager. Left alone they survive the activity that created them.
+     *
+     * The device is disconnected rather than handed on, because the ViewModel holding the
+     * connection state is activity scoped: a new CollectActivity gets a fresh one that reports
+     * disconnected regardless, so keeping the GATT link open would only orphan it.
+     */
+    override fun onDestroy() {
+        endConnection()
+        super.onDestroy()
+    }
+
     override fun setupConnectUi() {
         // Cancel any ongoing device search
         deviceSearchJob?.cancel()

--- a/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/InnoSpectraTraitLayout.kt
@@ -6,9 +6,11 @@ import android.bluetooth.BluetoothManager
 import android.bluetooth.le.BluetoothLeScanner
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanResult
+import android.content.BroadcastReceiver
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.ServiceConnection
 import android.content.pm.PackageManager
 import android.os.Build
@@ -20,6 +22,7 @@ import androidx.core.content.edit
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.preference.PreferenceManager
 import com.ISCSDK.ISCNIRScanSDK
 import com.ISCSDK.ISCNIRScanSDK.NanoDevice
@@ -41,6 +44,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.threeten.bp.OffsetDateTime
 import java.util.UUID
 import kotlin.jvm.java
@@ -53,6 +57,12 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         //how long a device scan may run before it stops itself
         private const val SCAN_PERIOD_MS = 30000L
 
+        //how long to wait for the device to report its scan config after connecting
+        private const val DEVICE_INFO_TIMEOUT_MS = 30000L
+
+        private const val DEVICE_INFO_POLL_MS = 500L
+        private const val DEVICE_SEARCH_POLL_MS = 500L
+
         private const val DEFAULT_DEVICE_FILTER = "NIR"
     }
 
@@ -61,6 +71,10 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
     private var connectedNanoDevice: NanoDevice? = null
     private var deviceList: MutableList<Pair<BluetoothDevice, NanoDevice>> = mutableListOf()
     private var nanoReceiver: InnoSpectraBase? = null
+
+    //notices the link dropping, registered and unregistered with nanoReceiver
+    private var gattDisconnectReceiver: BroadcastReceiver? = null
+
     private var isStarting = false
 
     //held so the scan can actually be stopped again; non-null means a scan is running.
@@ -76,8 +90,8 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
     @Volatile
     private var scanNameFilter: String = DEFAULT_DEVICE_FILTER
 
-    private var deviceConnectionJob: kotlinx.coroutines.Job? = null
     private var deviceSearchJob: kotlinx.coroutines.Job? = null
+    private var deviceInfoCheckJob: kotlinx.coroutines.Job? = null
 
     @Volatile
     private var scanTimeoutJob: kotlinx.coroutines.Job? = null
@@ -179,6 +193,9 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         deviceSearchJob?.cancel()
         deviceSearchJob = null
 
+        deviceInfoCheckJob?.cancel()
+        deviceInfoCheckJob = null
+
         // Reset connection state
         isStarting = false
 
@@ -190,6 +207,8 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
             settingsButton?.visibility = GONE
             toggleProgressBar(false)
             startDeviceSearch()
+            //arriving at the trait disconnected still reconnects on its own
+            attemptAutoReconnect()
             setupConnectButton()
         }
     }
@@ -206,28 +225,36 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         return connected
     }
 
+    /**
+     * Starts scanning only.
+     *
+     * Auto-reconnect deliberately does not live here. This is also what the connect button calls,
+     * and SpectralTraitLayout follows it immediately with the device picker, so doing both meant
+     * pressing connect raced a background reconnect against the user's own selection: the spinner
+     * and the picker came up together, and whichever won left the other stale. Arriving at the
+     * trait disconnected still auto-reconnects, from setupConnectUi().
+     */
     override fun startDeviceSearch() {
+        setupDeviceSearch()
+    }
+
+    /**
+     * Reconnects to the saved device once it turns up in the scan results.
+     */
+    private fun attemptAutoReconnect() {
 
         val deviceId = controller.getPreferences().getString(GeneralKeys.INNOSPECTRA_NANO_DEVICE_ID, "") ?: ""
         val deviceName = controller.getPreferences().getString(GeneralKeys.INNOSPECTRA_NANO_DEVICE_NAME, "") ?: ""
 
-        if (deviceId.isNotBlank() && deviceName.isNotBlank()) {
+        if (deviceId.isBlank() || deviceName.isBlank()) return
 
-            setupDeviceSearch()
+        scheduleDeviceSearch(deviceName, deviceId) { data ->
 
-            scheduleDeviceSearch(deviceName, deviceId) { data ->
+            val device = data.first as BluetoothDevice
+            val nanoDevice = data.second as NanoDevice
 
-                val device = data.first as BluetoothDevice
-                val nanoDevice = data.second as NanoDevice
-
-                // wrap as Device so it can be handled by connectDevice(Device)
-                connectDevice(Device(device to nanoDevice))
-            }
-
-        }
-        else {
-
-            setupDeviceSearch()
+            // wrap as Device so it can be handled by connectDevice(Device)
+            connectDevice(Device(device to nanoDevice))
         }
     }
 
@@ -329,43 +356,59 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
     }
 
     private fun scheduleDeviceInfoCheck(onInfoReceived: suspend () -> Unit) {
-        background.launch {
-            while (true) {
-                val config = (context as CollectActivity).innoSpectraViewModel?.getActiveConfig()
-                if (config != null) {
-                    onInfoReceived()
-                    break
+
+        // Cancel any existing check first
+        deviceInfoCheckJob?.cancel()
+
+        deviceInfoCheckJob = background.launch {
+
+            // Bounded: if the config never arrives the device is not talking to us, and an
+            // unbounded loop here would keep polling for the life of the process.
+            val config = withTimeoutOrNull(DEVICE_INFO_TIMEOUT_MS) {
+
+                var activeConfig = (context as CollectActivity).innoSpectraViewModel?.getActiveConfig()
+
+                while (activeConfig == null) {
+                    delay(DEVICE_INFO_POLL_MS)
+                    activeConfig = (context as CollectActivity).innoSpectraViewModel?.getActiveConfig()
                 }
-                delay(500L)
+
+                activeConfig
+            }
+
+            if (config != null) {
+                onInfoReceived()
+            } else {
+                Log.w(TAG, "scheduleDeviceInfoCheck: timed out waiting for device config")
             }
         }
     }
 
-    private fun scheduleDeviceConnection() {
-        // Cancel any existing job first
-        deviceConnectionJob?.cancel()
+    /**
+     * Handles the SDK's GATT disconnect broadcast.
+     *
+     * This replaces a `while (true)` loop that asked the ViewModel for the connection state every
+     * 250ms, which meant a Bluetooth binder call four times a second for as long as the process
+     * lived. The SDK already tells us when the link drops, so there is nothing to poll for.
+     *
+     * Deliberately does not try to reconnect. Reconnecting means scanning, and a standing scan is
+     * what made the app unresponsive in the first place. Returning to the connect UI and letting
+     * the collector re-select the device is the intended behaviour after a mid-session drop;
+     * arriving at the trait with a saved device still connects on its own via setupConnectUi().
+     */
+    private fun onGattDisconnected() {
 
-        deviceConnectionJob = background.launch {
-            while (true) {
-                val connected = (context as CollectActivity).innoSpectraViewModel?.isConnected()
-                if (connected == false) {
-                    // Hardware disconnect detected - perform proper cleanup
-                    withContext(Dispatchers.Main) {
-                        if (!isLocked) {
-                            isStarting = false
-                            endConnection()
+        if (isLocked) return
 
-                            connectButton?.visibility = VISIBLE
-                            captureButton?.visibility = GONE
-                            progressBar?.visibility = GONE
-                            settingsButton?.visibility = GONE
-                        }
-                    }
-                    break
-                }
-                delay(250L)
-            }
-        }
+        Log.d(TAG, "onGattDisconnected: device reported disconnect, tearing down")
+
+        isStarting = false
+        endConnection()
+
+        connectButton?.visibility = VISIBLE
+        captureButton?.visibility = GONE
+        progressBar?.visibility = GONE
+        settingsButton?.visibility = GONE
     }
 
     private fun scheduleDeviceSearch(deviceName: String, macAddress: String, onDeviceFound: suspend (Pair<*, *>) -> Unit) {
@@ -373,21 +416,35 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         deviceSearchJob?.cancel()
 
         deviceSearchJob = background.launch {
-            while (true) {
-                // Check if already starting to prevent race conditions
-                if (isStarting) {
-                    Log.d(TAG, "scheduleDeviceSearch: connection already starting, stopping search")
-                    break
+
+            // Bounded by the scan period: once the scan stops, deviceList cannot grow, so polling
+            // past that point would never succeed.
+            val device = withTimeoutOrNull(SCAN_PERIOD_MS) {
+
+                var found: Pair<BluetoothDevice, NanoDevice>? = null
+
+                while (found == null) {
+
+                    // Check if already starting to prevent race conditions
+                    if (isStarting) {
+                        Log.d(TAG, "scheduleDeviceSearch: connection already starting, stopping search")
+                        break
+                    }
+
+                    found = deviceList.firstOrNull { deviceData ->
+                        deviceData.second.nanoMac == macAddress && deviceData.second.nanoName == deviceName
+                    }
+
+                    if (found == null) delay(DEVICE_SEARCH_POLL_MS)
                 }
 
-                val device = deviceList.firstOrNull { deviceData ->
-                    deviceData.second.nanoMac == macAddress && deviceData.second.nanoName == deviceName
-                }
-                if (device != null) {
-                    onDeviceFound(device)
-                    break
-                }
-                delay(500L)
+                found
+            }
+
+            if (device != null) {
+                onDeviceFound(device)
+            } else {
+                Log.d(TAG, "scheduleDeviceSearch: $deviceName not found within the scan period")
             }
         }
     }
@@ -530,6 +587,7 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
                         it.register(context)
                         Log.d(TAG, "beginConnection: registered InnoSpectraBase receiver")
                     }
+                    registerGattDisconnectReceiver()
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "beginConnection: failed to bind service - ${e.message}")
@@ -544,7 +602,8 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
     }
 
     /**
-     * Unregisters the active [InnoSpectraBase] receiver set, if there is one.
+     * Unregisters the active [InnoSpectraBase] receiver set and the GATT disconnect receiver,
+     * if they are registered.
      *
      * The receivers are registered against LocalBroadcastManager, which is application scoped, so
      * nothing removes them implicitly when this view or the activity goes away. A stale set means
@@ -553,18 +612,52 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
      * instead of costing a constant amount.
      */
     private fun unregisterNanoReceiver() {
+
         try {
             nanoReceiver?.unregister(context)
         } catch (e: Exception) {
             Log.d(TAG, "Error unregistering nanoReceiver: ${e.message}")
         }
         nanoReceiver = null
+
+        try {
+            gattDisconnectReceiver?.let {
+                LocalBroadcastManager.getInstance(context).unregisterReceiver(it)
+            }
+        } catch (e: Exception) {
+            Log.d(TAG, "Error unregistering gattDisconnectReceiver: ${e.message}")
+        }
+        gattDisconnectReceiver = null
+    }
+
+    /**
+     * Registers the receiver that notices the device dropping its connection.
+     *
+     * Kept on the same lifetime as [nanoReceiver] so the two cannot get out of step.
+     */
+    private fun registerGattDisconnectReceiver() {
+
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                onGattDisconnected()
+            }
+        }
+
+        gattDisconnectReceiver = receiver
+
+        LocalBroadcastManager.getInstance(context).registerReceiver(
+            receiver,
+            IntentFilter(ISCNIRScanSDK.ACTION_GATT_DISCONNECTED)
+        )
     }
 
     private fun endConnection() {
         // Cancel ongoing device search to prevent reconnection attempts
         deviceSearchJob?.cancel()
         deviceSearchJob = null
+
+        deviceInfoCheckJob?.cancel()
+        deviceInfoCheckJob = null
 
         // Stop any scan started while looking for this device
         stopDeviceScan()
@@ -600,17 +693,8 @@ class InnoSpectraTraitLayout : SpectralTraitLayout {
         }
     }
 
-    override fun enableCapture(device: Device) {
-        super.enableCapture(device)
-        scheduleDeviceConnection()
-    }
-
     override fun disconnectAndEraseDevice(device: Device) {
         if (!isLocked) {
-            // Cancel the connection monitoring job to prevent race conditions
-            deviceConnectionJob?.cancel()
-            deviceConnectionJob = null
-
             isStarting = false
             endConnection()
             controller.getPreferences().edit {

--- a/app/src/main/java/com/fieldbook/tracker/traits/LayoutCollections.java
+++ b/app/src/main/java/com/fieldbook/tracker/traits/LayoutCollections.java
@@ -1,6 +1,7 @@
 package com.fieldbook.tracker.traits;
 
 import android.app.Activity;
+import android.util.Log;
 
 import java.util.ArrayList;
 
@@ -72,6 +73,23 @@ public class LayoutCollections {
         for (BaseTraitLayout layout : this.traitLayouts) {
             if (layout instanceof LabelPrintTraitLayout) {
                 ((LabelPrintTraitLayout) layout).unregisterReceiver();
+            }
+        }
+    }
+
+    /**
+     * Releases resources held by every layout, not just the one currently showing.
+     *
+     * A layout the user never opened still holds whatever it allocated at construction, so this
+     * has to walk the whole list.
+     */
+    public void onDestroy() {
+        for (BaseTraitLayout layout : this.traitLayouts) {
+            try {
+                layout.onDestroy();
+            } catch (Exception e) {
+                //one layout failing to tear down must not stop the rest
+                Log.e("LayoutCollections", "Error destroying " + layout.getClass().getSimpleName(), e);
             }
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/traits/NixTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/NixTraitLayout.kt
@@ -302,7 +302,10 @@ class NixTraitLayout : SpectralTraitLayout {
         getDevice(device)?.let { nixDevice ->
 
             toggleProgressBar(true)
-            connectButton?.isEnabled = false
+
+            // Hide, not just disable: the connect button is a FAB sitting over the progress bar,
+            // and a greyed out FAB still reads as tappable while the handshake runs.
+            connectButton?.visibility = GONE
 
             val nix = (context as CollectActivity).getNixSensorHelper()
 
@@ -310,7 +313,6 @@ class NixTraitLayout : SpectralTraitLayout {
 
             nix.connect(nixDevice) { connected ->
                 if (connected) {
-                    connectButton?.isEnabled = true
                     saveDevice(device)
                     enableCapture(device)
                     ensureSpectralCompat(nixDevice)

--- a/app/src/main/java/com/fieldbook/tracker/traits/NixTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/NixTraitLayout.kt
@@ -30,7 +30,10 @@ import com.nixsensor.universalsdk.OnDeviceResultListener
 import com.nixsensor.universalsdk.ReferenceWhite
 import com.nixsensor.universalsdk.ScanMode
 import com.serenegiant.bluetooth.BluetoothManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.threeten.bp.OffsetDateTime
 
 
@@ -42,10 +45,14 @@ class NixTraitLayout : SpectralTraitLayout {
     companion object {
         const val TAG = "NixTraitLayout"
         const val SEARCH_RECURSION_LIMIT = 42
+
+        //how long a measurement may run before the capture UI is restored anyway
+        private const val CAPTURE_TIMEOUT_MS = 20000L
     }
 
 
     private var recursionCount = 0
+    private var captureTimeoutJob: kotlinx.coroutines.Job? = null
     private val nixSaver = SpectralSaver(database)
 
     constructor(context: Context?) : super(context)
@@ -70,6 +77,7 @@ class NixTraitLayout : SpectralTraitLayout {
      * Only the scan needs releasing, since it otherwise keeps the radio busy for the whole process.
      */
     override fun onDestroy() {
+        cancelCaptureTimeout()
         controller.getNixSensorHelper().stopScan()
         super.onDestroy()
     }
@@ -213,6 +221,10 @@ class NixTraitLayout : SpectralTraitLayout {
 
         if (IDeviceScanner.isBluetoothPermissionGranted(context)) {
 
+            //the budget is per wait, not per session: without this every retry ever spent counts
+            //against the limit and device search stops working permanently partway through a day
+            recursionCount = 0
+
             controller.getNixSensorHelper().search {}
 
         } else {
@@ -339,6 +351,7 @@ class NixTraitLayout : SpectralTraitLayout {
             ?: (device.deviceImplementation as? NixSensorHelper.NixDevice)?.device
 
     override fun disconnectAndEraseDevice(device: Device) {
+        cancelCaptureTimeout()
         getDevice(device)?.let { nixDevice ->
             nixDevice.disconnect()
             controller.getPreferences().edit {
@@ -361,29 +374,44 @@ class NixTraitLayout : SpectralTraitLayout {
 
     override fun capture(device: Device, entryId: String, traitId: String, callback: ResultCallback) {
 
-        getDevice(device)?.let { nixDevice ->
+        // setupCaptureButton() has already disabled the button and raised the overlay, so every
+        // path out of here has to hand them back. Falling through silently strands the trait.
+        val nixDevice = getDevice(device)
 
-            Log.d(TAG, "Device state: ${nixDevice.state}")
+        if (nixDevice == null) {
+            Log.w(TAG, "capture: no device backing the capture request")
+            enableCapture(device)
+            callback.onResult(false)
+            return
+        }
 
-            if (!isDeviceCompatible(nixDevice)) {
-                Toast.makeText(context, R.string.nix_device_incompatible, Toast.LENGTH_SHORT).show()
-                enableCapture(device)
-                return@let
-            }
+        Log.d(TAG, "Device state: ${nixDevice.state}")
 
-            if (nixDevice.state != DeviceState.IDLE) {
-                Toast.makeText(context, R.string.nix_device_connecting, Toast.LENGTH_SHORT).show()
-                enableCapture(device)
-                return@let
-            }
+        if (!isDeviceCompatible(nixDevice)) {
+            Toast.makeText(context, R.string.nix_device_incompatible, Toast.LENGTH_SHORT).show()
+            enableCapture(device)
+            callback.onResult(false)
+            return
+        }
 
-            callback.onResult(true)
+        if (nixDevice.state != DeviceState.IDLE) {
+            Toast.makeText(context, R.string.nix_device_connecting, Toast.LENGTH_SHORT).show()
+            enableCapture(device)
+            callback.onResult(false)
+            return
+        }
 
-            nixDevice.measure(object : OnDeviceResultListener {
+        callback.onResult(true)
+
+        startCaptureTimeout(device)
+
+        nixDevice.measure(object : OnDeviceResultListener {
                 override fun onDeviceResult(
                     status: CommandStatus,
                     measurements: Map<ScanMode, IMeasurementData>?
                 ) {
+
+                    cancelCaptureTimeout()
 
                     captureButton?.isEnabled = true
                     toggleProgressBar(false)
@@ -452,8 +480,39 @@ class NixTraitLayout : SpectralTraitLayout {
                         }
                     }
                 }
-            })
+        })
+    }
+
+    /**
+     * Restores the capture UI if a measurement never reports back.
+     *
+     * The SDK gives no guarantee that OnDeviceResultListener fires: if the sensor drops the link
+     * mid measurement the callback simply never arrives, leaving the button disabled and the
+     * overlay up with no way back short of switching traits.
+     */
+    private fun startCaptureTimeout(device: Device) {
+
+        captureTimeoutJob?.cancel()
+
+        captureTimeoutJob = background.launch {
+
+            delay(CAPTURE_TIMEOUT_MS)
+
+            withContext(Dispatchers.Main) {
+
+                Log.w(TAG, "capture: no measurement result within timeout, restoring the capture UI")
+
+                enableCapture(device)
+
+                //drop the placeholder row added when the capture started
+                submitList()
+            }
         }
+    }
+
+    private fun cancelCaptureTimeout() {
+        captureTimeoutJob?.cancel()
+        captureTimeoutJob = null
     }
 
     private fun isDeviceCompatible(device: IDeviceCompat): Boolean {

--- a/app/src/main/java/com/fieldbook/tracker/traits/NixTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/NixTraitLayout.kt
@@ -70,15 +70,19 @@ class NixTraitLayout : SpectralTraitLayout {
     }
 
     /**
-     * Stops scanning when the activity goes away.
+     * Stops scanning, and any connect attempt still waiting, when the activity goes away.
      *
      * The connected device is deliberately left alone: NixSensorHelper is activity scoped and
      * disconnecting here is what the commented out call in CollectActivity.onDestroy was avoiding.
-     * Only the scan needs releasing, since it otherwise keeps the radio busy for the whole process.
+     * The scan needs releasing, since it otherwise keeps the radio busy for the whole process, and
+     * so does a pending connect, whose callbacks would otherwise land on a view that is gone.
      */
     override fun onDestroy() {
         cancelCaptureTimeout()
-        controller.getNixSensorHelper().stopScan()
+        with(controller.getNixSensorHelper()) {
+            stopScan()
+            cancelPendingConnect()
+        }
         super.onDestroy()
     }
 
@@ -309,14 +313,24 @@ class NixTraitLayout : SpectralTraitLayout {
 
             val nix = (context as CollectActivity).getNixSensorHelper()
 
-            nix.stopScan()
-
+            //the scan is left running: the helper waits for the device to advertise before it
+            //opens the link, and stops scanning itself once it has a handle to connect through
             nix.connect(nixDevice) { connected ->
-                if (connected) {
-                    saveDevice(device)
-                    enableCapture(device)
-                    ensureSpectralCompat(nixDevice)
+
+                if (connected != null) {
+
+                    //what the helper connected, which is not always what the picker handed over
+                    val live = connected.toDevice()
+
+                    saveDevice(live)
+                    enableCapture(live)
+                    ensureSpectralCompat(connected)
+
                 } else {
+                    //covers a refused attempt, one the SDK never answered, and a device that
+                    //never advertised, so the trait is never left on the spinner with no way back
+                    Toast.makeText(context, R.string.nix_error_connect_failed, Toast.LENGTH_SHORT)
+                        .show()
                     setupConnectUi()
                 }
             }
@@ -355,7 +369,9 @@ class NixTraitLayout : SpectralTraitLayout {
     override fun disconnectAndEraseDevice(device: Device) {
         cancelCaptureTimeout()
         getDevice(device)?.let { nixDevice ->
-            nixDevice.disconnect()
+            //through the helper so the disconnect is stamped: the next connect waits out the
+            //teardown instead of being swallowed by it
+            controller.getNixSensorHelper().disconnect(nixDevice)
             controller.getPreferences().edit {
                 remove(GeneralKeys.NIX_ADDRESS)
                 remove(GeneralKeys.NIX_NAME)

--- a/app/src/main/java/com/fieldbook/tracker/traits/NixTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/NixTraitLayout.kt
@@ -62,6 +62,18 @@ class NixTraitLayout : SpectralTraitLayout {
         return Formats.NIX.getDatabaseName()
     }
 
+    /**
+     * Stops scanning when the activity goes away.
+     *
+     * The connected device is deliberately left alone: NixSensorHelper is activity scoped and
+     * disconnecting here is what the commented out call in CollectActivity.onDestroy was avoiding.
+     * Only the scan needs releasing, since it otherwise keeps the radio busy for the whole process.
+     */
+    override fun onDestroy() {
+        controller.getNixSensorHelper().stopScan()
+        super.onDestroy()
+    }
+
     override fun loadLayout() {
         super.loadLayout()
 

--- a/app/src/main/java/com/fieldbook/tracker/traits/SpectralTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/SpectralTraitLayout.kt
@@ -36,6 +36,7 @@ import com.github.mikephil.charting.formatter.ValueFormatter
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -148,6 +149,21 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
         } finally {
             skipConnectionSetup = false
         }
+    }
+
+    /**
+     * Cancels the worker scope so it does not outlive the activity.
+     *
+     * [background] is created per layout and layouts are created per CollectActivity, so without
+     * this every leave-and-re-enter of Collect left another live scope behind, holding this view
+     * and through it the destroyed activity.
+     *
+     * A save still in flight when the user leaves Collect is cancelled with it. That is the
+     * intended trade: the alternative is a scope that never ends.
+     */
+    override fun onDestroy() {
+        super.onDestroy()
+        background.cancel()
     }
 
     override fun loadLayout() {
@@ -496,18 +512,23 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
 
     private fun submitList(submitPlaceholder: Boolean = false) {
 
-        background.launch(Dispatchers.Main) {
+        background.launch {
 
+            val traitId = currentTrait.id
+            val entryId = currentRange.uniqueId
+
+            //one query and one Base64 decode per saved sample, kept off the main thread
             val frames = spectralDataList.filterNotNull()
-                .map {
-                    val observation = database.getObservationById(it.observationId.toString())
-                    it.toSpectralFrame(
-                        observation!!.observation_unit_id,
+                .mapNotNull { fact ->
+                    val observation = database.getObservationById(fact.observationId.toString())
+                        ?: return@mapNotNull null
+                    fact.toSpectralFrame(
+                        observation.observation_unit_id,
                         observation.observation_variable_db_id.toString()
                     )
                 }
                 .filter {
-                    it.traitId == currentTrait.id && it.entryId == currentRange.uniqueId
+                    it.traitId == traitId && it.entryId == entryId
                 }.toMutableList()
 
             if (submitPlaceholder) {
@@ -516,46 +537,28 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
                 frames.removeIf { it.traitId.isEmpty() }
             }
 
-            when (state) {
-                State.Spectral -> submitSpectralList(frames, submitPlaceholder)
-                State.Color -> submitColorList(frames)
-            }
+            withContext(Dispatchers.Main) {
 
-            if (submitPlaceholder) {
-
-                listOf(recycler, colorRecycler).forEachIndexed { i, r ->
-                    r?.postDelayed({
-                        r.scrollToPosition(0)
-                    }, i*50L)
+                when (state) {
+                    State.Spectral -> submitSpectralList(frames, submitPlaceholder)
+                    State.Color -> submitColorList(frames)
                 }
+
+                if (submitPlaceholder) {
+
+                    listOf(recycler, colorRecycler).forEachIndexed { i, r ->
+                        r?.postDelayed({
+                            r.scrollToPosition(0)
+                        }, i*50L)
+                    }
+                }
+
+                controller.updateNumberOfObservations()
             }
-
-            controller.updateNumberOfObservations()
-
         }
     }
 
     private fun submitSpectralList(frames: List<SpectralFrame>, submitPlaceholder: Boolean = false) {
-
-        if (frames.isEmpty() && !submitPlaceholder) {
-            lineChart?.visibility = GONE
-            recycler?.visibility = GONE
-        } else {
-            lineChart?.visibility = VISIBLE
-            recycler?.visibility = VISIBLE
-        }
-
-        val frames = spectralDataList.filterNotNull()
-            .map {
-                val observation = database.getObservationById(it.observationId.toString())
-                it.toSpectralFrame(
-                    observation!!.observation_unit_id,
-                    observation.observation_variable_db_id.toString()
-                )
-            }
-            .filter {
-                it.traitId == currentTrait.id && it.entryId == currentRange.uniqueId
-            }
 
         if (frames.isEmpty() && !submitPlaceholder) {
             lineChart?.visibility = GONE
@@ -587,7 +590,8 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
 
         lineChart!!.invalidate()
 
-        submitLinesList(if (submitPlaceholder) frames + SpectralFrame.placeholder() else frames)
+        //frames already carries the placeholder when one was requested
+        submitLinesList(frames)
     }
 
     private fun submitColorList(frames: List<SpectralFrame>) {
@@ -739,26 +743,26 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
         val studyId = collectActivity.studyId
         val plot = (context as? CollectActivity)?.observationUnit
         val traitDbId = currentTrait.id
-        val observations = database.getAllObservations(studyId, plot, traitDbId)
 
-        if (observations.isEmpty()) {
+        background.launch {
 
-            background.launch {
+            val observations = database.getAllObservations(studyId, plot, traitDbId)
+
+            if (observations.isEmpty()) {
 
                 insertAndSetNa()
-            }
 
-        } else {
-
-            if (observations.size == 1 && observations[0].value == "NA") {
+            } else if (observations.size == 1 && observations[0].value == "NA") {
 
                 //already set to NA, do nothing
-                return
 
             } else {
 
-                askUserReplaceObservationsWithNa(observations)
+                withContext(Dispatchers.Main) {
 
+                    askUserReplaceObservationsWithNa(observations)
+
+                }
             }
         }
     }

--- a/app/src/main/java/com/fieldbook/tracker/traits/SpectralTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/SpectralTraitLayout.kt
@@ -8,8 +8,9 @@ import android.net.Uri
 import android.util.AttributeSet
 import android.util.Log
 import android.util.TypedValue
+import android.view.View
 import android.widget.EditText
-import android.widget.ProgressBar
+import android.widget.TextView
 import android.widget.Toast
 import androidx.recyclerview.widget.RecyclerView
 import com.fieldbook.tracker.R
@@ -34,6 +35,7 @@ import com.github.mikephil.charting.data.LineData
 import com.github.mikephil.charting.data.LineDataSet
 import com.github.mikephil.charting.formatter.ValueFormatter
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -69,8 +71,12 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
     protected var recycler: RecyclerView? = null
     protected var colorRecycler: RecyclerView? = null
     protected var lineChart: LineChart? = null
-    protected var progressBar: ProgressBar? = null
+    protected var progressBar: CircularProgressIndicator? = null
     protected var settingsButton: FloatingActionButton? = null
+
+    //card carrying the busy indicator, raised above the graph so it reads as floating over it
+    protected var progressCard: View? = null
+    protected var progressLabel: TextView? = null
 
     protected val spectralDataList = mutableListOf<SpectralFact?>()
 
@@ -80,6 +86,9 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
 
     //set while onRefresh() reloads entry data, so loadLayout() leaves the connection alone
     private var skipConnectionSetup = false
+
+    //whether the showing overlay expects progress readings, see toggleProgressBar
+    private var acceptsProgress = false
 
     protected val hapticFeedback by lazy {
         controller.getVibrator()
@@ -113,6 +122,8 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
         colorRecycler = act.findViewById(R.id.color_recycler_view)
         lineChart = act.findViewById(R.id.line_chart)
         progressBar = act.findViewById(R.id.progress_bar)
+        progressCard = act.findViewById(R.id.progress_card)
+        progressLabel = act.findViewById(R.id.progress_label)
         settingsButton = act.findViewById(R.id.settings_btn)
 
         recycler?.adapter = LineGraphSelectableAdapter(this)
@@ -414,7 +425,7 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
 
             withContext(Dispatchers.Main) {
 
-                progressBar?.visibility = GONE
+                toggleProgressBar(false)
 
                 connectButton?.setOnClickListener {
                     if (isLocked) return@setOnClickListener
@@ -510,7 +521,7 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
         return colorResValue.data
     }
 
-    private fun submitList(submitPlaceholder: Boolean = false) {
+    protected fun submitList(submitPlaceholder: Boolean = false) {
 
         background.launch {
 
@@ -642,14 +653,86 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
         return y0 + ((y1 - y0) / (x1 - x0)) * (target - x0)
     }
 
-    protected fun toggleProgressBar(flag: Boolean) {
+    /**
+     * Shows or hides the busy overlay.
+     *
+     * The indicator always starts as a spinner. Material's setProgressCompat() finishes the
+     * indeterminate sweep and hands over to the arc on the first real reading, so [determinate]
+     * only says whether readings are expected at all, not how the indicator starts. A stage that
+     * has nothing to report yet keeps spinning instead of parking a bar near zero.
+     *
+     * @param determinate true if [setProgressPercent] will be called for this overlay.
+     * @param label optional text under the indicator, null hides it.
+     */
+    protected fun toggleProgressBar(
+        flag: Boolean,
+        determinate: Boolean = false,
+        label: String? = null
+    ) {
 
         background.launch(Dispatchers.Main) {
 
-            progressBar?.visibility = if (flag) VISIBLE else INVISIBLE
+            acceptsProgress = flag && determinate
 
+            if (flag) {
+
+                //the mode has to change while the indicator is hidden: Material throws if you
+                //switch to indeterminate on one that is already visible
+                progressCard?.visibility = GONE
+                progressBar?.visibility = INVISIBLE
+
+                progressBar?.let { indicator ->
+                    indicator.isIndeterminate = true
+                    indicator.progress = 0
+                }
+            }
+
+            progressLabel?.let { view ->
+                view.text = label ?: ""
+                view.visibility = if (flag && label != null) VISIBLE else GONE
+            }
+
+            progressBar?.visibility = if (flag) VISIBLE else INVISIBLE
+            progressCard?.visibility = if (flag) VISIBLE else GONE
         }
     }
+
+    /**
+     * Reports a real reading, switching the indicator from spinner to arc on the first call.
+     *
+     * Ignored unless the overlay was opened expecting progress, so a stale reading cannot hijack
+     * an indeterminate overlay raised for something else.
+     */
+    protected fun setProgressPercent(percent: Int, label: String? = null) {
+
+        background.launch(Dispatchers.Main) {
+
+            if (acceptsProgress) {
+                //animated, so Material completes the sweep and transitions rather than snapping
+                progressBar?.setProgressCompat(percent.coerceIn(0, 100), true)
+            }
+
+            label?.let { showProgressLabel(it) }
+        }
+    }
+
+    /**
+     * Updates the text under the indicator without touching the arc, for stages that have no
+     * reading of their own to report.
+     */
+    protected fun setProgressLabel(label: String) {
+
+        background.launch(Dispatchers.Main) {
+
+            showProgressLabel(label)
+        }
+    }
+
+    private fun showProgressLabel(label: String) {
+        progressLabel?.text = label
+        progressLabel?.visibility = VISIBLE
+    }
+
 
     override fun deleteTraitListener() {
         super.deleteTraitListener()

--- a/app/src/main/java/com/fieldbook/tracker/traits/SpectralTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/SpectralTraitLayout.kt
@@ -77,6 +77,9 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
     protected var state: State = State.Spectral
     private var displayedFrameCount: Int = 0
 
+    //set while onRefresh() reloads entry data, so loadLayout() leaves the connection alone
+    private var skipConnectionSetup = false
+
     protected val hapticFeedback by lazy {
         controller.getVibrator()
     }
@@ -130,6 +133,23 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
         }
     }
 
+    /**
+     * Reloads the values shown for the current entry without touching the device connection.
+     *
+     * BaseTraitLayout.onRefresh() delegates to loadLayout(), so without this every plot change ran
+     * the connect path: re-running establishConnection() and, whenever the device was not
+     * connected, restarting device discovery and another auto-reconnect attempt. Moving between
+     * entries is not a reason to renegotiate the connection.
+     */
+    override fun onRefresh() {
+        skipConnectionSetup = true
+        try {
+            loadLayout()
+        } finally {
+            skipConnectionSetup = false
+        }
+    }
+
     override fun loadLayout() {
         super.loadLayout()
 
@@ -137,7 +157,7 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
 
         loadSpectralFactsList(firstLoad = true)
 
-        if (!establishConnection()) {
+        if (!skipConnectionSetup && !establishConnection()) {
             setupConnectUi()
         }
 

--- a/app/src/main/java/com/fieldbook/tracker/traits/SpectralTraitLayout.kt
+++ b/app/src/main/java/com/fieldbook/tracker/traits/SpectralTraitLayout.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.concurrent.CopyOnWriteArrayList
 
 open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
     LineGraphSelectableAdapter.Listener, ColorAdapter.Listener {
@@ -78,7 +79,16 @@ open class SpectralTraitLayout : BaseTraitLayout, Spectrometer,
     protected var progressCard: View? = null
     protected var progressLabel: TextView? = null
 
-    protected val spectralDataList = mutableListOf<SpectralFact?>()
+    /**
+     * Samples for the current entry.
+     *
+     * Copy on write because this is touched from both dispatchers: captures add on the main
+     * thread while submitList() iterates on IO, and deletes mutate from IO. A plain ArrayList
+     * throws ConcurrentModificationException on the IO thread when those overlap, which is an
+     * uncaught crash rather than a dropped frame. The list holds a handful of samples per entry,
+     * so copying on each mutation costs nothing.
+     */
+    protected val spectralDataList: MutableList<SpectralFact?> = CopyOnWriteArrayList()
 
     protected var selected: Int = 0
     protected var state: State = State.Spectral

--- a/app/src/main/java/com/fieldbook/tracker/utilities/NixSensorHelper.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/NixSensorHelper.kt
@@ -1,6 +1,8 @@
 package com.fieldbook.tracker.utilities
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.widget.Toast
 import com.fieldbook.tracker.BuildConfig
@@ -22,7 +24,10 @@ class NixSensorHelper @Inject constructor(@ActivityContext val context: Context)
 
     companion object {
         private const val TAG = "Nix"
-        //private const val SCAN_PERIOD_MS = 30000L
+
+        //how long a scan may run before it stops itself, so an unattended search does not leave
+        //the radio scanning for the rest of the session
+        private const val SCAN_PERIOD_MS = 30000L
     }
 
     data class NixDevice(
@@ -35,6 +40,12 @@ class NixSensorHelper @Inject constructor(@ActivityContext val context: Context)
     private var licenseManagerState: LicenseManagerState = LicenseManagerState.INACTIVE
     private var deviceList: MutableList<NixDevice> = mutableListOf()
     private var scanner = DeviceScanner(context)
+
+    private val scanTimeoutHandler = Handler(Looper.getMainLooper())
+    private val scanTimeoutRunnable = Runnable {
+        Log.d(TAG, "Scan period elapsed, stopping scan")
+        stopScan()
+    }
 
     var connectedDevice: IDeviceCompat? = null
 
@@ -102,7 +113,8 @@ class NixSensorHelper @Inject constructor(@ActivityContext val context: Context)
             return
         }
 
-        scanner.stop()
+        //via stopScan so a timeout armed for the outgoing scanner cannot fire against the new one
+        stopScan()
 
         scanner = DeviceScanner(context)
 
@@ -138,12 +150,15 @@ class NixSensorHelper @Inject constructor(@ActivityContext val context: Context)
 
         if (scanner.state == IDeviceScanner.DeviceScannerState.IDLE) {
 
+            scanTimeoutHandler.removeCallbacks(scanTimeoutRunnable)
+            scanTimeoutHandler.postDelayed(scanTimeoutRunnable, SCAN_PERIOD_MS)
+
             scanner.start(object : IDeviceScanner.OnDeviceFoundListener {
                 override fun onScanResult(sender: IDeviceScanner, device: IDeviceCompat) {
                     //log device details
                     val logMsg = "Device found: ${device.name} ID: ${device.id} Type: ${device.type} ScanCount: ${device.scanCount} RSSI: ${device.rssi} Battery: ${device.batteryLevel}"
                     Log.d(TAG, logMsg)
-                    if (!deviceList.map { it.id }.contains(device.id)) {
+                    if (deviceList.none { it.id == device.id }) {
                         deviceList.add(NixDevice(
                             id = device.id,
                             name = device.name,
@@ -181,13 +196,14 @@ class NixSensorHelper @Inject constructor(@ActivityContext val context: Context)
 
             Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
 
-            scanner.stop()
+            stopScan()
 
             onResult(false)
         }
     }
 
     fun stopScan() {
+        scanTimeoutHandler.removeCallbacks(scanTimeoutRunnable)
         scanner.stop()
     }
 

--- a/app/src/main/java/com/fieldbook/tracker/utilities/NixSensorHelper.kt
+++ b/app/src/main/java/com/fieldbook/tracker/utilities/NixSensorHelper.kt
@@ -28,6 +28,13 @@ class NixSensorHelper @Inject constructor(@ActivityContext val context: Context)
         //how long a scan may run before it stops itself, so an unattended search does not leave
         //the radio scanning for the rest of the session
         private const val SCAN_PERIOD_MS = 30000L
+
+        //how long a connect attempt may go unanswered before it is abandoned and the UI released
+        private const val CONNECT_TIMEOUT_MS = 15000L
+
+        //how long to wait for a device to advertise again after a disconnect before giving up on
+        //connecting to it
+        private const val SIGHTING_TIMEOUT_MS = 15000L
     }
 
     data class NixDevice(
@@ -46,6 +53,27 @@ class NixSensorHelper @Inject constructor(@ActivityContext val context: Context)
         Log.d(TAG, "Scan period elapsed, stopping scan")
         stopScan()
     }
+
+    private val connectHandler = Handler(Looper.getMainLooper())
+
+    //ids of devices disconnected since the scanner last saw them advertise: they are not
+    //reachable again until they are
+    private val needsSighting = mutableSetOf<String>()
+
+    private var connectTimeout: Runnable? = null
+    private var connectingDevice: IDeviceCompat? = null
+
+    //a connect held until the device it is for advertises
+    private data class SightingWait(
+        val id: String,
+        val onSighted: (IDeviceCompat?) -> Unit,
+        val timeout: Runnable
+    )
+
+    private var sightingWait: SightingWait? = null
+
+    //retires the open connect attempt so a deliberate disconnect does not surface as a failure
+    private var retireAttempt: (() -> Unit)? = null
 
     var connectedDevice: IDeviceCompat? = null
 
@@ -158,13 +186,36 @@ class NixSensorHelper @Inject constructor(@ActivityContext val context: Context)
                     //log device details
                     val logMsg = "Device found: ${device.name} ID: ${device.id} Type: ${device.type} ScanCount: ${device.scanCount} RSSI: ${device.rssi} Battery: ${device.batteryLevel}"
                     Log.d(TAG, logMsg)
-                    if (deviceList.none { it.id == device.id }) {
-                        deviceList.add(NixDevice(
-                            id = device.id,
-                            name = device.name,
-                            device = device,
-                            description = "${device.type} (${device.id})"
-                        ))
+
+                    val found = NixDevice(
+                        id = device.id,
+                        name = device.name,
+                        device = device,
+                        description = "${device.type} (${device.id})"
+                    )
+
+                    val known = deviceList.indexOfFirst { it.id == device.id }
+
+                    //the newest handle wins: search() builds a fresh DeviceScanner each time, and
+                    //a device object left over from a scanner that has since been stopped never
+                    //calls back when connected through
+                    if (known < 0) {
+                        deviceList.add(found)
+                    } else if (deviceList[known].device !== connectedDevice) {
+                        deviceList[known] = found
+                    }
+
+                    needsSighting.remove(device.id)
+
+                    //a connect waiting on this device now has a handle it can use, and scan
+                    //callbacks do not arrive on the main thread
+                    sightingWait?.takeIf { it.id == device.id }?.let { waiting ->
+
+                        sightingWait = null
+
+                        connectHandler.removeCallbacks(waiting.timeout)
+
+                        connectHandler.post { waiting.onSighted(found.device) }
                     }
                 }
 
@@ -217,19 +268,182 @@ class NixSensorHelper @Inject constructor(@ActivityContext val context: Context)
 
     fun getDeviceList() = deviceList.toImmutableList()
 
-    fun connect(device: IDeviceCompat, onConnected: (Boolean) -> Unit) {
+    /**
+     * Opens a connection to [device] and reports the device that connected through [onConnected],
+     * or null if the attempt did not get there.
+     *
+     * A device that has been disconnected since the scanner last saw it is waited on until it
+     * advertises again. It only accepts a connection while it is broadcasting, and a Nix takes a
+     * few seconds to get back to that after a link drops, so a quick disconnect and reconnect
+     * failed outright: the connect went nowhere and nothing called back. The sighting also yields
+     * the handle to connect through, the one the live scanner just produced rather than one left
+     * over from a scanner that has since been stopped.
+     *
+     * The attempt itself is then bounded by [CONNECT_TIMEOUT_MS], so one the SDK never answers
+     * still hands the UI back instead of hanging on it.
+     *
+     * [onConnected] is not single shot. It reports the outcome of the attempt, and then any later
+     * drop of an established connection, which is how the trait finds its way back to connect UI.
+     */
+    fun connect(device: IDeviceCompat, onConnected: (IDeviceCompat?) -> Unit) {
 
-        this.connectedDevice = device
+        cancelPendingConnect()
 
-        this.connectedDevice?.connect(object : IDeviceCompat.OnDeviceStateChangeListener {
+        //whatever the previous attempt does from here is no longer this one's concern: without
+        //retiring it, its late callback drives the trait UI while this attempt is still running
+        retireAttempt?.invoke()
+        retireAttempt = null
+
+        //an attempt the SDK never answered still holds the radio, so cancel it before opening
+        //another one
+        connectingDevice?.let { stale ->
+
+            Log.d(TAG, "Cancelling an unanswered connect to ${stale.name}")
+
+            runCatching { stale.disconnect() }
+        }
+
+        connectingDevice = null
+
+        //USB devices never advertise, and a device the scanner has seen since its last disconnect
+        //is reachable as it stands: both connect through the handle in hand
+        if (device.interfaceType == IDeviceCompat.InterfaceType.USB_CDC ||
+            device.id !in needsSighting) {
+
+            beginConnect(handleFor(device), onConnected)
+
+        } else {
+
+            Log.d(TAG, "Waiting for ${device.name} to advertise before connecting")
+
+            awaitSighting(device.id) { sighted ->
+
+                if (sighted == null) {
+
+                    Log.w(TAG, "${device.name} never advertised, abandoning connect")
+
+                    onConnected(null)
+
+                } else {
+
+                    beginConnect(sighted, onConnected)
+                }
+            }
+        }
+    }
+
+    /**
+     * Calls [onSighted] with the scanner's handle for [id] the next time it advertises, or with
+     * null once [SIGHTING_TIMEOUT_MS] has passed without it.
+     */
+    private fun awaitSighting(id: String, onSighted: (IDeviceCompat?) -> Unit) {
+
+        val timeout = Runnable {
+            sightingWait = null
+            onSighted(null)
+        }
+
+        sightingWait = SightingWait(id, onSighted, timeout)
+
+        //nothing will be sighted unless something is scanning, and a scan already running has to
+        //outlast this wait rather than stop itself partway through it
+        if (scanner.state == IDeviceScanner.DeviceScannerState.IDLE) {
+
+            search {}
+
+        } else {
+
+            scanTimeoutHandler.removeCallbacks(scanTimeoutRunnable)
+            scanTimeoutHandler.postDelayed(scanTimeoutRunnable, SCAN_PERIOD_MS)
+        }
+
+        connectHandler.postDelayed(timeout, SIGHTING_TIMEOUT_MS)
+    }
+
+    //the scanner's current handle for this device, which is the one worth connecting through
+    private fun handleFor(device: IDeviceCompat) =
+        deviceList.firstOrNull { it.id == device.id }?.device ?: device
+
+    private fun beginConnect(device: IDeviceCompat, onConnected: (IDeviceCompat?) -> Unit) {
+
+        //scanning from here on only competes with the connection being opened
+        stopScan()
+
+        connectingDevice = device
+
+        //null while the attempt is open, then the result it was reported with, so that whichever
+        //of the SDK or the timeout arrives first is the one that owns the outcome
+        var outcome: Boolean? = null
+
+        //lets a deliberate disconnect close the attempt out without reporting it as a failure
+        retireAttempt = { outcome = false }
+
+        val timeout = Runnable {
+
+            if (outcome == null) {
+
+                outcome = false
+
+                connectTimeout = null
+
+                Log.w(TAG, "No answer from ${device.name} in ${CONNECT_TIMEOUT_MS}ms, giving up")
+
+                //also cancels an attempt still in progress, per IDeviceCompat.disconnect
+                runCatching { device.disconnect() }
+
+                noteDisconnected(device)
+
+                onConnected(null)
+            }
+        }
+
+        connectTimeout = timeout
+
+        connectHandler.postDelayed(timeout, CONNECT_TIMEOUT_MS)
+
+        device.connect(object : IDeviceCompat.OnDeviceStateChangeListener {
+
             override fun onConnected(sender: IDeviceCompat) {
-                onConnected(true)
+
                 Log.d(TAG, "Device connected")
+
+                if (outcome == false) {
+
+                    //the attempt was already given up on, so nothing owns this link
+                    Log.w(TAG, "Connected after giving up on ${sender.name}, dropping the link")
+
+                    runCatching { sender.disconnect() }
+
+                    return
+                }
+
+                outcome = true
+
+                clearConnectTimeout()
+
+                connectingDevice = null
+
+                connectedDevice = sender
+
+                onConnected(sender)
             }
 
             override fun onDisconnected(sender: IDeviceCompat, status: DeviceStatus) {
-                onConnected(false)
-                Log.d(TAG, "Device disconnected")
+
+                Log.d(TAG, "Device disconnected: $status")
+
+                noteDisconnected(sender)
+
+                //a failed attempt and a dropped connection both leave the trait disconnected, but
+                //an attempt already abandoned by the timeout was reported once already
+                if (outcome != false) {
+
+                    outcome = false
+
+                    clearConnectTimeout()
+
+                    onConnected(null)
+                }
             }
 
             override fun onBatteryStateChanged(sender: IDeviceCompat, newState: Int) {
@@ -242,9 +456,70 @@ class NixSensorHelper @Inject constructor(@ActivityContext val context: Context)
         })
     }
 
-    fun disconnect() {
+    /**
+     * Drops the link to [device], or to whatever is connected when none is given.
+     */
+    fun disconnect(device: IDeviceCompat? = null) {
+
+        cancelPendingConnect()
+
         stopScan()
-        connectedDevice?.disconnect()
+
+        //the user asked for this one, so the open attempt is retired rather than failed
+        retireAttempt?.invoke()
+        retireAttempt = null
+
+        val target = device ?: connectedDevice
+
+        runCatching { target?.disconnect() }
+
+        //an attempt still open for some other device would otherwise outlive this disconnect
+        connectingDevice?.let { runCatching { it.disconnect() } }
+
+        target?.let { requireSighting(it) }
+
+        connectingDevice = null
+
         connectedDevice = null
+    }
+
+    private fun noteDisconnected(device: IDeviceCompat) {
+
+        requireSighting(device)
+
+        if (connectingDevice === device) connectingDevice = null
+
+        if (connectedDevice === device) connectedDevice = null
+    }
+
+    /**
+     * Marks [device] as out of reach until the scanner sees it advertise again.
+     *
+     * A Nix takes a few seconds to start advertising after a link drops, and a connect opened
+     * before then fails outright with nothing to show for it, which is what a quick disconnect
+     * and reconnect ran into. The next connect waits for the device to announce itself instead.
+     */
+    private fun requireSighting(device: IDeviceCompat) {
+        needsSighting.add(device.id)
+    }
+
+    /**
+     * Drops the wait for a device to advertise and the timeout watching over an attempt already
+     * open. Called when the trait goes away, so neither fires into a view that is already gone.
+     */
+    fun cancelPendingConnect() {
+
+        sightingWait?.let { connectHandler.removeCallbacks(it.timeout) }
+
+        sightingWait = null
+
+        clearConnectTimeout()
+    }
+
+    private fun clearConnectTimeout() {
+
+        connectTimeout?.let { connectHandler.removeCallbacks(it) }
+
+        connectTimeout = null
     }
 }

--- a/app/src/main/res/layout/traits_spectral.xml
+++ b/app/src/main/res/layout/traits_spectral.xml
@@ -2,20 +2,9 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:minHeight="@dimen/fb_spectral_busy_card_min_height"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
-
-    <ProgressBar style="@style/IndeterminateProgressStyle"
-        android:layout_margin="16dp"
-        android:layout_width="@dimen/brapi_filter_pb_size"
-        android:layout_height="@dimen/brapi_filter_pb_size"
-        android:id="@+id/progress_bar"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:visibility="invisible"
-        android:elevation="3dp"
-        android:indeterminate="true"/>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         style="@style/FloatingActionButtonStyle.TraitButtons"
@@ -103,5 +92,59 @@
         app:layout_constraintTop_toBottomOf="@id/color_recycler_view"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <!--
+        Busy indicator, shown while connecting or taking a measurement.
+
+        Declared last and raised above the FABs so it reads as floating over the graph rather than
+        being lost in it. clickable stops a tap landing on whatever sits behind the card.
+    -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/progress_card"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone"
+        tools:visibility="visible"
+        app:cardCornerRadius="24dp"
+        app:cardElevation="8dp"
+        app:cardBackgroundColor="?attr/fb_color_background"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:padding="40dp">
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/progress_bar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                app:indicatorColor="?attr/fb_color_indeterminate_progress_bar"
+                app:trackThickness="8dp"
+                app:trackCornerRadius="4dp"
+                app:indicatorSize="96dp" />
+
+            <TextView
+                android:id="@+id/progress_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:textColor="?attr/fb_color_text_dark"
+                android:textSize="16sp"
+                android:visibility="gone"
+                tools:text="Loading scan configs"
+                tools:visibility="visible" />
+
+        </LinearLayout>
+
+    </com.google.android.material.card.MaterialCardView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -46,6 +46,13 @@
     <dimen name="fb_trait_fab_image_size_small">24dp</dimen>
 
     <dimen name="fb_trait_fab_size">76dp</dimen>
+    <!--
+        Floor for the spectral trait layout so the busy card is never clipped. While connecting
+        the chart and both recyclers are gone, so without this the layout collapses to the height
+        of the connect button and the card has nowhere to draw.
+        96dp indicator + 40dp padding twice + label and its margin.
+    -->
+    <dimen name="fb_spectral_busy_card_min_height">240dp</dimen>
     <dimen name="fb_trait_big_fab_size">176dp</dimen>
     <dimen name="fb_trait_fab_image_size">38dp</dimen>
   

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1920,6 +1920,7 @@
     <string name="nix_error_bluetooth_permissions">You must accept bluetooth permissions or try restarting the app.</string>
     <string name="nix_error_bluetooth_unavailable">Bluetooth is unavailable.</string>
     <string name="nix_error_bluetooth_disabled">Bluetooth is disabled on the device.</string>
+    <string name="nix_error_connect_failed">Could not connect to the device, try again.</string>
     <string name="list_item_color_placeholder_content_description">Placeholder for new scan</string>
     <string name="loading">Loading</string>
     <string name="nix_error_no_network">Nix may require internet to work properly.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1704,6 +1704,15 @@
     <string name="inno_spectra_save_failed">Save failed</string>
     <string name="inno_spectra_hardware_incompatible">Hardware incompatible</string>
     <string name="inno_spectra_function_locked">Function locked</string>
+
+    <!-- stages reported while the inno spectra device is connecting -->
+    <string name="inno_spectra_connect_connecting">Connecting</string>
+    <string name="inno_spectra_connect_handshake">Starting up</string>
+    <string name="inno_spectra_connect_device_info">Reading device info</string>
+    <string name="inno_spectra_connect_device_uuid">Identifying device</string>
+    <string name="inno_spectra_connect_device_status">Reading status</string>
+    <string name="inno_spectra_connect_scan_configs">Loading scan configs</string>
+    <string name="inno_spectra_connect_ready">Ready</string>
     <string name="header_temperature">Temperature</string>
     <string name="header_humidity">Humidity</string>
     <string name="header_firmware">Firmware</string>


### PR DESCRIPTION
### Description

<!--
Provide a summary of your changes including motivation and context.  
If these changes fix a bug or resolve a feature request, be sure to link to that issue.
-->

## Fix InnoSpectra/Nix resource leaks causing progressive ANRs

- **Stop leaking Bluetooth resources on every reconnect and trait switch.** `InnoSpectraBase`'s 17 `LocalBroadcastManager` receivers were re-registered without unregistering the previous set, and because several handlers respond to a broadcast by issuing a BLE command that itself broadcasts a reply, duplicate sets compounded per round rather than costing a constant amount. BLE scans were likewise started and never stopped, accumulating main-looper scan callbacks with each disconnected trait toggle. Scans are now owned, deduped, bounded by a 30s period and stopped on connect/teardown; the same period was applied to the Nix scanner.

- **Remove the per-activity leak and the polling that kept it alive.** `SpectralTraitLayout`'s `CoroutineScope` was never cancelled, so every re-entry into Collect left another live scope holding a destroyed `CollectActivity` along with a `while(true)` loop making four Bluetooth binder calls a second, forever. Added a `BaseTraitLayout.onDestroy()` hook driven from `LayoutCollections`, replaced the connection poll with the SDK's `ACTION_GATT_DISCONNECTED` broadcast, and bounded the two remaining unbounded loops.

- **Fix responsiveness and correctness in the collection path.** `submitSpectralList` shadowed its own parameter and re-ran the entire query-and-Base64-decode, so each refresh did 2×N synchronous SQLite reads on the UI thread; the duplicate is gone and the remainder moved to IO (`spectralDataList` is now copy-on-write, since captures mutate it from main while that query iterates). Plot navigation no longer restarts device discovery, the connect button no longer races a background auto-reconnect, and capture paths in both traits now have timeouts and guaranteed UI restoration instead of stranding a disabled button.

- **Rework the busy indicator.** Replaced the raw `ProgressBar` with a Material `CircularProgressIndicator` on an elevated card, and drove it from the SDK's own handshake broadcasts. It spins through the 6s connect phase (which has nothing to report) then transitions to a determinate arc, with stage percentages weighted by measured durations.

### Notes

- The disconnect receiver relies on `ISCNIRScanSDK.ACTION_GATT_DISCONNECTED` being public
- The entire InnoSpectra broadcast path depends on Jetifier remaining enabled, since the SDK links the old support-library `LocalBroadcastManager`. If Jetifier is ever turned off, every InnoSpectra receiver silently stops firing.


### Change Type

<!--
Select the most applicable option by placing an `x` in the box.
If you select `OTHER`, there is no need to fill in the **Release Note** section. For all other types, a release note is required.
-->

- [ ] **`ADDITION`** (non-breaking change that adds functionality)
- [ ] **`CHANGE`** (fix or feature that alters existing functionality)
- [x] **`FIX`** (non-breaking change that resolves an issue)
- [ ] **`OTHER`** (use only for changes like tooling, build system, CI, docs, etc.)

### Release Note

<!--
Provide a brief, user-friendly release note in the fenced block below. This will be included in the changelog file during the release process.  
Release notes are **required** for all change types except `OTHER`.

Examples of release notes:
- Fixed a bug causing Field Book to crash when collecting categorical data.
- Added a new option to enable a sound when data is deleted.
- Modified the drag-and-drop behavior for traits.
-->

```release-note
InnoSpectra and Nix trait improvements and bug fixes
```